### PR TITLE
Switch gRPC schema loading from runtime protobuf files to precompiled descriptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ build
 /proto/**
 src/proto/*.ts
 src/proto/**/*.ts
+!src/proto/node.descriptor.ts
 
 src/assets/proto/**

--- a/examples/kraken-orderbook-demo.ts
+++ b/examples/kraken-orderbook-demo.ts
@@ -6,19 +6,17 @@ import path from "path";
 import type { SubscribeResponse__Output } from "../src/proto/cex_broker/SubscribeResponse";
 import { SubscriptionType } from "../src/proto/cex_broker/SubscriptionType";
 import type { ProtoGrpcType } from "../src/proto/node";
+import { PROTO_LOADER_OPTIONS } from "../src/proto-loader-options";
 
 const PROTO_FILE = "../src/proto/node.proto";
 
 console.log("CEX Broker - Kraken Orderbook Demo");
 console.log("━".repeat(55));
 
-const packageDef = protoLoader.loadSync(path.resolve(__dirname, PROTO_FILE), {
-	keepCase: true,
-	longs: String,
-	enums: String,
-	defaults: true,
-	oneofs: true,
-});
+const packageDef = protoLoader.loadSync(
+	path.resolve(__dirname, PROTO_FILE),
+	PROTO_LOADER_OPTIONS,
+);
 
 const proto = grpc.loadPackageDefinition(
 	packageDef,

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -51,9 +51,11 @@ function resolveEnumValue<T extends Record<string, number>>(
 	value: T[keyof T] | keyof T | undefined,
 ): T[keyof T] | undefined {
 	if (typeof value === "number") {
-		return value as T[keyof T];
+		return Object.values(enumValues).includes(value)
+			? (value as T[keyof T])
+			: undefined;
 	}
-	if (typeof value === "string" && value in enumValues) {
+	if (typeof value === "string" && Object.hasOwn(enumValues, value)) {
 		return enumValues[value] as T[keyof T];
 	}
 	return undefined;
@@ -71,7 +73,7 @@ const actionNames = createEnumNameMap(Action);
 const subscriptionTypeNames = createEnumNameMap(SubscriptionType);
 
 export function getActionName(action: unknown): string {
-	if (typeof action === "string" && action in Action) {
+	if (typeof action === "string" && Object.hasOwn(Action, action)) {
 		return action;
 	}
 	return typeof action === "number"
@@ -82,7 +84,7 @@ export function getActionName(action: unknown): string {
 export function getSubscriptionTypeName(subscriptionType: unknown): string {
 	if (
 		typeof subscriptionType === "string" &&
-		subscriptionType in SubscriptionType
+		Object.hasOwn(SubscriptionType, subscriptionType)
 	) {
 		return subscriptionType;
 	}

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -41,8 +41,23 @@ export const SubscriptionType = {
 } as const;
 
 export type Action = (typeof Action)[keyof typeof Action];
+export type ActionName = keyof typeof Action;
 export type SubscriptionType =
 	(typeof SubscriptionType)[keyof typeof SubscriptionType];
+export type SubscriptionTypeName = keyof typeof SubscriptionType;
+
+function resolveEnumValue<T extends Record<string, number>>(
+	enumValues: T,
+	value: T[keyof T] | keyof T | undefined,
+): T[keyof T] | undefined {
+	if (typeof value === "number") {
+		return value as T[keyof T];
+	}
+	if (typeof value === "string" && value in enumValues) {
+		return enumValues[value] as T[keyof T];
+	}
+	return undefined;
+}
 
 function createEnumNameMap<T extends Record<string, number>>(
 	enumValues: T,
@@ -56,21 +71,38 @@ const actionNames = createEnumNameMap(Action);
 const subscriptionTypeNames = createEnumNameMap(SubscriptionType);
 
 export function getActionName(action: unknown): string {
+	if (typeof action === "string" && action in Action) {
+		return action;
+	}
 	return typeof action === "number"
 		? (actionNames[action] ?? `unknown_${action}`)
 		: `unknown_${action ?? "undefined"}`;
 }
 
-export function getSubscriptionTypeName(subscriptionType: number): string {
-	return (
-		subscriptionTypeNames[subscriptionType] ?? `unknown_${subscriptionType}`
-	);
+export function getSubscriptionTypeName(subscriptionType: unknown): string {
+	if (
+		typeof subscriptionType === "string" &&
+		subscriptionType in SubscriptionType
+	) {
+		return subscriptionType;
+	}
+	return typeof subscriptionType === "number"
+		? (subscriptionTypeNames[subscriptionType] ?? `unknown_${subscriptionType}`)
+		: `unknown_${subscriptionType ?? "undefined"}`;
+}
+
+export function resolveAction(
+	action: Action | ActionName | undefined,
+): Action | undefined {
+	return resolveEnumValue(Action, action);
 }
 
 export function resolveSubscriptionType(
-	type: SubscriptionType | undefined,
+	type: SubscriptionType | SubscriptionTypeName | undefined,
 ): SubscriptionType {
-	return type === undefined || type === SubscriptionType.NO_ACTION
+	const resolvedType = resolveEnumValue(SubscriptionType, type);
+	return resolvedType === undefined ||
+		resolvedType === SubscriptionType.NO_ACTION
 		? SubscriptionType.ORDERBOOK
-		: type;
+		: resolvedType;
 }

--- a/src/proto-loader-options.ts
+++ b/src/proto-loader-options.ts
@@ -1,0 +1,9 @@
+import type { Options } from "@grpc/proto-loader";
+
+export const PROTO_LOADER_OPTIONS = {
+	keepCase: true,
+	longs: String,
+	enums: String,
+	defaults: true,
+	oneofs: true,
+} satisfies Options;

--- a/src/proto-package-definition.ts
+++ b/src/proto-package-definition.ts
@@ -1,0 +1,8 @@
+import * as protoLoader from "@grpc/proto-loader";
+import descriptor from "./proto/node.descriptor.ts";
+import { PROTO_LOADER_OPTIONS } from "./proto-loader-options";
+
+export const CEX_BROKER_PACKAGE_DEFINITION = protoLoader.fromJSON(
+	descriptor as unknown as Record<string, unknown>,
+	PROTO_LOADER_OPTIONS,
+);

--- a/src/proto/node.descriptor.ts
+++ b/src/proto/node.descriptor.ts
@@ -1,0 +1,127 @@
+// Auto-generated from src/proto/node.proto. Do not edit manually.
+const descriptor = {
+	nested: {
+		cex_broker: {
+			nested: {
+				ActionRequest: {
+					fields: {
+						action: {
+							type: "Action",
+							id: 1,
+						},
+						payload: {
+							keyType: "string",
+							type: "string",
+							id: 2,
+						},
+						cex: {
+							type: "string",
+							id: 3,
+						},
+						symbol: {
+							type: "string",
+							id: 4,
+						},
+					},
+				},
+				ActionResponse: {
+					fields: {
+						result: {
+							type: "string",
+							id: 1,
+						},
+						proof: {
+							type: "string",
+							id: 2,
+						},
+					},
+				},
+				SubscribeRequest: {
+					fields: {
+						cex: {
+							type: "string",
+							id: 1,
+						},
+						symbol: {
+							type: "string",
+							id: 2,
+						},
+						type: {
+							type: "SubscriptionType",
+							id: 3,
+						},
+						options: {
+							keyType: "string",
+							type: "string",
+							id: 4,
+						},
+					},
+				},
+				SubscribeResponse: {
+					fields: {
+						data: {
+							type: "string",
+							id: 1,
+						},
+						timestamp: {
+							type: "int64",
+							id: 2,
+						},
+						symbol: {
+							type: "string",
+							id: 3,
+						},
+						type: {
+							type: "SubscriptionType",
+							id: 4,
+						},
+					},
+				},
+				SubscriptionType: {
+					values: {
+						NO_ACTION: 0,
+						ORDERBOOK: 1,
+						TRADES: 2,
+						TICKER: 3,
+						OHLCV: 4,
+						BALANCE: 5,
+						ORDERS: 6,
+					},
+				},
+				cex_service: {
+					methods: {
+						ExecuteAction: {
+							requestType: "ActionRequest",
+							responseType: "ActionResponse",
+						},
+						Subscribe: {
+							requestType: "SubscribeRequest",
+							responseType: "SubscribeResponse",
+							responseStream: true,
+						},
+					},
+				},
+				Action: {
+					values: {
+						NoAction: 0,
+						Deposit: 1,
+						Withdraw: 2,
+						CreateOrder: 3,
+						GetOrderDetails: 4,
+						CancelOrder: 5,
+						FetchBalances: 6,
+						FetchDepositAddresses: 7,
+						FetchTicker: 8,
+						FetchCurrency: 9,
+						Call: 10,
+						FetchAccountId: 11,
+						FetchFees: 12,
+						InternalTransfer: 13,
+					},
+				},
+			},
+		},
+	},
+} as const;
+
+export default descriptor;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,6 @@
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import ccxt, { type Exchange } from "@usherlabs/ccxt";
-import path from "path";
-import { fileURLToPath } from "url";
 import type { z } from "zod";
 import {
 	authenticateRequest,
@@ -41,6 +39,7 @@ import {
 	InternalTransferPayloadSchema,
 	WithdrawPayloadSchema,
 } from "./schemas/action-payloads";
+import descriptor from "./proto/node.descriptor.ts";
 import type { PolicyConfig } from "./types";
 
 type ActionRequest = {
@@ -69,16 +68,9 @@ type SubscribeResponse = {
 	type: SubscriptionTypeValue;
 };
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const protoPath = path.join(__dirname, "proto", "node.proto");
-
-const packageDef = protoLoader.loadSync(protoPath, {
-	keepCase: true,
-	longs: String,
-	defaults: true,
-	oneofs: true,
-});
+const packageDef = protoLoader.fromJSON(
+	descriptor as unknown as Record<string, unknown>,
+);
 const grpcObj = grpc.loadPackageDefinition(packageDef) as unknown as {
 	cex_broker: {
 		cex_service: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,4 @@
 import * as grpc from "@grpc/grpc-js";
-import * as protoLoader from "@grpc/proto-loader";
 import ccxt, { type Exchange } from "@usherlabs/ccxt";
 import type { z } from "zod";
 import {
@@ -19,15 +18,19 @@ import {
 } from "./helpers";
 import {
 	Action,
+	type ActionName,
+	type Action as ActionType,
 	getActionName,
 	getSubscriptionTypeName,
-	type Action as ActionType,
+	resolveAction,
 	resolveSubscriptionType,
 	SubscriptionType,
+	type SubscriptionTypeName,
 	type SubscriptionType as SubscriptionTypeValue,
 } from "./helpers/constants";
 import { log } from "./helpers/logger";
 import type { OtelMetrics } from "./helpers/otel";
+import { CEX_BROKER_PACKAGE_DEFINITION } from "./proto-package-definition";
 import {
 	CallPayloadSchema,
 	CancelOrderPayloadSchema,
@@ -39,11 +42,10 @@ import {
 	InternalTransferPayloadSchema,
 	WithdrawPayloadSchema,
 } from "./schemas/action-payloads";
-import descriptor from "./proto/node.descriptor.ts";
 import type { PolicyConfig } from "./types";
 
 type ActionRequest = {
-	action?: ActionType;
+	action?: ActionType | ActionName;
 	payload?: Record<string, string>;
 	cex?: string;
 	symbol?: string;
@@ -57,7 +59,7 @@ type ActionResponse = {
 type SubscribeRequest = {
 	cex?: string;
 	symbol?: string;
-	type?: SubscriptionTypeValue;
+	type?: SubscriptionTypeValue | SubscriptionTypeName;
 	options?: Record<string, string>;
 };
 
@@ -68,10 +70,9 @@ type SubscribeResponse = {
 	type: SubscriptionTypeValue;
 };
 
-const packageDef = protoLoader.fromJSON(
-	descriptor as unknown as Record<string, unknown>,
-);
-const grpcObj = grpc.loadPackageDefinition(packageDef) as unknown as {
+const grpcObj = grpc.loadPackageDefinition(
+	CEX_BROKER_PACKAGE_DEFINITION,
+) as unknown as {
 	cex_broker: {
 		cex_service: {
 			service: grpc.ServiceDefinition<grpc.UntypedServiceImplementation>;
@@ -152,7 +153,8 @@ export function getServer(
 			callback: grpc.sendUnaryData<ActionResponse>,
 		) => {
 			const startTime = Date.now();
-			const { action, cex, symbol } = call.request;
+			const { action: rawAction, cex, symbol } = call.request;
+			const action = resolveAction(rawAction);
 			let actionCompleted = false;
 
 			// Wrap callback to track success/failure

--- a/test/helpers-constants.test.ts
+++ b/test/helpers-constants.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
 	getActionName,
+	getSubscriptionTypeName,
+	resolveAction,
 	resolveSubscriptionType,
 	SubscriptionType,
 } from "../src/helpers/constants";
@@ -19,8 +21,26 @@ describe("Helper Constants", () => {
 		);
 	});
 
+	test("defaults invalid numeric subscription types to ORDERBOOK", () => {
+		expect(resolveSubscriptionType(999 as never)).toBe(
+			SubscriptionType.ORDERBOOK,
+		);
+	});
+
+	test("rejects invalid numeric actions", () => {
+		expect(resolveAction(999 as never)).toBeUndefined();
+	});
+
 	test("returns stable action labels for metrics", () => {
 		expect(getActionName(11)).toBe("FetchAccountId");
 		expect(getActionName(undefined)).toBe("unknown_undefined");
+	});
+
+	test("reports inherited action labels as unknown", () => {
+		expect(getActionName("__proto__")).toBe("unknown___proto__");
+	});
+
+	test("reports inherited subscription type labels as unknown", () => {
+		expect(getSubscriptionTypeName("__proto__")).toBe("unknown___proto__");
 	});
 });

--- a/test/internal-transfer-rpc.test.ts
+++ b/test/internal-transfer-rpc.test.ts
@@ -3,16 +3,14 @@ import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type { Exchange } from "@usherlabs/ccxt";
 import type { BrokerPoolEntry } from "../src/helpers/index";
+import { PROTO_LOADER_OPTIONS } from "../src/proto-loader-options";
 import { getServer } from "../src/server";
 import type { PolicyConfig } from "../src/types";
 
-const packageDef = protoLoader.loadSync("src/proto/node.proto", {
-	keepCase: true,
-	longs: String,
-	enums: String,
-	defaults: true,
-	oneofs: true,
-});
+const packageDef = protoLoader.loadSync(
+	"src/proto/node.proto",
+	PROTO_LOADER_OPTIONS,
+);
 const grpcObj = grpc.loadPackageDefinition(packageDef) as {
 	cex_broker: {
 		cex_service: new (

--- a/test/proto-descriptor.test.ts
+++ b/test/proto-descriptor.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import protobuf from "protobufjs";
+import descriptor from "../src/proto/node.descriptor.ts";
+
+describe("Proto descriptor", () => {
+	test("matches src/proto/node.proto", async () => {
+		const root = await protobuf.load("src/proto/node.proto");
+		expect(root.toJSON()).toEqual(descriptor);
+	});
+});

--- a/test/server-proto-loader-options.test.ts
+++ b/test/server-proto-loader-options.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { CEX_BROKER_PACKAGE_DEFINITION } from "../src/proto-package-definition";
+
+const service = CEX_BROKER_PACKAGE_DEFINITION["cex_broker.cex_service"];
+
+describe("server proto descriptor loading", () => {
+	test("uses the runtime proto-loader options for descriptor deserialization", () => {
+		const actionRequestBuffer = service.ExecuteAction.requestSerialize({
+			action: 13,
+			cex: "binance",
+			symbol: "USDT",
+			payload: { amount: "1" },
+		});
+
+		expect(
+			service.ExecuteAction.requestDeserialize(actionRequestBuffer),
+		).toEqual({
+			action: "InternalTransfer",
+			cex: "binance",
+			symbol: "USDT",
+			payload: { amount: "1" },
+		});
+
+		const subscribeRequestBuffer = service.Subscribe.requestSerialize({
+			cex: "kraken",
+			symbol: "ETH/USDT",
+		});
+
+		expect(
+			service.Subscribe.requestDeserialize(subscribeRequestBuffer),
+		).toEqual({
+			cex: "kraken",
+			symbol: "ETH/USDT",
+			type: "NO_ACTION",
+			options: {},
+		});
+
+		const subscribeResponseBuffer = service.Subscribe.responseSerialize({
+			data: "{}",
+			timestamp: "123",
+			symbol: "ETH/USDT",
+			type: 1,
+		});
+
+		expect(
+			service.Subscribe.responseDeserialize(subscribeResponseBuffer),
+		).toEqual({
+			data: "{}",
+			timestamp: "123",
+			symbol: "ETH/USDT",
+			type: "ORDERBOOK",
+		});
+	});
+});


### PR DESCRIPTION

related to https://linear.app/usherlabs/issue/FIET-812/fix-cex-broker-cjs-bundle-startup-crash-when-loading-protobuf-schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation for protobuf descriptor consistency, runtime serialization/deserialization, and helper behavior (enum/name resolution and invalid inputs).

* **Chores**
  * Adjusted ignore rules to track the generated protobuf descriptor.
  * Centralized proto-loader options and updated examples/tests to use them.
  * Included a precompiled gRPC package definition for stable loading.

* **Refactor**
  * Server now accepts action and subscription type as either names or numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->