### PR TITLE
Add deposit policy enforcement and coin-based withdrawal constraints

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -2,14 +2,16 @@
 
 This broker uses a JSON policy file to restrict:
 
-- **Withdrawals**: permitted exchanges, networks, and destination address whitelist
+- **Withdrawals**: permitted exchanges, networks, tokens, and destination address whitelist
+- **Deposits**: permitted exchanges, networks, and tokens (gates deposit address fetching)
 - **Orders**: permitted exchanges/pairs, plus optional directional conversion limits
 
 The policy is loaded at startup. If you start the broker with a **policy file path**, the file is watched and policies are reloaded when the file changes.
 
 ## Quick start
 
-- **Example policy**: `policy/policy.json`
+- **Example policy**: `policy/policy.example.json`
+- **Backtest policy**: `policy/policy.backtest.json`
 - **CLI usage**:
 
 ```bash
@@ -23,7 +25,7 @@ Top-level keys (all required):
 | Key | Type | Description |
 |-----|------|-------------|
 | `withdraw` | `{ rule: WithdrawRuleEntry[] }` | Withdrawal restrictions (at least one rule entry required) |
-| `deposit` | `{}` | Placeholder object — not enforced today |
+| `deposit` | `{ rule?: DepositRuleEntry[] }` | Deposit restrictions (optional; omitting `rule` or using `{}` allows all) |
 | `order` | `{ rule: OrderRule }` | Order/conversion restrictions |
 
 Canonical type: `PolicyConfig` in `src/types.ts`.
@@ -32,10 +34,14 @@ Canonical type: `PolicyConfig` in `src/types.ts`.
 {
   "withdraw": {
     "rule": [
-      { "exchange": "BINANCE", "network": "ARBITRUM", "whitelist": [] }
+      { "exchange": "BINANCE", "network": "ARBITRUM", "coins": ["ETH", "USDT"], "whitelist": ["0x..."] }
     ]
   },
-  "deposit": {},
+  "deposit": {
+    "rule": [
+      { "exchange": "BINANCE", "network": "ARBITRUM", "coins": ["ETH", "USDT"] }
+    ]
+  },
   "order": { "rule": { "markets": [], "limits": [] } }
 }
 ```
@@ -124,6 +130,26 @@ Accepted values:
 
 ---
 
+### `withdraw.rule[].coins`
+
+| | |
+|---|---|
+| **Type** | `string[]` |
+| **Required** | No |
+| **Normalisation** | Each entry is trimmed, uppercased |
+
+Optional array of CEX ticker symbols that are allowed for withdrawal under this rule.
+
+Accepted values:
+
+- **An array of ticker symbols** — e.g. `["ETH", "USDT", "USDC", "ARB"]`. Only these tokens may be withdrawn when this rule matches.
+- **`["*"]`** — wildcard; allows any token (same as omitting the field).
+- **Omitted / not present** — allows any token (backward compatible with rules written before `coins` was added).
+
+Matching is **case-insensitive** — both the policy value and the request ticker are uppercased before comparison.
+
+---
+
 ### Full withdraw example
 
 ```json
@@ -133,6 +159,7 @@ Accepted values:
       {
         "exchange": "BINANCE",
         "network": "ARBITRUM",
+        "coins": ["ETH", "USDT", "USDC", "ARB"],
         "whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
       },
       {
@@ -143,6 +170,7 @@ Accepted values:
       {
         "exchange": "*",
         "network": "BEP20",
+        "coins": ["BNB", "USDT"],
         "whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
       },
       {
@@ -155,12 +183,13 @@ Accepted values:
 }
 ```
 
-In this example, a BINANCE + ARBITRUM withdraw uses the first rule (priority 4). A BINANCE + SOL withdraw falls to the second rule (priority 3). A KRAKEN + BEP20 withdraw uses the third rule (priority 2). Everything else hits the global catch-all (priority 1).
+In this example, a BINANCE + ARBITRUM withdraw uses the first rule (priority 4) and only allows ETH, USDT, USDC, and ARB. A BINANCE + SOL withdraw falls to the second rule (priority 3), which has no `coins` restriction — any token is allowed. A KRAKEN + BEP20 withdraw uses the third rule (priority 2) and is restricted to BNB and USDT. Everything else hits the global catch-all (priority 1), which also allows any token.
 
 Common rejection reasons:
 
 - no matching exchange + network entry
 - address not whitelisted
+- token not in `coins` for the matched rule
 
 ---
 
@@ -261,12 +290,107 @@ Example:
 
 | | |
 |---|---|
-| **Type** | `{}` (empty object) |
+| **Type** | `{ rule?: DepositRuleEntry[] }` |
+| **Required** | Yes (the `deposit` key must be present) |
+
+Deposit validation gates the `FetchDepositAddresses` action — a request to fetch a deposit address is rejected if the policy does not permit deposits for the given exchange, network, and token. The actual deposit confirmation is not gated by the policy (only the address fetch is).
+
+### Backward compatibility
+
+- **`"deposit": {}`** — no `rule` key or empty rule array: **all deposits are allowed**. This is backward compatible with policies written before deposit rules were added.
+- **`"deposit": { "rule": [...] }`** — only deposits matching a rule are allowed.
+
+---
+
+### `deposit.rule: DepositRuleEntry[]`
+
+**Optional.** When omitted or empty, all deposits are permitted.
+
+Each entry scopes deposit permissions to an `exchange` + `network` combination, optionally restricted to specific tokens. When a `FetchDepositAddresses` request arrives, the broker finds the highest-priority matching rule and validates the token against it.
+
+#### Rule matching priority
+
+Same priority scheme as withdraw rules:
+
+| Priority | `exchange` | `network` | Description |
+|----------|-----------|-----------|-------------|
+| 4 (highest) | exact match | exact match | Fully specific rule |
+| 3 | exact match | `"*"` | Exchange-specific, any network |
+| 2 | `"*"` | exact match | Network-specific, any exchange |
+| 1 (lowest) | `"*"` | `"*"` | Global catch-all |
+
+If rules are present but no entry matches, the request is rejected.
+
+---
+
+### `deposit.rule[].exchange`
+
+| | |
+|---|---|
+| **Type** | `string` |
 | **Required** | Yes |
+| **Normalisation** | Trimmed, uppercased |
 
-`deposit` is required in the current policy schema, but it is **not enforced** today.
+Same as `withdraw.rule[].exchange` — an exchange identifier (e.g. `"BINANCE"`) or `"*"` for wildcard.
 
-At present, deposits are effectively always allowed; this field is reserved for future deposit rule support. Set it to `{}`.
+---
+
+### `deposit.rule[].network`
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Normalisation** | Trimmed, uppercased |
+
+Same as `withdraw.rule[].network` — a network/chain identifier (e.g. `"ARBITRUM"`) or `"*"` for wildcard.
+
+---
+
+### `deposit.rule[].coins`
+
+| | |
+|---|---|
+| **Type** | `string[]` |
+| **Required** | No |
+| **Normalisation** | Each entry is trimmed, uppercased |
+
+Optional array of CEX ticker symbols allowed for deposit under this rule. Behaves identically to `withdraw.rule[].coins`:
+
+- **An array of ticker symbols** — e.g. `["ETH", "USDT"]`. Only these tokens may be deposited.
+- **`["*"]`** — wildcard; allows any token (same as omitting the field).
+- **Omitted / not present** — allows any token.
+
+Matching is **case-insensitive**.
+
+---
+
+### Full deposit example
+
+```json
+{
+  "deposit": {
+    "rule": [
+      {
+        "exchange": "BINANCE",
+        "network": "ARBITRUM",
+        "coins": ["ETH", "USDT", "USDC", "ARB"]
+      },
+      {
+        "exchange": "*",
+        "network": "*"
+      }
+    ]
+  }
+}
+```
+
+In this example, a BINANCE + ARBITRUM deposit address request is matched by the first rule (priority 4) and is restricted to ETH, USDT, USDC, and ARB. Any other exchange/network combination hits the catch-all rule, which allows all tokens.
+
+Common rejection reasons:
+
+- deposit rules are present but no matching exchange + network entry
+- token not in `coins` for the matched rule
 
 ---
 
@@ -285,5 +409,7 @@ The broker validates the policy JSON against a Joi schema when loading it.
 
 - **Withdraw address rejected**: ensure the address is in the matching `withdraw.rule[].whitelist` entry (lowercase recommended).
 - **Withdraw exchange/network rejected**: ensure there is a `withdraw.rule[]` entry whose `exchange` and `network` match (or wildcard-match) the request.
+- **Withdraw token rejected**: ensure the matched `withdraw.rule[].coins` includes the token ticker (or omit `coins` to allow all).
+- **Deposit address fetch rejected**: ensure `deposit.rule` contains a matching entry for the exchange + network + token, or use `"deposit": {}` to allow all.
 - **Order rejected (market)**: ensure `order.rule.markets` contains a matching pattern for the exchange + pair.
 - **Order rejected (limits)**: if `limits` is non-empty, ensure there's an entry for the exact `from` → `to` direction and the amount is within bounds.

--- a/policy/policy.backtest.json
+++ b/policy/policy.backtest.json
@@ -1,0 +1,65 @@
+{
+	"withdraw": {
+		"rule": [
+			{
+				"exchange": "BINANCE",
+				"network": "BEP20",
+				"coins": ["BNB", "USDT", "USDC", "ETH"],
+				"whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
+			},
+			{
+				"exchange": "BINANCE",
+				"network": "ARBITRUM",
+				"coins": ["ETH", "USDT", "USDC", "ARB"],
+				"whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
+			},
+			{
+				"exchange": "*",
+				"network": "ARBITRUM",
+				"coins": ["ETH", "USDT", "USDC", "ARB"],
+				"whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
+			}
+		]
+	},
+	"deposit": {
+		"rule": [
+			{
+				"exchange": "BINANCE",
+				"network": "BEP20",
+				"coins": ["BNB", "USDT", "USDC", "ETH"]
+			},
+			{
+				"exchange": "BINANCE",
+				"network": "ARBITRUM",
+				"coins": ["ETH", "USDT", "USDC", "ARB"]
+			},
+			{
+				"exchange": "*",
+				"network": "ARBITRUM",
+				"coins": ["ETH", "USDT", "USDC", "ARB"]
+			}
+		]
+	},
+	"order": {
+		"rule": {
+			"markets": [
+				"BINANCE:ARB/USDT",
+				"BYBIT:ARB/USDC",
+				"UPBIT:ETH/USDC",
+				"BINANCE:ETH/USDT",
+				"BINANCE:BTC/ETH",
+				"BINANCE:BTC/USDC",
+				"KRAKEN:ETH/USDT",
+				"KRAKEN:ETH/USDC"
+			],
+			"limits": [
+				{ "from": "USDT", "to": "ETH", "min": 1, "max": 100000 },
+				{ "from": "ETH", "to": "USDT", "min": 0.5, "max": 5 },
+				{ "from": "ARB", "to": "USDC", "min": 1, "max": 1000 },
+				{ "from": "USDC", "to": "ARB", "min": 1, "max": 10000 },
+				{ "from": "ARB", "to": "USDT", "min": 1, "max": 1000 },
+				{ "from": "USDT", "to": "ARB", "min": 1, "max": 10000 }
+			]
+		}
+	}
+}

--- a/policy/policy.example.json
+++ b/policy/policy.example.json
@@ -1,0 +1,48 @@
+{
+	"withdraw": {
+		"rule": [
+			{
+				"exchange": "BINANCE",
+				"network": "ARBITRUM",
+				"coins": ["ETH", "USDT", "USDC", "ARB"],
+				"whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
+			},
+			{
+				"exchange": "BINANCE",
+				"network": "BEP20",
+				"coins": ["BNB", "USDT", "USDC"],
+				"whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
+			},
+			{
+				"exchange": "*",
+				"network": "ARBITRUM",
+				"whitelist": ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"]
+			}
+		]
+	},
+	"deposit": {
+		"rule": [
+			{
+				"exchange": "BINANCE",
+				"network": "ARBITRUM",
+				"coins": ["ETH", "USDT", "USDC", "ARB"]
+			},
+			{
+				"exchange": "BINANCE",
+				"network": "BEP20",
+				"coins": ["BNB", "USDT", "USDC"]
+			}
+		]
+	},
+	"order": {
+		"rule": {
+			"markets": ["BINANCE:ARB/USDT", "BINANCE:ETH/USDT", "BINANCE:BTC/USDC"],
+			"limits": [
+				{ "from": "USDT", "to": "ETH", "min": 1, "max": 100000 },
+				{ "from": "ETH", "to": "USDT", "min": 0.5, "max": 5 },
+				{ "from": "ARB", "to": "USDT", "min": 1, "max": 1000 },
+				{ "from": "USDT", "to": "ARB", "min": 1, "max": 10000 }
+			]
+		}
+	}
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -253,6 +253,13 @@ export function loadPolicy(policyPath: string): PolicyConfig {
 			exchange: Joi.string().required(),
 			network: Joi.string().required(),
 			whitelist: Joi.array().items(Joi.string()).required(),
+			coins: Joi.array().items(Joi.string()).optional(),
+		});
+
+		const depositRuleEntrySchema = Joi.object({
+			exchange: Joi.string().required(),
+			network: Joi.string().required(),
+			coins: Joi.array().items(Joi.string()).optional(),
 		});
 
 		// Joi schema for OrderRule
@@ -276,9 +283,9 @@ export function loadPolicy(policyPath: string): PolicyConfig {
 				rule: Joi.array().items(withdrawRuleEntrySchema).min(1).required(),
 			}).required(),
 
-			deposit: Joi.object()
-				.pattern(Joi.string(), Joi.valid(null)) // Record<string, null>
-				.required(),
+			deposit: Joi.object({
+				rule: Joi.array().items(depositRuleEntrySchema).optional(),
+			}).required(),
 
 			order: Joi.object({
 				rule: orderRuleSchema.required(),
@@ -314,7 +321,23 @@ export function normalizePolicyConfig(policy: PolicyConfig): PolicyConfig {
 				whitelist: rule.whitelist.map((address) =>
 					address.trim().toLowerCase(),
 				),
+				...(rule.coins && {
+					coins: rule.coins.map((c) => c.trim().toUpperCase()),
+				}),
 			})),
+		},
+		deposit: {
+			...policy.deposit,
+			...(policy.deposit.rule && {
+				rule: policy.deposit.rule.map((rule) => ({
+					...rule,
+					exchange: rule.exchange.trim().toUpperCase(),
+					network: rule.network.trim().toUpperCase(),
+					...(rule.coins && {
+						coins: rule.coins.map((c) => c.trim().toUpperCase()),
+					}),
+				})),
+			}),
 		},
 		order: {
 			...policy.order,

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -4,6 +4,7 @@ import type {
 	PolicyConfig,
 	BrokerCredentials,
 	WithdrawRuleEntry,
+	DepositRuleEntry,
 } from "../types";
 import { log } from "./logger";
 import type { Metadata, ServerUnaryCall } from "@grpc/grpc-js";
@@ -374,6 +375,28 @@ function getWithdrawRulePriority(
 	return 1;
 }
 
+function getDepositRulePriority(
+	rule: DepositRuleEntry,
+	exchange: string,
+	network: string,
+): number {
+	const exchangeMatch = rule.exchange === exchange || rule.exchange === "*";
+	const networkMatch = rule.network === network || rule.network === "*";
+	if (!exchangeMatch || !networkMatch) {
+		return 0;
+	}
+	if (rule.exchange === exchange && rule.network === network) {
+		return 4;
+	}
+	if (rule.exchange === exchange && rule.network === "*") {
+		return 3;
+	}
+	if (rule.exchange === "*" && rule.network === network) {
+		return 2;
+	}
+	return 1;
+}
+
 export function validateWithdraw(
 	policy: PolicyConfig,
 	exchange: string,
@@ -669,15 +692,54 @@ export async function resolveOrderExecution(
 	};
 }
 
-/**
- * Validates deposit request (currently empty but can be extended)
- */
 export function validateDeposit(
-	_policy: PolicyConfig,
-	_chain: string,
-	_amount: number,
+	policy: PolicyConfig,
+	exchange: string,
+	network: string,
+	ticker: string,
 ): { valid: boolean; error?: string } {
-	// Currently deposit policy is empty, so all deposits are allowed
-	// This can be extended when deposit rules are added to the policy
+	const normalizedPolicy = normalizePolicyConfig(policy);
+
+	if (
+		!normalizedPolicy.deposit.rule ||
+		normalizedPolicy.deposit.rule.length === 0
+	) {
+		return { valid: true };
+	}
+
+	const exchangeNorm = exchange.trim().toUpperCase();
+	const networkNorm = network.trim().toUpperCase();
+	const tickerNorm = ticker.trim().toUpperCase();
+
+	const matchingRules = normalizedPolicy.deposit.rule
+		.map((rule) => ({
+			rule,
+			priority: getDepositRulePriority(rule, exchangeNorm, networkNorm),
+		}))
+		.filter((r) => r.priority > 0)
+		.sort((a, b) => b.priority - a.priority);
+
+	const depositRule = matchingRules[0]?.rule;
+
+	if (!depositRule) {
+		return {
+			valid: false,
+			error: `Deposits not allowed for ${exchangeNorm}:${networkNorm}`,
+		};
+	}
+
+	if (
+		depositRule.coins &&
+		depositRule.coins.length > 0 &&
+		!depositRule.coins.includes("*")
+	) {
+		if (!depositRule.coins.includes(tickerNorm)) {
+			return {
+				valid: false,
+				error: `Token ${tickerNorm} not allowed for deposit on ${exchangeNorm}:${networkNorm}. Allowed: [${depositRule.coins.join(", ")}]`,
+			};
+		}
+	}
+
 	return { valid: true };
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -380,7 +380,7 @@ export function validateWithdraw(
 	network: string,
 	recipientAddress: string,
 	_amount: number,
-	_ticker: string,
+	ticker: string,
 ): { valid: boolean; error?: string } {
 	const normalizedPolicy = normalizePolicyConfig(policy);
 	const exchangeNorm = exchange.trim().toUpperCase();
@@ -410,6 +410,18 @@ export function validateWithdraw(
 			valid: false,
 			error: `Address ${recipientAddress} is not whitelisted for withdrawals`,
 		};
+	}
+
+	// Check if coin is allowed by the matched rule
+	const coins = withdrawRule.coins;
+	if (coins && coins.length > 0 && !coins.includes("*")) {
+		const tickerNorm = ticker.trim().toUpperCase();
+		if (!coins.includes(tickerNorm)) {
+			return {
+				valid: false,
+				error: `Token ${tickerNorm} is not allowed for withdrawals on ${exchangeNorm}:${networkNorm}. Allowed: [${coins.join(", ")}]`,
+			};
+		}
 	}
 
 	return { valid: true };

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import {
 	createBroker,
 	resolveOrderExecution,
 	selectBroker,
+	validateDeposit,
 	validateWithdraw,
 	verityHttpClientOverridePredicate,
 } from "./helpers";
@@ -614,6 +615,21 @@ export function getServer(
 							);
 						}
 						const fetchDepositAddresses = parsedPayload.data;
+						const depositValidation = validateDeposit(
+							policy,
+							cex,
+							fetchDepositAddresses.chain,
+							symbol,
+						);
+						if (!depositValidation.valid) {
+							return wrappedCallback(
+								{
+									code: grpc.status.PERMISSION_DENIED,
+									message: depositValidation.error,
+								},
+								null,
+							);
+						}
 						try {
 							const depositAddresses =
 								broker.has.fetchDepositAddress === true

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,13 @@ export type WithdrawRuleEntry = {
 	exchange: string;
 	network: string;
 	whitelist: string[];
+	coins?: string[];
+};
+
+export type DepositRuleEntry = {
+	exchange: string;
+	network: string;
+	coins?: string[];
 };
 
 export type OrderRule = {
@@ -21,7 +28,9 @@ export type PolicyConfig = {
 	withdraw: {
 		rule: WithdrawRuleEntry[];
 	};
-	deposit: Record<string, null>;
+	deposit: {
+		rule?: DepositRuleEntry[];
+	};
 	order: {
 		rule: OrderRule;
 	};

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -142,7 +142,7 @@ describe("Helper Functions", () => {
 			expect(result.error).toContain("is not whitelisted for withdrawals");
 		});
 
-		test("should ignore ticker checks for withdrawals", () => {
+		test("should allow any ticker when rule has no coins field (backward compat)", () => {
 			const result = validateWithdraw(
 				testPolicy,
 				"BINANCE",
@@ -234,6 +234,170 @@ describe("Helper Functions", () => {
 			);
 			expect(result.valid).toBe(false);
 			expect(result.error).toContain("exchange KRAKEN");
+		});
+
+		test("should allow withdrawal when ticker is in coins list", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				withdraw: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: ["ETH", "USDT"],
+						},
+					],
+				},
+			};
+			const result = validateWithdraw(
+				policy,
+				"BINANCE",
+				"ARB",
+				"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+				1000,
+				"ETH",
+			);
+			expect(result.valid).toBe(true);
+		});
+
+		test("should reject withdrawal when ticker is not in coins list", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				withdraw: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: ["ETH", "USDT"],
+						},
+					],
+				},
+			};
+			const result = validateWithdraw(
+				policy,
+				"BINANCE",
+				"ARB",
+				"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+				1000,
+				"ARB",
+			);
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain("Token ARB is not allowed");
+			expect(result.error).toContain("ETH");
+			expect(result.error).toContain("USDT");
+		});
+
+		test("should allow any ticker when coins is wildcard ['*']", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				withdraw: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: ["*"],
+						},
+					],
+				},
+			};
+			const result = validateWithdraw(
+				policy,
+				"BINANCE",
+				"ARB",
+				"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+				1000,
+				"ANYTHING",
+			);
+			expect(result.valid).toBe(true);
+		});
+
+		test("should allow any ticker when coins is empty array (same as omitted)", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				withdraw: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: [],
+						},
+					],
+				},
+			};
+			const result = validateWithdraw(
+				policy,
+				"BINANCE",
+				"ARB",
+				"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+				1000,
+				"ANYTHING",
+			);
+			expect(result.valid).toBe(true);
+		});
+
+		test("should match coins case-insensitively", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				withdraw: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: ["eth"],
+						},
+					],
+				},
+			};
+			// normalizePolicyConfig uppercases coins, so "eth" -> "ETH"
+			const result = validateWithdraw(
+				policy,
+				"BINANCE",
+				"ARB",
+				"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+				1000,
+				"ETH",
+			);
+			expect(result.valid).toBe(true);
+		});
+
+		test("highest-priority rule wins absolutely — no fallthrough to lower-priority on coin mismatch", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				withdraw: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: ["ETH"],
+						},
+						{
+							exchange: "*",
+							network: "ARB",
+							whitelist: ["0x9d467fa9062b6e9b1a46e26007ad82db116c67cb"],
+							coins: ["USDT"],
+						},
+					],
+				},
+			};
+			// BINANCE/ARB exact match (priority 4) wins over */ARB (priority 2).
+			// The winning rule only allows ETH, so USDT must be rejected.
+			const result = validateWithdraw(
+				policy,
+				"BINANCE",
+				"ARB",
+				"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+				1000,
+				"USDT",
+			);
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain("Token USDT is not allowed");
+			expect(result.error).toContain("ETH");
 		});
 
 		test("should prioritise exact match over wildcard rules", () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -688,19 +688,135 @@ describe("Helper Functions", () => {
 	});
 
 	describe("validateDeposit", () => {
-		test("should always allow deposits when policy is empty", () => {
-			const result = validateDeposit(testPolicy, "ARB", 1000);
+		test("should allow deposit when coin is in allowed list", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARBITRUM",
+							coins: ["ETH", "USDT"],
+						},
+					],
+				},
+			};
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ETH");
 			expect(result.valid).toBe(true);
-			expect(result.error).toBeUndefined();
 		});
 
-		test("should allow deposits with any amount", () => {
-			const result = validateDeposit(testPolicy, "ETH", 0.001);
+		test("should reject deposit when coin is not in allowed list", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [
+						{
+							exchange: "BINANCE",
+							network: "ARBITRUM",
+							coins: ["ETH", "USDT"],
+						},
+					],
+				},
+			};
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ARB");
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain("Token ARB not allowed");
+			expect(result.error).toContain("ETH");
+			expect(result.error).toContain("USDT");
+		});
+
+		test("should allow any coin when coins field is absent", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [{ exchange: "BINANCE", network: "ARBITRUM" }],
+				},
+			};
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "DOGE");
 			expect(result.valid).toBe(true);
 		});
 
-		test("should allow deposits on any chain", () => {
-			const result = validateDeposit(testPolicy, "POLYGON", 500);
+		test("should allow any coin when coins is wildcard ['*']", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [{ exchange: "BINANCE", network: "ARBITRUM", coins: ["*"] }],
+				},
+			};
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ANYTHING");
+			expect(result.valid).toBe(true);
+		});
+
+		test("should allow all deposits when deposit has no rule key", () => {
+			const policy: PolicyConfig = { ...testPolicy, deposit: {} };
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ETH");
+			expect(result.valid).toBe(true);
+		});
+
+		test("should allow all deposits when deposit has empty rule array", () => {
+			const policy: PolicyConfig = { ...testPolicy, deposit: { rule: [] } };
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ETH");
+			expect(result.valid).toBe(true);
+		});
+
+		test("should match exchange/network and allow any coin when rule has no coins", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [{ exchange: "BINANCE", network: "ARBITRUM" }],
+				},
+			};
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ETH");
+			expect(result.valid).toBe(true);
+		});
+
+		test("should reject wrong exchange/network when rules are present", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [{ exchange: "BINANCE", network: "ARBITRUM" }],
+				},
+			};
+			const result = validateDeposit(policy, "BYBIT", "OPTIMISM", "ETH");
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain("Deposits not allowed for BYBIT:OPTIMISM");
+		});
+
+		test("highest-priority rule wins with no fallthrough on coin mismatch", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [
+						{ exchange: "BINANCE", network: "ARBITRUM", coins: ["ETH"] },
+						{ exchange: "*", network: "ARBITRUM", coins: ["USDT"] },
+					],
+				},
+			};
+			// BINANCE/ARBITRUM matches rule1 (priority 4) which only allows ETH
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "USDT");
+			expect(result.valid).toBe(false);
+			expect(result.error).toContain("Token USDT not allowed");
+		});
+
+		test("should be case-insensitive for exchange, network, and coin", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [{ exchange: "binance", network: "arbitrum", coins: ["eth"] }],
+				},
+			};
+			const result = validateDeposit(policy, "Binance", "Arbitrum", "Eth");
+			expect(result.valid).toBe(true);
+		});
+
+		test("should allow all coins when coins is empty array", () => {
+			const policy: PolicyConfig = {
+				...testPolicy,
+				deposit: {
+					rule: [{ exchange: "BINANCE", network: "ARBITRUM", coins: [] }],
+				},
+			};
+			const result = validateDeposit(policy, "BINANCE", "ARBITRUM", "ANYTHING");
 			expect(result.valid).toBe(true);
 		});
 	});


### PR DESCRIPTION
related to https://linear.app/usherlabs/issue/FIET-718/cex-broker-add-token-restrictions-to-withdrawdeposit-policies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-based withdrawal allowlists per rule with wildcard and case-insensitive matching.
  * Token-based deposit rules enforced for deposit-address fetching; missing/empty rules allow all.
  * Added example and backtest policy files including order/limit samples.

* **Documentation**
  * Expanded policy docs with coin semantics, examples, rejection reasons, and troubleshooting.

* **Tests**
  * Added/updated tests covering coin allowlist behavior, priority matching, and case-insensitivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->