### PR TITLE
Expose InternalTransfer as standalone gRPC action

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 
+export PATH="$HOME/.bun/bin:$PATH"
+
 bun format
 bun test

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -33,6 +33,26 @@ export type BrokerPoolEntry = {
 	secondaryBrokers: BrokerAccount[];
 };
 
+export class BrokerAccountPreconditionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "BrokerAccountPreconditionError";
+	}
+}
+
+function requireDestinationEmail(
+	dest: BrokerAccount,
+	transferType: "sub-to-sub" | "primary-to-sub",
+) {
+	const email = dest.email?.trim();
+	if (!email) {
+		throw new BrokerAccountPreconditionError(
+			`Destination account '${dest.label}' requires an email configured for ${transferType} transfers`,
+		);
+	}
+	return email;
+}
+
 export function authenticateRequest<T, E>(
 	call: ServerUnaryCall<T, E>,
 	whitelistIps: string[],
@@ -594,13 +614,9 @@ export async function transferBinanceInternal(
 				"Binance sub→sub transfer is unavailable in this CCXT build",
 			);
 		}
-		if (!dest.email) {
-			throw new Error(
-				`Destination account "${dest.label}" has no email configured (required for sub→sub transfers)`,
-			);
-		}
+		const destEmail = requireDestinationEmail(dest, "sub-to-sub");
 		return await exchange.sapiPostSubAccountTransferSubToSub({
-			toEmail: dest.email,
+			toEmail: destEmail,
 			asset,
 			amount: amountStr,
 		});
@@ -612,15 +628,11 @@ export async function transferBinanceInternal(
 				"Binance universal transfer is unavailable in this CCXT build",
 			);
 		}
-		if (!dest.email) {
-			throw new Error(
-				`Destination account "${dest.label}" has no email configured (required for master→sub transfers)`,
-			);
-		}
+		const destEmail = requireDestinationEmail(dest, "primary-to-sub");
 		return await exchange.sapiPostSubAccountUniversalTransfer({
 			fromAccountType: "SPOT",
 			toAccountType: "SPOT",
-			toEmail: dest.email,
+			toEmail: destEmail,
 			asset,
 			amount: amountStr,
 		});

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -543,27 +543,92 @@ export function validateWithdraw(
 	return { valid: true };
 }
 
-export async function transferBinanceSubAccountToMaster(
+type BinanceImplicitMethods = {
+	sapiPostSubAccountTransferSubToMaster?: (
+		params: Record<string, unknown>,
+	) => Promise<unknown>;
+	sapiPostSubAccountTransferSubToSub?: (
+		params: Record<string, unknown>,
+	) => Promise<unknown>;
+	sapiPostSubAccountUniversalTransfer?: (
+		params: Record<string, unknown>,
+	) => Promise<unknown>;
+};
+
+/**
+ * Routes an internal transfer to the correct Binance SAPI endpoint
+ * based on source and destination account types.
+ */
+export async function transferBinanceInternal(
 	source: BrokerAccount,
+	dest: BrokerAccount,
 	code: string,
 	amount: number,
 ) {
-	const exchange = source.exchange as Exchange & {
-		sapiPostSubAccountTransferSubToMaster?: (
-			params: Record<string, unknown>,
-		) => Promise<unknown>;
-	};
-	if (typeof exchange.sapiPostSubAccountTransferSubToMaster !== "function") {
-		throw new Error(
-			"Binance sub-account transfer is unavailable in this CCXT build",
-		);
-	}
+	const exchange = source.exchange as Exchange & BinanceImplicitMethods;
 	await source.exchange.loadMarkets();
 	const currency = source.exchange.currency(code);
-	return await exchange.sapiPostSubAccountTransferSubToMaster({
-		asset: currency.id,
-		amount: source.exchange.currencyToPrecision(code, amount),
-	});
+	const asset = currency.id;
+	const amountStr = source.exchange.currencyToPrecision(code, amount);
+
+	const isSourceSecondary = source.label.startsWith("secondary:");
+	const isDestPrimary = dest.label === "primary";
+	const isDestSecondary = dest.label.startsWith("secondary:");
+	const isSourcePrimary = source.label === "primary";
+
+	if (isSourceSecondary && isDestPrimary) {
+		if (typeof exchange.sapiPostSubAccountTransferSubToMaster !== "function") {
+			throw new Error(
+				"Binance sub→master transfer is unavailable in this CCXT build",
+			);
+		}
+		return await exchange.sapiPostSubAccountTransferSubToMaster({
+			asset,
+			amount: amountStr,
+		});
+	}
+
+	if (isSourceSecondary && isDestSecondary) {
+		if (typeof exchange.sapiPostSubAccountTransferSubToSub !== "function") {
+			throw new Error(
+				"Binance sub→sub transfer is unavailable in this CCXT build",
+			);
+		}
+		if (!dest.email) {
+			throw new Error(
+				`Destination account "${dest.label}" has no email configured (required for sub→sub transfers)`,
+			);
+		}
+		return await exchange.sapiPostSubAccountTransferSubToSub({
+			toEmail: dest.email,
+			asset,
+			amount: amountStr,
+		});
+	}
+
+	if (isSourcePrimary && isDestSecondary) {
+		if (typeof exchange.sapiPostSubAccountUniversalTransfer !== "function") {
+			throw new Error(
+				"Binance universal transfer is unavailable in this CCXT build",
+			);
+		}
+		if (!dest.email) {
+			throw new Error(
+				`Destination account "${dest.label}" has no email configured (required for master→sub transfers)`,
+			);
+		}
+		return await exchange.sapiPostSubAccountUniversalTransfer({
+			fromAccountType: "SPOT",
+			toAccountType: "SPOT",
+			toEmail: dest.email,
+			asset,
+			amount: amountStr,
+		});
+	}
+
+	throw new Error(
+		`Unsupported transfer direction: ${source.label} → ${dest.label}`,
+	);
 }
 
 /**

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -33,17 +33,6 @@ export type BrokerPoolEntry = {
 	secondaryBrokers: BrokerAccount[];
 };
 
-export class WithdrawRoutingError extends Error {}
-export class WithdrawRoutingUnavailableError extends WithdrawRoutingError {}
-
-function isMasterBrokerAccount(account: BrokerAccount): boolean {
-	return account.label === "primary" || account.role === "master";
-}
-
-function isSubaccountBrokerAccount(account: BrokerAccount): boolean {
-	return !isMasterBrokerAccount(account);
-}
-
 export function authenticateRequest<T, E>(
 	call: ServerUnaryCall<T, E>,
 	whitelistIps: string[],
@@ -554,26 +543,7 @@ export function validateWithdraw(
 	return { valid: true };
 }
 
-function normalizeAccountSelector(
-	selector: string | undefined,
-	metadata: Metadata,
-	defaultSelector: "current" | "primary",
-): string {
-	const raw = selector?.trim().toLowerCase() ?? defaultSelector;
-	if (raw === "current") {
-		return getCurrentBrokerSelector(metadata);
-	}
-	if (raw === "primary") {
-		return "primary";
-	}
-	const secondaryMatch = raw.match(/^secondary:(\d+)$/);
-	if (secondaryMatch) {
-		return `secondary:${secondaryMatch[1]}`;
-	}
-	throw new WithdrawRoutingError(`Invalid account selector "${selector}"`);
-}
-
-async function transferBinanceSubAccountToMaster(
+export async function transferBinanceSubAccountToMaster(
 	source: BrokerAccount,
 	code: string,
 	amount: number,
@@ -584,8 +554,8 @@ async function transferBinanceSubAccountToMaster(
 		) => Promise<unknown>;
 	};
 	if (typeof exchange.sapiPostSubAccountTransferSubToMaster !== "function") {
-		throw new WithdrawRoutingUnavailableError(
-			"Binance sub-account to master transfer is unavailable in this CCXT build",
+		throw new Error(
+			"Binance sub-account transfer is unavailable in this CCXT build",
 		);
 	}
 	await source.exchange.loadMarkets();
@@ -594,108 +564,6 @@ async function transferBinanceSubAccountToMaster(
 		asset: currency.id,
 		amount: source.exchange.currencyToPrecision(code, amount),
 	});
-}
-
-export async function executeWithdrawWithRouting(args: {
-	cex: string;
-	brokers: BrokerPoolEntry | undefined;
-	metadata: Metadata;
-	selectedBroker: Exchange;
-	code: string;
-	amount: number;
-	recipientAddress: string;
-	network: string;
-	params?: Record<string, string | number>;
-	routeViaMaster?: boolean;
-	sourceAccount?: string;
-	masterAccount?: string;
-}) {
-	const {
-		cex,
-		brokers,
-		metadata,
-		selectedBroker,
-		code,
-		amount,
-		recipientAddress,
-		network,
-		params,
-		routeViaMaster,
-		sourceAccount,
-		masterAccount,
-	} = args;
-	const withdrawParams = {
-		...(params ?? {}),
-		network,
-	};
-	if (!routeViaMaster) {
-		return await selectedBroker.withdraw(
-			code,
-			amount,
-			recipientAddress,
-			undefined,
-			withdrawParams,
-		);
-	}
-	const sourceSelector = normalizeAccountSelector(
-		sourceAccount,
-		metadata,
-		"current",
-	);
-	const masterSelector = normalizeAccountSelector(
-		masterAccount,
-		metadata,
-		"primary",
-	);
-	if (!brokers) {
-		throw new WithdrawRoutingUnavailableError(
-			"Routed withdraw requires configured broker accounts",
-		);
-	}
-	const source = resolveBrokerAccount(brokers, sourceSelector);
-	if (!source) {
-		throw new WithdrawRoutingError(
-			`Source account ${sourceSelector} is not configured`,
-		);
-	}
-	const master = resolveBrokerAccount(brokers, masterSelector);
-	if (!master) {
-		throw new WithdrawRoutingError(
-			`Master account ${masterSelector} is not configured`,
-		);
-	}
-	if (!isMasterBrokerAccount(master)) {
-		throw new WithdrawRoutingError(
-			`Master account ${masterSelector} must resolve to the primary/master account`,
-		);
-	}
-	if (source.label === master.label) {
-		return await master.exchange.withdraw(
-			code,
-			amount,
-			recipientAddress,
-			undefined,
-			withdrawParams,
-		);
-	}
-	if (!isSubaccountBrokerAccount(source)) {
-		throw new WithdrawRoutingError(
-			`Source account ${sourceSelector} must resolve to a subaccount when routeViaMaster is enabled`,
-		);
-	}
-	if (cex.trim().toLowerCase() !== "binance") {
-		throw new WithdrawRoutingUnavailableError(
-			`Withdraw routing via master is not supported for ${cex}`,
-		);
-	}
-	await transferBinanceSubAccountToMaster(source, code, amount);
-	return await master.exchange.withdraw(
-		code,
-		amount,
-		recipientAddress,
-		undefined,
-		withdrawParams,
-	);
 }
 
 /**

--- a/src/proto/node.proto
+++ b/src/proto/node.proto
@@ -57,4 +57,5 @@ enum Action {
   Call=10;
   FetchAccountId=11;
   FetchFees= 12;
+  InternalTransfer= 13;
 }

--- a/src/schemas/action-payloads.ts
+++ b/src/schemas/action-payloads.ts
@@ -57,10 +57,13 @@ export const WithdrawPayloadSchema = z.object({
 	recipientAddress: z.string().min(1),
 	amount: z.coerce.number().positive(),
 	chain: z.string().min(1),
-	routeViaMaster: booleanLikeSchema.optional().default(false),
-	sourceAccount: z.string().min(1).optional(),
-	masterAccount: z.string().min(1).optional(),
 	params: z.preprocess(parseJsonString, stringNumberRecordSchema).default({}),
+});
+
+export const InternalTransferPayloadSchema = z.object({
+	amount: z.coerce.number().positive(),
+	fromAccount: z.string().min(1).optional(),
+	toAccount: z.string().min(1).optional(),
 });
 
 export const CreateOrderPayloadSchema = z.object({
@@ -93,6 +96,9 @@ export type FetchDepositAddressesPayload = z.infer<
 	typeof FetchDepositAddressesPayloadSchema
 >;
 export type WithdrawPayload = z.infer<typeof WithdrawPayloadSchema>;
+export type InternalTransferPayload = z.infer<
+	typeof InternalTransferPayloadSchema
+>;
 export type CreateOrderPayload = z.infer<typeof CreateOrderPayloadSchema>;
 export type GetOrderDetailsPayload = z.infer<
 	typeof GetOrderDetailsPayloadSchema

--- a/src/server.ts
+++ b/src/server.ts
@@ -1093,6 +1093,19 @@ export function getServer(
 						}
 
 						try {
+							if (useVerity) {
+								sourceAccount.exchange.setHttpClientOverride(
+									buildHttpClientOverrideFromMetadata(
+										metadata,
+										verityProverUrl,
+										(proof, notaryPubKey) => {
+											verityProof = proof;
+											log.debug(`Verity proof:`, { proof, notaryPubKey });
+										},
+									),
+									verityHttpClientOverridePredicate,
+								);
+							}
 							const result = await transferBinanceInternal(
 								sourceAccount,
 								destAccount,
@@ -1114,10 +1127,17 @@ export function getServer(
 									null,
 								);
 							}
+							const msg = getErrorMessage(error);
+							let code = grpc.status.INTERNAL;
+							if (msg.includes("Unsupported transfer direction")) {
+								code = grpc.status.INVALID_ARGUMENT;
+							} else if (msg.includes("unavailable in this CCXT build")) {
+								code = grpc.status.UNIMPLEMENTED;
+							}
 							wrappedCallback(
 								{
-									code: grpc.status.INTERNAL,
-									message: `InternalTransfer failed: ${getErrorMessage(error)}`,
+									code,
+									message: `InternalTransfer failed: ${msg}`,
 								},
 								null,
 							);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1068,7 +1068,8 @@ export function getServer(
 						}
 						const transferPayload = parsedPayload.data;
 
-						if (cex.trim().toLowerCase() !== "binance") {
+						const normalizedCex = cex.trim().toLowerCase();
+						if (normalizedCex !== "binance") {
 							return wrappedCallback(
 								{
 									code: grpc.status.UNIMPLEMENTED,
@@ -1078,12 +1079,12 @@ export function getServer(
 							);
 						}
 
-						const pool = brokers[cex as keyof typeof brokers];
+						const pool = brokers[normalizedCex as keyof typeof brokers];
 						if (!pool) {
 							return wrappedCallback(
 								{
 									code: grpc.status.FAILED_PRECONDITION,
-									message: `No broker accounts configured for ${cex}`,
+									message: `No broker accounts configured for ${normalizedCex}`,
 								},
 								null,
 							);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import {
 	resolveBrokerAccount,
 	resolveOrderExecution,
 	selectBroker,
-	transferBinanceSubAccountToMaster,
+	transferBinanceInternal,
 	validateDeposit,
 	validateWithdraw,
 	verityHttpClientOverridePredicate,
@@ -1092,8 +1092,9 @@ export function getServer(
 						}
 
 						try {
-							const result = await transferBinanceSubAccountToMaster(
+							const result = await transferBinanceInternal(
 								sourceAccount,
+								destAccount,
 								symbol,
 								transferPayload.amount,
 							);

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,8 +92,8 @@ function mapCcxtErrorToGrpcStatus(error: unknown): grpc.status | undefined {
 	if (error instanceof ccxt.InsufficientFunds)
 		return grpc.status.FAILED_PRECONDITION;
 	if (error instanceof ccxt.InvalidAddress) return grpc.status.INVALID_ARGUMENT;
-	if (error instanceof ccxt.BadRequest) return grpc.status.INVALID_ARGUMENT;
 	if (error instanceof ccxt.BadSymbol) return grpc.status.NOT_FOUND;
+	if (error instanceof ccxt.BadRequest) return grpc.status.INVALID_ARGUMENT;
 	if (error instanceof ccxt.NotSupported) return grpc.status.UNIMPLEMENTED;
 	if (error instanceof ccxt.RateLimitExceeded)
 		return grpc.status.RESOURCE_EXHAUSTED;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
-import type { Exchange } from "@usherlabs/ccxt";
+import ccxt, { type Exchange } from "@usherlabs/ccxt";
 import type { z } from "zod";
 import {
 	authenticateRequest,
@@ -81,6 +81,27 @@ function safeLogError(context: string, error: unknown): void {
 	} catch {
 		console.error(context, error);
 	}
+}
+
+/** Maps CCXT typed errors to appropriate gRPC status codes. Returns undefined for unrecognized errors. */
+function mapCcxtErrorToGrpcStatus(error: unknown): grpc.status | undefined {
+	if (error instanceof ccxt.AuthenticationError)
+		return grpc.status.UNAUTHENTICATED;
+	if (error instanceof ccxt.PermissionDenied)
+		return grpc.status.PERMISSION_DENIED;
+	if (error instanceof ccxt.InsufficientFunds)
+		return grpc.status.FAILED_PRECONDITION;
+	if (error instanceof ccxt.InvalidAddress) return grpc.status.INVALID_ARGUMENT;
+	if (error instanceof ccxt.BadRequest) return grpc.status.INVALID_ARGUMENT;
+	if (error instanceof ccxt.BadSymbol) return grpc.status.NOT_FOUND;
+	if (error instanceof ccxt.NotSupported) return grpc.status.UNIMPLEMENTED;
+	if (error instanceof ccxt.RateLimitExceeded)
+		return grpc.status.RESOURCE_EXHAUSTED;
+	if (error instanceof ccxt.OnMaintenance) return grpc.status.UNAVAILABLE;
+	if (error instanceof ccxt.ExchangeNotAvailable)
+		return grpc.status.UNAVAILABLE;
+	if (error instanceof ccxt.NetworkError) return grpc.status.UNAVAILABLE;
+	return undefined;
 }
 
 export function getServer(
@@ -740,9 +761,11 @@ export function getServer(
 							});
 						} catch (error) {
 							safeLogError("Withdraw failed", error);
+							const code =
+								mapCcxtErrorToGrpcStatus(error) ?? grpc.status.INTERNAL;
 							wrappedCallback(
 								{
-									code: grpc.status.INTERNAL,
+									code,
 									message: `Withdraw failed: ${getErrorMessage(error)}`,
 								},
 								null,
@@ -1128,11 +1151,13 @@ export function getServer(
 								);
 							}
 							const msg = getErrorMessage(error);
-							let code = grpc.status.INTERNAL;
+							let code: grpc.status;
 							if (msg.includes("Unsupported transfer direction")) {
 								code = grpc.status.INVALID_ARGUMENT;
 							} else if (msg.includes("unavailable in this CCXT build")) {
 								code = grpc.status.UNIMPLEMENTED;
+							} else {
+								code = mapCcxtErrorToGrpcStatus(error) ?? grpc.status.INTERNAL;
 							}
 							wrappedCallback(
 								{

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,10 +203,14 @@ export function getServer(
 					);
 				}
 
+				const normalizedCex = cex.trim().toLowerCase();
+
 				// If the Exchange is not already pre-loaded for preset API credentials via constructor - createBroker for non-gated APIs may be available for other exchanges.
 				const broker =
-					selectBroker(brokers[cex as keyof typeof brokers], metadata) ??
-					createBroker(cex, metadata);
+					selectBroker(
+						brokers[normalizedCex as keyof typeof brokers],
+						metadata,
+					) ?? createBroker(normalizedCex, metadata);
 
 				if (!broker) {
 					return wrappedCallback(
@@ -1068,7 +1072,6 @@ export function getServer(
 						}
 						const transferPayload = parsedPayload.data;
 
-						const normalizedCex = cex.trim().toLowerCase();
 						if (normalizedCex !== "binance") {
 							return wrappedCallback(
 								{

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,14 +7,14 @@ import {
 	type BrokerPoolEntry,
 	buildHttpClientOverrideFromMetadata,
 	createBroker,
-	executeWithdrawWithRouting,
+	getCurrentBrokerSelector,
+	resolveBrokerAccount,
 	resolveOrderExecution,
 	selectBroker,
+	transferBinanceSubAccountToMaster,
 	validateDeposit,
 	validateWithdraw,
 	verityHttpClientOverridePredicate,
-	WithdrawRoutingError,
-	WithdrawRoutingUnavailableError,
 } from "./helpers";
 import { log } from "./helpers/logger";
 import type { OtelMetrics } from "./helpers/otel";
@@ -34,6 +34,7 @@ import {
 	FetchDepositAddressesPayloadSchema,
 	FetchFeesPayloadSchema,
 	GetOrderDetailsPayloadSchema,
+	InternalTransferPayloadSchema,
 	WithdrawPayloadSchema,
 } from "./schemas/action-payloads";
 import type { PolicyConfig } from "./types";
@@ -702,7 +703,6 @@ export function getServer(
 							);
 						}
 						const transferValue = parsedPayload.data;
-						// Validate against policy
 						const transferValidation = validateWithdraw(
 							policy,
 							cex,
@@ -721,45 +721,16 @@ export function getServer(
 							);
 						}
 						try {
-							let transaction: Awaited<ReturnType<Exchange["withdraw"]>>;
-							try {
-								transaction = await executeWithdrawWithRouting({
-									cex,
-									brokers: brokers[cex as keyof typeof brokers],
-									metadata,
-									selectedBroker: broker,
-									code: symbol,
-									amount: transferValue.amount,
-									recipientAddress: transferValue.recipientAddress,
+							const transaction = await broker.withdraw(
+								symbol,
+								transferValue.amount,
+								transferValue.recipientAddress,
+								undefined,
+								{
+									...(transferValue.params ?? {}),
 									network: transferValue.chain,
-									params: transferValue.params,
-									routeViaMaster: transferValue.routeViaMaster,
-									sourceAccount: transferValue.sourceAccount,
-									masterAccount: transferValue.masterAccount,
-								});
-							} catch (error) {
-								if (error instanceof WithdrawRoutingUnavailableError) {
-									log.warn("Withdraw routing unavailable, falling back", {
-										cex,
-										error: error.message,
-									});
-									if (transferValue.routeViaMaster) {
-										throw error;
-									}
-									transaction = await broker.withdraw(
-										symbol,
-										transferValue.amount,
-										transferValue.recipientAddress,
-										undefined,
-										{
-											...(transferValue.params ?? {}),
-											network: transferValue.chain,
-										},
-									);
-								} else {
-									throw error;
-								}
-							}
+								},
+							);
 							log.info(`Withdraw Result: ${JSON.stringify(transaction)}`);
 
 							wrappedCallback(null, {
@@ -768,17 +739,10 @@ export function getServer(
 							});
 						} catch (error) {
 							safeLogError("Withdraw failed", error);
-							const message =
-								error instanceof WithdrawRoutingError
-									? error.message
-									: getErrorMessage(error);
 							wrappedCallback(
 								{
-									code:
-										error instanceof WithdrawRoutingError
-											? grpc.status.INVALID_ARGUMENT
-											: grpc.status.INTERNAL,
-									message: `Withdraw failed: ${message}`,
+									code: grpc.status.INTERNAL,
+									message: `Withdraw failed: ${getErrorMessage(error)}`,
 								},
 								null,
 							);
@@ -1054,6 +1018,101 @@ export function getServer(
 							);
 						}
 						break;
+
+					case Action.InternalTransfer: {
+						if (!symbol) {
+							return wrappedCallback(
+								{
+									code: grpc.status.INVALID_ARGUMENT,
+									message: `ValidationError: Symbol required`,
+								},
+								null,
+							);
+						}
+						const parsedPayload = parsePayload(
+							InternalTransferPayloadSchema,
+							call.request.payload,
+						);
+						if (!parsedPayload.success) {
+							return wrappedCallback(
+								{
+									code: grpc.status.INVALID_ARGUMENT,
+									message: parsedPayload.message,
+								},
+								null,
+							);
+						}
+						const transferPayload = parsedPayload.data;
+
+						if (cex.trim().toLowerCase() !== "binance") {
+							return wrappedCallback(
+								{
+									code: grpc.status.UNIMPLEMENTED,
+									message: `InternalTransfer is only supported for Binance`,
+								},
+								null,
+							);
+						}
+
+						const pool = brokers[cex as keyof typeof brokers];
+						if (!pool) {
+							return wrappedCallback(
+								{
+									code: grpc.status.FAILED_PRECONDITION,
+									message: `No broker accounts configured for ${cex}`,
+								},
+								null,
+							);
+						}
+
+						const fromSelector =
+							transferPayload.fromAccount ?? getCurrentBrokerSelector(metadata);
+						const toSelector = transferPayload.toAccount ?? "primary";
+
+						const sourceAccount = resolveBrokerAccount(pool, fromSelector);
+						if (!sourceAccount) {
+							return wrappedCallback(
+								{
+									code: grpc.status.INVALID_ARGUMENT,
+									message: `Source account "${fromSelector}" is not configured`,
+								},
+								null,
+							);
+						}
+
+						const destAccount = resolveBrokerAccount(pool, toSelector);
+						if (!destAccount) {
+							return wrappedCallback(
+								{
+									code: grpc.status.INVALID_ARGUMENT,
+									message: `Destination account "${toSelector}" is not configured`,
+								},
+								null,
+							);
+						}
+
+						try {
+							const result = await transferBinanceSubAccountToMaster(
+								sourceAccount,
+								symbol,
+								transferPayload.amount,
+							);
+							wrappedCallback(null, {
+								proof: verityProof,
+								result: JSON.stringify(result),
+							});
+						} catch (error) {
+							safeLogError("InternalTransfer failed", error);
+							wrappedCallback(
+								{
+									code: grpc.status.INTERNAL,
+									message: `InternalTransfer failed: ${getErrorMessage(error)}`,
+								},
+								null,
+							);
+						}
+						break;
+					}
 
 					default:
 						return wrappedCallback({

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type { Exchange } from "@usherlabs/ccxt";
 import type { z } from "zod";
 import {
 	authenticateRequest,
+	BrokerAccountPreconditionError,
 	type BrokerPoolEntry,
 	buildHttpClientOverrideFromMetadata,
 	createBroker,
@@ -1104,6 +1105,15 @@ export function getServer(
 							});
 						} catch (error) {
 							safeLogError("InternalTransfer failed", error);
+							if (error instanceof BrokerAccountPreconditionError) {
+								return wrappedCallback(
+									{
+										code: grpc.status.FAILED_PRECONDITION,
+										message: getErrorMessage(error),
+									},
+									null,
+								);
+							}
 							wrappedCallback(
 								{
 									code: grpc.status.INTERNAL,

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1063,7 +1063,7 @@ describe("Helper Functions", () => {
 			});
 		});
 
-		test("sub→sub: throws when dest email is missing", async () => {
+		test("sub→sub: throws a clear error when dest email is missing", async () => {
 			const { exchange } = createMockExchange([
 				"sapiPostSubAccountTransferSubToSub",
 			]);
@@ -1074,10 +1074,12 @@ describe("Helper Functions", () => {
 					"USDT",
 					1,
 				),
-			).rejects.toThrow("no email configured (required for sub→sub transfers)");
+			).rejects.toThrow(
+				"Destination account 'secondary:2' requires an email configured for sub-to-sub transfers",
+			);
 		});
 
-		test("primary→secondary: throws when dest email is missing", async () => {
+		test("primary→secondary: throws a clear error when dest email is missing", async () => {
 			const { exchange } = createMockExchange([
 				"sapiPostSubAccountUniversalTransfer",
 			]);
@@ -1089,7 +1091,7 @@ describe("Helper Functions", () => {
 					1,
 				),
 			).rejects.toThrow(
-				"no email configured (required for master→sub transfers)",
+				"Destination account 'secondary:1' requires an email configured for primary-to-sub transfers",
 			);
 		});
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -7,18 +7,19 @@ import path from "path";
 import {
 	type BrokerPoolEntry,
 	createBrokerPool,
-	executeWithdrawWithRouting,
 	getCurrentBrokerSelector,
 	loadPolicy,
 	resolveBrokerAccount,
 	resolveOrderExecution,
+	transferBinanceSubAccountToMaster,
 	validateDeposit,
 	validateOrder,
 	validateWithdraw,
-	WithdrawRoutingError,
-	WithdrawRoutingUnavailableError,
 } from "../src/helpers/index";
-import { WithdrawPayloadSchema } from "../src/schemas/action-payloads";
+import {
+	InternalTransferPayloadSchema,
+	WithdrawPayloadSchema,
+} from "../src/schemas/action-payloads";
 import type { PolicyConfig } from "../src/types";
 
 describe("Helper Functions", () => {
@@ -830,31 +831,22 @@ describe("Helper Functions", () => {
 		});
 	});
 
-	describe("withdraw routing", () => {
+	describe("broker account resolution", () => {
 		function createMockExchange() {
 			const state = {
-				withdrawCalls: [] as unknown[],
 				transferCalls: [] as unknown[],
 			};
 			const exchange = {
 				loadMarkets: async () => undefined,
 				currency: (code: string) => ({ id: code }),
 				currencyToPrecision: (_code: string, amount: number) => String(amount),
-				withdraw: async (...args: unknown[]) => {
-					state.withdrawCalls.push(args);
-					return { id: "withdraw-1" };
-				},
 				sapiPostSubAccountTransferSubToMaster: async (
 					params: Record<string, unknown>,
 				) => {
 					state.transferCalls.push(params);
 					return { txnId: "transfer-1" };
 				},
-			} as unknown as Exchange & {
-				sapiPostSubAccountTransferSubToMaster: (
-					params: Record<string, unknown>,
-				) => Promise<unknown>;
-			};
+			} as unknown as Exchange;
 			return { exchange, state };
 		}
 
@@ -865,22 +857,6 @@ describe("Helper Functions", () => {
 			}
 			return metadata;
 		}
-
-		test("should parse routed withdraw payload fields", () => {
-			const payload = WithdrawPayloadSchema.parse({
-				recipientAddress: "0xabc",
-				amount: "1.25",
-				chain: "ARB",
-				routeViaMaster: "true",
-				sourceAccount: "secondary:1",
-				masterAccount: "primary",
-			});
-
-			expect(payload.routeViaMaster).toBe(true);
-			expect(payload.amount).toBe(1.25);
-			expect(payload.sourceAccount).toBe("secondary:1");
-			expect(payload.masterAccount).toBe("primary");
-		});
 
 		test("should resolve broker selectors from metadata", () => {
 			const primaryMetadata = createMetadata();
@@ -933,184 +909,110 @@ describe("Helper Functions", () => {
 				email: "sub2@example.com",
 			});
 		});
+	});
 
-		test("should route binance withdraws through master account", async () => {
-			const { exchange: primary, state: primaryState } = createMockExchange();
-			const { exchange: secondary, state: secondaryState } =
-				createMockExchange();
-			const pool: BrokerPoolEntry = {
-				primary: { exchange: primary, label: "primary", role: "master" },
-				secondaryBrokers: [
-					{
-						exchange: secondary,
-						label: "secondary:1",
-						index: 1,
-						role: "subaccount",
-					},
-				],
-			};
-
-			await executeWithdrawWithRouting({
-				cex: "binance",
-				brokers: pool,
-				metadata: createMetadata("1"),
-				selectedBroker: secondary,
-				code: "USDT",
-				amount: 2,
+	describe("withdraw payload schema", () => {
+		test("should parse withdraw payload without routing fields", () => {
+			const payload = WithdrawPayloadSchema.parse({
 				recipientAddress: "0xabc",
-				network: "ARB",
-				routeViaMaster: true,
-				sourceAccount: "current",
-				masterAccount: "primary",
+				amount: "1.25",
+				chain: "ARB",
 			});
 
-			expect(secondaryState.transferCalls).toHaveLength(1);
-			expect(primaryState.withdrawCalls).toHaveLength(1);
-			expect(secondaryState.transferCalls[0]).toMatchObject({
+			expect(payload.amount).toBe(1.25);
+			expect(payload.recipientAddress).toBe("0xabc");
+			expect(payload.chain).toBe("ARB");
+		});
+
+		test("should reject unknown routing fields", () => {
+			const payload = WithdrawPayloadSchema.parse({
+				recipientAddress: "0xabc",
+				amount: "1.25",
+				chain: "ARB",
+				routeViaMaster: "true",
+			});
+			// routeViaMaster is no longer in the schema, so it should be stripped
+			expect(
+				(payload as Record<string, unknown>).routeViaMaster,
+			).toBeUndefined();
+		});
+	});
+
+	describe("InternalTransfer payload schema", () => {
+		test("should parse amount with defaults", () => {
+			const payload = InternalTransferPayloadSchema.parse({
+				amount: "5.5",
+			});
+			expect(payload.amount).toBe(5.5);
+			expect(payload.fromAccount).toBeUndefined();
+			expect(payload.toAccount).toBeUndefined();
+		});
+
+		test("should parse explicit account selectors", () => {
+			const payload = InternalTransferPayloadSchema.parse({
+				amount: "10",
+				fromAccount: "secondary:1",
+				toAccount: "primary",
+			});
+			expect(payload.amount).toBe(10);
+			expect(payload.fromAccount).toBe("secondary:1");
+			expect(payload.toAccount).toBe("primary");
+		});
+
+		test("should reject missing amount", () => {
+			expect(() => InternalTransferPayloadSchema.parse({})).toThrow();
+		});
+	});
+
+	describe("transferBinanceSubAccountToMaster", () => {
+		function createMockBrokerAccount(hasSapiMethod: boolean) {
+			const state = { transferCalls: [] as unknown[] };
+			const exchange: Record<string, unknown> = {
+				loadMarkets: async () => undefined,
+				currency: (code: string) => ({ id: code }),
+				currencyToPrecision: (_code: string, amount: number) => String(amount),
+			};
+			if (hasSapiMethod) {
+				exchange.sapiPostSubAccountTransferSubToMaster = async (
+					params: Record<string, unknown>,
+				) => {
+					state.transferCalls.push(params);
+					return { txnId: "transfer-1" };
+				};
+			}
+			return {
+				account: {
+					exchange: exchange as unknown as Exchange,
+					label: "secondary:1" as const,
+					index: 1,
+				},
+				state,
+			};
+		}
+
+		test("should call SAPI transfer with correct asset and amount", async () => {
+			const { account, state } = createMockBrokerAccount(true);
+
+			const result = await transferBinanceSubAccountToMaster(
+				account,
+				"USDT",
+				2.5,
+			);
+
+			expect(state.transferCalls).toHaveLength(1);
+			expect(state.transferCalls[0]).toMatchObject({
 				asset: "USDT",
-				amount: "2",
+				amount: "2.5",
 			});
+			expect(result).toMatchObject({ txnId: "transfer-1" });
 		});
 
-		test("should skip transfer when source and master are the same", async () => {
-			const { exchange: primary, state } = createMockExchange();
-			const pool: BrokerPoolEntry = {
-				primary: { exchange: primary, label: "primary" },
-				secondaryBrokers: [],
-			};
-
-			await executeWithdrawWithRouting({
-				cex: "binance",
-				brokers: pool,
-				metadata: createMetadata(),
-				selectedBroker: primary,
-				code: "USDT",
-				amount: 1,
-				recipientAddress: "0xabc",
-				network: "ARB",
-				routeViaMaster: true,
-				sourceAccount: "primary",
-				masterAccount: "primary",
-			});
-
-			expect(state.transferCalls).toHaveLength(0);
-			expect(state.withdrawCalls).toHaveLength(1);
-		});
-
-		test("should report unavailable routing for unsupported exchanges", async () => {
-			const { exchange: primary } = createMockExchange();
-			const { exchange: secondary } = createMockExchange();
-			const pool: BrokerPoolEntry = {
-				primary: { exchange: primary, label: "primary" },
-				secondaryBrokers: [
-					{ exchange: secondary, label: "secondary:1", index: 1 },
-				],
-			};
+		test("should throw when SAPI method is unavailable", async () => {
+			const { account } = createMockBrokerAccount(false);
 
 			await expect(
-				executeWithdrawWithRouting({
-					cex: "bybit",
-					brokers: pool,
-					metadata: createMetadata("1"),
-					selectedBroker: secondary,
-					code: "USDT",
-					amount: 2,
-					recipientAddress: "0xabc",
-					network: "ARB",
-					routeViaMaster: true,
-				}),
-			).rejects.toBeInstanceOf(WithdrawRoutingUnavailableError);
-		});
-
-		test("should reject a non-master target account for routed withdraws", async () => {
-			const { exchange: primary } = createMockExchange();
-			const { exchange: secondary } = createMockExchange();
-			const pool: BrokerPoolEntry = {
-				primary: { exchange: primary, label: "primary", role: "master" },
-				secondaryBrokers: [
-					{
-						exchange: secondary,
-						label: "secondary:1",
-						index: 1,
-						role: "subaccount",
-					},
-				],
-			};
-
-			await expect(
-				executeWithdrawWithRouting({
-					cex: "binance",
-					brokers: pool,
-					metadata: createMetadata("1"),
-					selectedBroker: secondary,
-					code: "USDT",
-					amount: 2,
-					recipientAddress: "0xabc",
-					network: "ARB",
-					routeViaMaster: true,
-					sourceAccount: "secondary:1",
-					masterAccount: "secondary:1",
-				}),
-			).rejects.toThrow(
-				"Master account secondary:1 must resolve to the primary/master account",
-			);
-		});
-
-		test("should reject a non-subaccount source for routed withdraws", async () => {
-			const { exchange: primary } = createMockExchange();
-			const { exchange: secondary } = createMockExchange();
-			const pool: BrokerPoolEntry = {
-				primary: { exchange: primary, label: "primary", role: "master" },
-				secondaryBrokers: [
-					{
-						exchange: secondary,
-						label: "secondary:1",
-						index: 1,
-						role: "master",
-					},
-				],
-			};
-
-			await expect(
-				executeWithdrawWithRouting({
-					cex: "binance",
-					brokers: pool,
-					metadata: createMetadata(),
-					selectedBroker: primary,
-					code: "USDT",
-					amount: 2,
-					recipientAddress: "0xabc",
-					network: "ARB",
-					routeViaMaster: true,
-					sourceAccount: "primary",
-					masterAccount: "secondary:1",
-				}),
-			).rejects.toThrow(
-				"Source account primary must resolve to a subaccount when routeViaMaster is enabled",
-			);
-		});
-
-		test("should reject invalid account selectors", async () => {
-			const { exchange: primary } = createMockExchange();
-			const pool: BrokerPoolEntry = {
-				primary: { exchange: primary, label: "primary" },
-				secondaryBrokers: [],
-			};
-
-			await expect(
-				executeWithdrawWithRouting({
-					cex: "binance",
-					brokers: pool,
-					metadata: createMetadata(),
-					selectedBroker: primary,
-					code: "USDT",
-					amount: 2,
-					recipientAddress: "0xabc",
-					network: "ARB",
-					routeViaMaster: true,
-					sourceAccount: "secondary:bad",
-				}),
-			).rejects.toBeInstanceOf(WithdrawRoutingError);
+				transferBinanceSubAccountToMaster(account, "USDT", 1),
+			).rejects.toThrow("Binance sub-account transfer is unavailable");
 		});
 	});
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -11,7 +11,7 @@ import {
 	loadPolicy,
 	resolveBrokerAccount,
 	resolveOrderExecution,
-	transferBinanceSubAccountToMaster,
+	transferBinanceInternal,
 	validateDeposit,
 	validateOrder,
 	validateWithdraw,
@@ -964,55 +964,181 @@ describe("Helper Functions", () => {
 		});
 	});
 
-	describe("transferBinanceSubAccountToMaster", () => {
-		function createMockBrokerAccount(hasSapiMethod: boolean) {
-			const state = { transferCalls: [] as unknown[] };
+	describe("transferBinanceInternal", () => {
+		type SapiMethods =
+			| "sapiPostSubAccountTransferSubToMaster"
+			| "sapiPostSubAccountTransferSubToSub"
+			| "sapiPostSubAccountUniversalTransfer";
+
+		function createMockExchange(enabledMethods: SapiMethods[]) {
+			const calls: Record<string, unknown[]> = {};
 			const exchange: Record<string, unknown> = {
 				loadMarkets: async () => undefined,
 				currency: (code: string) => ({ id: code }),
 				currencyToPrecision: (_code: string, amount: number) => String(amount),
 			};
-			if (hasSapiMethod) {
-				exchange.sapiPostSubAccountTransferSubToMaster = async (
-					params: Record<string, unknown>,
-				) => {
-					state.transferCalls.push(params);
-					return { txnId: "transfer-1" };
+			for (const method of enabledMethods) {
+				calls[method] = [];
+				exchange[method] = async (params: Record<string, unknown>) => {
+					calls[method].push(params);
+					return { txnId: `${method}-ok` };
 				};
 			}
-			return {
-				account: {
-					exchange: exchange as unknown as Exchange,
-					label: "secondary:1" as const,
-					index: 1,
-				},
-				state,
-			};
+			return { exchange: exchange as unknown as Exchange, calls };
 		}
 
-		test("should call SAPI transfer with correct asset and amount", async () => {
-			const { account, state } = createMockBrokerAccount(true);
+		function account(
+			label: "primary" | `secondary:${number}`,
+			exchange: Exchange,
+			email?: string,
+		) {
+			return {
+				exchange,
+				label,
+				email,
+			} as import("../src/helpers/index").BrokerAccount;
+		}
 
-			const result = await transferBinanceSubAccountToMaster(
-				account,
+		test("sub→master: calls SubToMaster endpoint", async () => {
+			const { exchange, calls } = createMockExchange([
+				"sapiPostSubAccountTransferSubToMaster",
+			]);
+			const result = await transferBinanceInternal(
+				account("secondary:1", exchange),
+				account("primary", exchange),
 				"USDT",
 				2.5,
 			);
-
-			expect(state.transferCalls).toHaveLength(1);
-			expect(state.transferCalls[0]).toMatchObject({
+			expect(calls.sapiPostSubAccountTransferSubToMaster).toHaveLength(1);
+			expect(calls.sapiPostSubAccountTransferSubToMaster[0]).toMatchObject({
 				asset: "USDT",
 				amount: "2.5",
 			});
-			expect(result).toMatchObject({ txnId: "transfer-1" });
+			expect(result).toMatchObject({
+				txnId: "sapiPostSubAccountTransferSubToMaster-ok",
+			});
 		});
 
-		test("should throw when SAPI method is unavailable", async () => {
-			const { account } = createMockBrokerAccount(false);
+		test("sub→sub: calls SubToSub endpoint with toEmail", async () => {
+			const { exchange, calls } = createMockExchange([
+				"sapiPostSubAccountTransferSubToSub",
+			]);
+			const result = await transferBinanceInternal(
+				account("secondary:1", exchange),
+				account("secondary:2", exchange, "dest@test.com"),
+				"ETH",
+				1.0,
+			);
+			expect(calls.sapiPostSubAccountTransferSubToSub).toHaveLength(1);
+			expect(calls.sapiPostSubAccountTransferSubToSub[0]).toMatchObject({
+				toEmail: "dest@test.com",
+				asset: "ETH",
+				amount: "1",
+			});
+			expect(result).toMatchObject({
+				txnId: "sapiPostSubAccountTransferSubToSub-ok",
+			});
+		});
 
+		test("primary→secondary: calls UniversalTransfer endpoint", async () => {
+			const { exchange, calls } = createMockExchange([
+				"sapiPostSubAccountUniversalTransfer",
+			]);
+			const result = await transferBinanceInternal(
+				account("primary", exchange),
+				account("secondary:1", exchange, "sub@test.com"),
+				"BTC",
+				0.1,
+			);
+			expect(calls.sapiPostSubAccountUniversalTransfer).toHaveLength(1);
+			expect(calls.sapiPostSubAccountUniversalTransfer[0]).toMatchObject({
+				fromAccountType: "SPOT",
+				toAccountType: "SPOT",
+				toEmail: "sub@test.com",
+				asset: "BTC",
+				amount: "0.1",
+			});
+			expect(result).toMatchObject({
+				txnId: "sapiPostSubAccountUniversalTransfer-ok",
+			});
+		});
+
+		test("sub→sub: throws when dest email is missing", async () => {
+			const { exchange } = createMockExchange([
+				"sapiPostSubAccountTransferSubToSub",
+			]);
 			await expect(
-				transferBinanceSubAccountToMaster(account, "USDT", 1),
-			).rejects.toThrow("Binance sub-account transfer is unavailable");
+				transferBinanceInternal(
+					account("secondary:1", exchange),
+					account("secondary:2", exchange),
+					"USDT",
+					1,
+				),
+			).rejects.toThrow("no email configured (required for sub→sub transfers)");
+		});
+
+		test("primary→secondary: throws when dest email is missing", async () => {
+			const { exchange } = createMockExchange([
+				"sapiPostSubAccountUniversalTransfer",
+			]);
+			await expect(
+				transferBinanceInternal(
+					account("primary", exchange),
+					account("secondary:1", exchange),
+					"USDT",
+					1,
+				),
+			).rejects.toThrow(
+				"no email configured (required for master→sub transfers)",
+			);
+		});
+
+		test("primary→primary: throws unsupported direction", async () => {
+			const { exchange } = createMockExchange([]);
+			await expect(
+				transferBinanceInternal(
+					account("primary", exchange),
+					account("primary", exchange),
+					"USDT",
+					1,
+				),
+			).rejects.toThrow("Unsupported transfer direction: primary → primary");
+		});
+
+		test("sub→master: throws when SAPI method unavailable", async () => {
+			const { exchange } = createMockExchange([]);
+			await expect(
+				transferBinanceInternal(
+					account("secondary:1", exchange),
+					account("primary", exchange),
+					"USDT",
+					1,
+				),
+			).rejects.toThrow("sub→master transfer is unavailable");
+		});
+
+		test("sub→sub: throws when SAPI method unavailable", async () => {
+			const { exchange } = createMockExchange([]);
+			await expect(
+				transferBinanceInternal(
+					account("secondary:1", exchange),
+					account("secondary:2", exchange, "dest@test.com"),
+					"USDT",
+					1,
+				),
+			).rejects.toThrow("sub→sub transfer is unavailable");
+		});
+
+		test("primary→secondary: throws when SAPI method unavailable", async () => {
+			const { exchange } = createMockExchange([]);
+			await expect(
+				transferBinanceInternal(
+					account("primary", exchange),
+					account("secondary:1", exchange, "sub@test.com"),
+					"USDT",
+					1,
+				),
+			).rejects.toThrow("universal transfer is unavailable");
 		});
 	});
 });

--- a/test/internal-transfer-rpc.test.ts
+++ b/test/internal-transfer-rpc.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as grpc from "@grpc/grpc-js";
+import * as protoLoader from "@grpc/proto-loader";
+import type { Exchange } from "@usherlabs/ccxt";
+import type { BrokerPoolEntry } from "../src/helpers/index";
+import { getServer } from "../src/server";
+import type { PolicyConfig } from "../src/types";
+
+const packageDef = protoLoader.loadSync("src/proto/node.proto", {
+	keepCase: true,
+	longs: String,
+	enums: String,
+	defaults: true,
+	oneofs: true,
+});
+const grpcObj = grpc.loadPackageDefinition(packageDef) as {
+	cex_broker: {
+		cex_service: new (
+			address: string,
+			credentials: grpc.ChannelCredentials,
+		) => {
+			ExecuteAction(
+				request: Record<string, unknown>,
+				callback: grpc.requestCallback<{ result: string; proof: string }>,
+			): void;
+			close(): void;
+		};
+	};
+};
+
+const testPolicy: PolicyConfig = {
+	withdraw: { rule: [] },
+	deposit: {},
+	order: { rule: { markets: [], limits: [] } },
+};
+
+function createMockExchange(enabledMethods: string[]) {
+	const calls: Record<string, unknown[]> = {};
+	const exchange: Record<string, unknown> = {
+		loadMarkets: async () => undefined,
+		currency: (code: string) => ({ id: code }),
+		currencyToPrecision: (_code: string, amount: number) => String(amount),
+	};
+	for (const method of enabledMethods) {
+		calls[method] = [];
+		exchange[method] = async (params: Record<string, unknown>) => {
+			calls[method].push(params);
+			return { txnId: `${method}-ok` };
+		};
+	}
+	return { exchange: exchange as Exchange, calls };
+}
+
+function createBinancePool(
+	primaryExchange: Exchange,
+	secondaryExchange: Exchange,
+	destEmail?: string,
+): Record<string, BrokerPoolEntry> {
+	return {
+		binance: {
+			primary: { exchange: primaryExchange, label: "primary" },
+			secondaryBrokers: [
+				{ exchange: secondaryExchange, label: "secondary:1", index: 1 },
+				{
+					exchange: secondaryExchange,
+					label: "secondary:2",
+					index: 2,
+					email: destEmail,
+				},
+			],
+		},
+	};
+}
+
+function bindServer(server: grpc.Server) {
+	return new Promise<number>((resolve, reject) => {
+		server.bindAsync(
+			"127.0.0.1:0",
+			grpc.ServerCredentials.createInsecure(),
+			(error, port) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				server.start();
+				resolve(port);
+			},
+		);
+	});
+}
+
+function executeAction(
+	client: InstanceType<typeof grpcObj.cex_broker.cex_service>,
+	request: Record<string, unknown>,
+) {
+	return new Promise<{ result: string; proof: string }>((resolve, reject) => {
+		client.ExecuteAction(request, (error, response) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve(response as { result: string; proof: string });
+		});
+	});
+}
+
+describe("InternalTransfer RPC", () => {
+	let server: grpc.Server | undefined;
+	let client: InstanceType<typeof grpcObj.cex_broker.cex_service> | undefined;
+
+	afterEach(async () => {
+		client?.close();
+		if (server) {
+			await server.forceShutdown();
+		}
+	});
+
+	test("returns FAILED_PRECONDITION when sub→sub dest email is missing", async () => {
+		const { exchange: primaryExchange } = createMockExchange([]);
+		const { exchange: secondaryExchange } = createMockExchange([
+			"sapiPostSubAccountTransferSubToSub",
+		]);
+		server = getServer(
+			testPolicy,
+			createBinancePool(primaryExchange, secondaryExchange),
+			["*"],
+			false,
+			"",
+		);
+		const port = await bindServer(server);
+		client = new grpcObj.cex_broker.cex_service(
+			`127.0.0.1:${port}`,
+			grpc.credentials.createInsecure(),
+		);
+
+		await expect(
+			executeAction(client, {
+				action: 13,
+				cex: "binance",
+				symbol: "USDT",
+				payload: {
+					amount: "1",
+					fromAccount: "secondary:1",
+					toAccount: "secondary:2",
+				},
+			}),
+		).rejects.toMatchObject({
+			code: grpc.status.FAILED_PRECONDITION,
+			details:
+				"Destination account 'secondary:2' requires an email configured for sub-to-sub transfers",
+		});
+	});
+
+	test("allows default sub→master transfer without a dest email", async () => {
+		const { exchange: primaryExchange } = createMockExchange([]);
+		const { exchange: secondaryExchange, calls } = createMockExchange([
+			"sapiPostSubAccountTransferSubToMaster",
+		]);
+		server = getServer(
+			testPolicy,
+			createBinancePool(primaryExchange, secondaryExchange),
+			["*"],
+			false,
+			"",
+		);
+		const port = await bindServer(server);
+		client = new grpcObj.cex_broker.cex_service(
+			`127.0.0.1:${port}`,
+			grpc.credentials.createInsecure(),
+		);
+
+		const response = await executeAction(client, {
+			action: 13,
+			cex: "binance",
+			symbol: "USDT",
+			payload: {
+				amount: "1.25",
+				fromAccount: "secondary:1",
+			},
+		});
+
+		expect(JSON.parse(response.result)).toMatchObject({
+			txnId: "sapiPostSubAccountTransferSubToMaster-ok",
+		});
+		expect(calls.sapiPostSubAccountTransferSubToMaster).toHaveLength(1);
+		expect(calls.sapiPostSubAccountTransferSubToMaster[0]).toMatchObject({
+			asset: "USDT",
+			amount: "1.25",
+		});
+	});
+});


### PR DESCRIPTION
related to https://linear.app/usherlabs/issue/FIET-723/executewithdrawwithrouting-is-not-idempotent-and-assumes-instant

Add Action.InternalTransfer (value 13) to the proto enum and
wire a new handler in server.ts that resolves source/destination
accounts and calls transferBinanceSubAccountToMaster directly.

Remove executeWithdrawWithRouting and all routing orchestration
from the Withdraw handler — fiet-maker now owns the two-step
saga (internal transfer + withdraw) via durable Restate calls.

- Delete WithdrawRoutingError, WithdrawRoutingUnavailableError
- Delete normalizeAccountSelector, isMasterBrokerAccount,
  isSubaccountBrokerAccount (no remaining callers)
- Strip routeViaMaster/sourceAccount/masterAccount from
  WithdrawPayloadSchema
- Add InternalTransferPayloadSchema (amount, fromAccount,
  toAccount)
- Export transferBinanceSubAccountToMaster from helpers
- Replace routed withdraw tests with InternalTransfer and
  direct transfer function tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added InternalTransfer action for Binance to move funds between primary and subaccounts; some directions now require a destination email.

* **Refactor**
  * Simplified withdraw flow to a single direct execution path and removed routing-related request fields.
  * Enhanced mapping of exchange errors to clearer RPC status codes and messages.

* **Tests**
  * Added unit and RPC tests for internal transfers, payload schemas, and broker-account resolution; removed routing-specific tests.

* **Chores**
  * Updated pre-push hook to ensure formatter/tests run reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->