### PR TITLE
Add broker auth probe for exchange accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,22 @@ bun run ./build/index.js
 ### Probing Exchange Auth
 
 ```bash
-# Probe the primary env-configured Binance account
+# Probe the exact raw credentials used by the Prover via .env
+# .env:
+# CEX_BROKER_PROBE_API_KEY=...
+# CEX_BROKER_PROBE_API_SECRET=...
 bun run src/cli.ts --probeAuth binance
 
-# Probe a sub-account configured as secondary:1
+# Probe a configured sub-account loaded as secondary:1
 bun run src/cli.ts --probeAuth binance --account secondary:1
 ```
 
-The probe uses the same env-configured broker account selection as runtime and prints a JSON result for:
+Probe mode precedence:
+
+- If `CEX_BROKER_PROBE_API_KEY` and `CEX_BROKER_PROBE_API_SECRET` are set, the probe uses those raw credentials and follows the same direct broker construction path as request-scoped auth.
+- Otherwise, the probe falls back to the env-configured broker pool and uses `primary` or `secondary:N` selection.
+
+The probe prints a JSON result for:
 
 - `fetchAccountId` via the exchange adapter
 - `fetchBalance` with `{ type: "spot" }`

--- a/README.md
+++ b/README.md
@@ -136,16 +136,34 @@ bun run build:ts
 bun run ./build/index.js
 ```
 
+### Probing Exchange Auth
+
+```bash
+# Probe the primary env-configured Binance account
+bun run src/cli.ts --probeAuth binance
+
+# Probe a sub-account configured as secondary:1
+bun run src/cli.ts --probeAuth binance --account secondary:1
+```
+
+The probe uses the same env-configured broker account selection as runtime and prints a JSON result for:
+
+- `fetchAccountId` via the exchange adapter
+- `fetchBalance` with `{ type: "spot" }`
+
 ### CLI Options
 
 ```bash
 cex-broker --help
 
 Options:
-  -p, --policy <path>                    Policy JSON file (required)
+  -p, --policy <path>                    Policy JSON file
   --port <number>                        Port number (default: 8086)
   -w, --whitelist <addresses...>         IPv4 address whitelist (space-separated list)
-  -vu, --verityProverUrl <url>           Verity Prover URL for zero-knowledge proofs
+  --whitelistAll                         Allow all IPv4 addresses (development mode)
+  --verityProverUrl <url>                Verity Prover URL for zero-knowledge proofs
+  --probeAuth <exchange>                 Probe auth for an env-configured exchange without starting the server
+  --account <selector>                   Account selector to probe, e.g. "primary" or "secondary:1"
 ```
 
 ### Available Scripts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
+import { config } from "dotenv";
 import { probeAuthCommand } from "./commands/probe-auth";
 import { startBrokerCommand } from "./commands/start-broker";
 
 const program = new Command();
+config();
 
 const isValidIPv4 = (ip: string) =>
 	/^(\d{1,3}\.){3}\d{1,3}$/.test(ip) &&

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,14 +1,19 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
+import { probeAuthCommand } from "./commands/probe-auth";
 import { startBrokerCommand } from "./commands/start-broker";
 
 const program = new Command();
 
+const isValidIPv4 = (ip: string) =>
+	/^(\d{1,3}\.){3}\d{1,3}$/.test(ip) &&
+	ip.split(".").every((part) => Number(part) >= 0 && Number(part) <= 255);
+
 program
 	.name("cex-broker")
-	.description("CLI to start the CEXBroker service")
-	.requiredOption("-p, --policy <path>", "Policy JSON file")
+	.description("CLI for the CEXBroker service")
+	.option("-p, --policy <path>", "Policy JSON file")
 	.option("--port <number>", "Port number (default: 8086)", "8086")
 	.option(
 		"-w, --whitelist <addresses...>",
@@ -16,20 +21,33 @@ program
 	)
 	.option("--whitelistAll", "Allow all IPv4 addresses (development mode)")
 	.option("--verityProverUrl <url>", "Verity Prover Url")
+	.option(
+		"--probeAuth <exchange>",
+		"Probe auth for an env-configured exchange without starting the server",
+	)
+	.option(
+		"--account <selector>",
+		'Account selector to probe, e.g. "primary" or "secondary:1"',
+		"primary",
+	)
 	.action(async (options) => {
 		try {
+			if (options.probeAuth) {
+				await probeAuthCommand(options.probeAuth, options.account);
+				return;
+			}
+
+			if (!options.policy) {
+				console.error("❌ --policy is required unless --probeAuth is used");
+				process.exit(1);
+			}
+
 			const whitelist: string[] = options.whitelistAll
 				? ["*"]
 				: (options.whitelist ?? []);
 
 			// Optional: Validate IPv4 addresses unless wildcard is used
 			if (whitelist.length > 0 && !whitelist.includes("*")) {
-				const isValidIPv4 = (ip: string) =>
-					/^(\d{1,3}\.){3}\d{1,3}$/.test(ip) &&
-					ip
-						.split(".")
-						.every((part) => Number(part) >= 0 && Number(part) <= 255);
-
 				for (const ip of whitelist) {
 					if (!isValidIPv4(ip)) {
 						console.error(`❌ Invalid IPv4 address: ${ip}`);

--- a/src/commands/probe-auth.ts
+++ b/src/commands/probe-auth.ts
@@ -7,12 +7,48 @@ const emptyPolicy: PolicyConfig = {
 	order: { rule: { markets: [], limits: [] } },
 };
 
+export function getProbeCredentialsFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+) {
+	const apiKey = env.CEX_BROKER_PROBE_API_KEY;
+	const apiSecret = env.CEX_BROKER_PROBE_API_SECRET;
+
+	if (!apiKey && !apiSecret) {
+		return null;
+	}
+
+	if (!apiKey || !apiSecret) {
+		throw new Error(
+			"CEX_BROKER_PROBE_API_KEY and CEX_BROKER_PROBE_API_SECRET must both be set for raw probe mode",
+		);
+	}
+
+	return { apiKey, apiSecret };
+}
+
+export async function runProbeAuth(
+	broker: Pick<
+		CEXBroker,
+		"loadEnvConfig" | "probeAuth" | "probeAuthWithCredentials"
+	>,
+	exchange: string,
+	accountSelector: string,
+	env: NodeJS.ProcessEnv = process.env,
+) {
+	const probeCreds = getProbeCredentialsFromEnv(env);
+	if (probeCreds) {
+		return broker.probeAuthWithCredentials(exchange, probeCreds);
+	}
+
+	broker.loadEnvConfig();
+	return broker.probeAuth(exchange, accountSelector);
+}
+
 export async function probeAuthCommand(
 	exchange: string,
 	accountSelector: string,
 ) {
 	const broker = new CEXBroker({}, emptyPolicy);
-	broker.loadEnvConfig();
-	const result = await broker.probeAuth(exchange, accountSelector);
+	const result = await runProbeAuth(broker, exchange, accountSelector);
 	console.log(JSON.stringify(result, null, 2));
 }

--- a/src/commands/probe-auth.ts
+++ b/src/commands/probe-auth.ts
@@ -1,0 +1,18 @@
+import CEXBroker from "../index";
+import type { PolicyConfig } from "../types";
+
+const emptyPolicy: PolicyConfig = {
+	withdraw: { rule: [] },
+	deposit: {},
+	order: { rule: { markets: [], limits: [] } },
+};
+
+export async function probeAuthCommand(
+	exchange: string,
+	accountSelector: string,
+) {
+	const broker = new CEXBroker({}, emptyPolicy);
+	broker.loadEnvConfig();
+	const result = await broker.probeAuth(exchange, accountSelector);
+	console.log(JSON.stringify(result, null, 2));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import * as grpc from "@grpc/grpc-js";
-import ccxt from "@usherlabs/ccxt";
+import ccxt, { type Exchange } from "@usherlabs/ccxt";
 import { unwatchFile, watchFile } from "fs";
 import Joi from "joi";
 import {
 	type BrokerPoolEntry,
+	createBroker,
 	createBrokerPool,
 	loadPolicy,
 	normalizePolicyConfig,
@@ -34,8 +35,9 @@ export type BrokerAuthProbeStep = {
 
 export type BrokerAuthProbeResult = {
 	exchange: string;
-	selector: string;
-	resolvedAccount: string;
+	mode: "configured" | "raw";
+	selector?: string;
+	resolvedAccount?: string;
 	role?: "master" | "subaccount";
 	fetchAccountId: BrokerAuthProbeStep & {
 		accountId?: string;
@@ -231,11 +233,45 @@ export default class CEXBroker {
 			selector,
 		);
 
-		const result: BrokerAuthProbeResult = {
-			exchange: normalizedExchange,
+		return this.runProbeAuthSteps(normalizedExchange, account.exchange, {
+			mode: "configured",
 			selector,
 			resolvedAccount: account.label,
 			role: account.role,
+		});
+	}
+
+	public async probeAuthWithCredentials(
+		exchangeName: string,
+		creds: { apiKey: string; apiSecret: string },
+	): Promise<BrokerAuthProbeResult> {
+		const normalizedExchange = exchangeName.trim().toLowerCase();
+		const exchange = createBroker(normalizedExchange, creds);
+		if (!exchange) {
+			throw new Error(
+				`Failed to create probe broker for "${normalizedExchange}" with provided credentials`,
+			);
+		}
+
+		return this.runProbeAuthSteps(normalizedExchange, exchange, {
+			mode: "raw",
+		});
+	}
+
+	private async runProbeAuthSteps(
+		exchangeName: string,
+		exchange: Exchange,
+		context: Pick<
+			BrokerAuthProbeResult,
+			"mode" | "selector" | "resolvedAccount" | "role"
+		>,
+	): Promise<BrokerAuthProbeResult> {
+		const result: BrokerAuthProbeResult = {
+			exchange: exchangeName,
+			mode: context.mode,
+			selector: context.selector,
+			resolvedAccount: context.resolvedAccount,
+			role: context.role,
 			fetchAccountId: {
 				success: false,
 			},
@@ -245,7 +281,7 @@ export default class CEXBroker {
 		};
 
 		try {
-			const accountId = await account.exchange.fetchAccountId();
+			const accountId = await exchange.fetchAccountId();
 			result.fetchAccountId = {
 				success: true,
 				accountId,
@@ -258,7 +294,7 @@ export default class CEXBroker {
 		}
 
 		try {
-			const balance = await account.exchange.fetchBalance({ type: "spot" });
+			const balance = await exchange.fetchBalance({ type: "spot" });
 			const total = balance.total ?? {};
 			const assetCount = Object.values(total).filter(
 				(value) => value !== undefined && value !== null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 	createBrokerPool,
 	loadPolicy,
 	normalizePolicyConfig,
+	resolveBrokerAccount,
 } from "./helpers";
 import { log } from "./helpers/logger";
 import {
@@ -25,6 +26,24 @@ import {
 } from "./types";
 
 export type { PolicyConfig } from "./types";
+
+export type BrokerAuthProbeStep = {
+	success: boolean;
+	error?: string;
+};
+
+export type BrokerAuthProbeResult = {
+	exchange: string;
+	selector: string;
+	resolvedAccount: string;
+	role?: "master" | "subaccount";
+	fetchAccountId: BrokerAuthProbeStep & {
+		accountId?: string;
+	};
+	fetchBalance: BrokerAuthProbeStep & {
+		assetCount?: number;
+	};
+};
 
 log.info("CCXT Version:", ccxt.version);
 
@@ -181,6 +200,81 @@ export default class CEXBroker {
 
 		// Build pool centrally
 		this.brokers = createBrokerPool(value);
+	}
+
+	public getBrokerAccount(exchangeName: string, selector = "primary") {
+		const normalizedExchange = exchangeName.trim().toLowerCase();
+		const brokerEntry = this.brokers[normalizedExchange];
+		if (!brokerEntry) {
+			throw new Error(`Exchange "${normalizedExchange}" is not configured`);
+		}
+
+		const account = resolveBrokerAccount(brokerEntry, selector);
+		if (!account) {
+			throw new Error(
+				`Account selector "${selector}" is not configured for "${normalizedExchange}"`,
+			);
+		}
+
+		return {
+			exchangeName: normalizedExchange,
+			account,
+		};
+	}
+
+	public async probeAuth(
+		exchangeName: string,
+		selector = "primary",
+	): Promise<BrokerAuthProbeResult> {
+		const { exchangeName: normalizedExchange, account } = this.getBrokerAccount(
+			exchangeName,
+			selector,
+		);
+
+		const result: BrokerAuthProbeResult = {
+			exchange: normalizedExchange,
+			selector,
+			resolvedAccount: account.label,
+			role: account.role,
+			fetchAccountId: {
+				success: false,
+			},
+			fetchBalance: {
+				success: false,
+			},
+		};
+
+		try {
+			const accountId = await account.exchange.fetchAccountId();
+			result.fetchAccountId = {
+				success: true,
+				accountId,
+			};
+		} catch (error) {
+			result.fetchAccountId = {
+				success: false,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+
+		try {
+			const balance = await account.exchange.fetchBalance({ type: "spot" });
+			const total = balance.total ?? {};
+			const assetCount = Object.values(total).filter(
+				(value) => value !== undefined && value !== null,
+			).length;
+			result.fetchBalance = {
+				success: true,
+				assetCount,
+			};
+		} catch (error) {
+			result.fetchBalance = {
+				success: false,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+
+		return result;
 	}
 
 	constructor(

--- a/test/probe-auth.test.ts
+++ b/test/probe-auth.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import {
+	getProbeCredentialsFromEnv,
+	runProbeAuth,
+} from "../src/commands/probe-auth";
 import CEXBroker from "../src/index";
 import type { PolicyConfig } from "../src/types";
 
@@ -39,6 +43,8 @@ describe("probeAuth", () => {
 		const result = await broker.probeAuth("binance");
 
 		expect(result.exchange).toBe("binance");
+		expect(result.mode).toBe("configured");
+		expect(result.selector).toBe("primary");
 		expect(result.resolvedAccount).toBe("primary");
 		expect(result.fetchAccountId).toEqual({
 			success: true,
@@ -83,6 +89,51 @@ describe("probeAuth", () => {
 		expect(result.fetchBalance.error).toContain("balance rejected");
 	});
 
+	test("should return probe results for raw credentials", async () => {
+		const broker = new CEXBroker({}, testPolicy);
+		const fakeExchange = {
+			fetchAccountId: async () => "1218874794",
+			fetchBalance: async () => ({
+				total: {
+					USDT: 1,
+				},
+			}),
+		};
+
+		(
+			broker as unknown as {
+				probeAuthWithCredentials: unknown;
+			}
+		).probeAuthWithCredentials = async (
+			exchange: string,
+			creds: { apiKey: string; apiSecret: string },
+		) => {
+			expect(exchange).toBe("binance");
+			expect(creds).toEqual({
+				apiKey: "probe_key",
+				apiSecret: "probe_secret",
+			});
+			return (
+				broker as unknown as {
+					runProbeAuthSteps: unknown;
+				}
+			).runProbeAuthSteps("binance", fakeExchange, {
+				mode: "raw",
+			});
+		};
+
+		const result = await runProbeAuth(broker, "binance", "secondary:1", {
+			CEX_BROKER_PROBE_API_KEY: "probe_key",
+			CEX_BROKER_PROBE_API_SECRET: "probe_secret",
+		});
+
+		expect(result.mode).toBe("raw");
+		expect(result.selector).toBeUndefined();
+		expect(result.resolvedAccount).toBeUndefined();
+		expect(result.fetchAccountId.success).toBe(true);
+		expect(result.fetchBalance.assetCount).toBe(1);
+	});
+
 	test("should reject missing account selectors", () => {
 		const broker = new CEXBroker({}, testPolicy);
 		(
@@ -101,6 +152,32 @@ describe("probeAuth", () => {
 
 		expect(() => broker.getBrokerAccount("binance", "secondary:1")).toThrow(
 			'Account selector "secondary:1" is not configured for "binance"',
+		);
+	});
+
+	test("should parse probe credentials from env", () => {
+		const result = getProbeCredentialsFromEnv({
+			CEX_BROKER_PROBE_API_KEY: "probe_key",
+			CEX_BROKER_PROBE_API_SECRET: "probe_secret",
+		});
+
+		expect(result).toEqual({
+			apiKey: "probe_key",
+			apiSecret: "probe_secret",
+		});
+	});
+
+	test("should ignore probe mode when env vars are absent", () => {
+		expect(getProbeCredentialsFromEnv({})).toBeNull();
+	});
+
+	test("should reject partial probe env configuration", () => {
+		expect(() =>
+			getProbeCredentialsFromEnv({
+				CEX_BROKER_PROBE_API_KEY: "probe_key",
+			}),
+		).toThrow(
+			"CEX_BROKER_PROBE_API_KEY and CEX_BROKER_PROBE_API_SECRET must both be set for raw probe mode",
 		);
 	});
 });

--- a/test/probe-auth.test.ts
+++ b/test/probe-auth.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import CEXBroker from "../src/index";
+import type { PolicyConfig } from "../src/types";
+
+const testPolicy: PolicyConfig = {
+	withdraw: { rule: [] },
+	deposit: {},
+	order: { rule: { markets: [], limits: [] } },
+};
+
+describe("probeAuth", () => {
+	test("should return probe results for a configured account", async () => {
+		const broker = new CEXBroker({}, testPolicy);
+		const fakeExchange = {
+			fetchAccountId: async () => "15210996",
+			fetchBalance: async () => ({
+				total: {
+					USDT: 10,
+					BTC: 0,
+				},
+			}),
+		};
+
+		(
+			broker as unknown as {
+				brokers: Record<string, unknown>;
+			}
+		).brokers = {
+			binance: {
+				primary: {
+					exchange: fakeExchange,
+					label: "primary",
+					role: "subaccount",
+				},
+				secondaryBrokers: [],
+			},
+		};
+
+		const result = await broker.probeAuth("binance");
+
+		expect(result.exchange).toBe("binance");
+		expect(result.resolvedAccount).toBe("primary");
+		expect(result.fetchAccountId).toEqual({
+			success: true,
+			accountId: "15210996",
+		});
+		expect(result.fetchBalance).toEqual({
+			success: true,
+			assetCount: 2,
+		});
+	});
+
+	test("should capture auth failures without stopping after the first error", async () => {
+		const broker = new CEXBroker({}, testPolicy);
+		const fakeExchange = {
+			fetchAccountId: async () => {
+				throw new Error("binance {-2015}");
+			},
+			fetchBalance: async () => {
+				throw new Error("binance balance rejected");
+			},
+		};
+
+		(
+			broker as unknown as {
+				brokers: Record<string, unknown>;
+			}
+		).brokers = {
+			binance: {
+				primary: {
+					exchange: fakeExchange,
+					label: "primary",
+				},
+				secondaryBrokers: [],
+			},
+		};
+
+		const result = await broker.probeAuth("binance");
+
+		expect(result.fetchAccountId.success).toBe(false);
+		expect(result.fetchAccountId.error).toContain("-2015");
+		expect(result.fetchBalance.success).toBe(false);
+		expect(result.fetchBalance.error).toContain("balance rejected");
+	});
+
+	test("should reject missing account selectors", () => {
+		const broker = new CEXBroker({}, testPolicy);
+		(
+			broker as unknown as {
+				brokers: Record<string, unknown>;
+			}
+		).brokers = {
+			binance: {
+				primary: {
+					exchange: {},
+					label: "primary",
+				},
+				secondaryBrokers: [],
+			},
+		};
+
+		expect(() => broker.getBrokerAccount("binance", "secondary:1")).toThrow(
+			'Account selector "secondary:1" is not configured for "binance"',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add a CLI auth probe for env-configured exchange accounts
- exercise the same broker account selection and CCXT auth path used at runtime
- document probe usage and add targeted test coverage

## Testing
- bun test test/probe-auth.test.ts test/helpers.test.ts test/cex-broker.test.ts
- bunx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI probe mode: --probeAuth <exchange> with --account <selector> (defaults to "primary"); added --whitelistAll; adjusted --policy so it's no longer marked "(required)".

* **Documentation**
  * Added "Probing Exchange Auth" section to the README and updated CLI help text.

* **Tests**
  * Added test coverage for the new authentication probing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->