### PR TITLE
Standardize read-only CEX accounting on CCXT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+build/
+.git/
+.devcontainer/
+.sandbox/
+coverage/
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ RUN apt-get update -y \
   && apt-get install -y --no-install-recommends ca-certificates curl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN bun install --global @usherlabs/cex-broker@0.2.6
+COPY package.json bun.lock ./
+COPY patches ./patches
+RUN bun install --frozen-lockfile
 
-CMD ["cex-broker"]
+COPY . .
+RUN bun run build
+
+EXPOSE 8086
+
+CMD ["bun", "run", "start-broker", "--policy", "policy/policy.json", "--port", "8086", "--whitelistAll"]

--- a/README.md
+++ b/README.md
@@ -222,12 +222,12 @@ message ActionResponse {
 - `FetchAccountId` (11): Get account identity from the exchange
 - `FetchFees` (12): Get market and token funding fee metadata
 - `InternalTransfer` (13): Transfer funds between configured broker accounts.
-- `FetchAccounting` (14): Read-only Binance accounting data for ETL. Payload:
-  `{ kind, params }`, where `params` is a JSON object string. Supported kinds
-  are `all_orders`, `my_trades`, `withdrawals`, `deposits`,
-  `sub_account_deposits`, `account_snapshot`, `account_info`,
-  `sub_account_assets`, `universal_transfer`, `sub_account_spot_transfer`, and
-  `klines`.
+- `FetchAccounting` (14): Read-only CEX accounting data through CCXT unified
+  methods. Payload: `{ kind, symbol, code, since, limit, timeframe, params }`,
+  where `params` is a JSON object string. Supported canonical kinds are
+  `orders`, `open_orders`, `closed_orders`, `trades`, `deposits`,
+  `withdrawals`, `transfers`, `ledger`, `balances`, and `ohlcv`. Unsupported
+  CCXT exchange capabilities return `UNIMPLEMENTED`.
 
 ### Vault-backed local container
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,29 @@ message ActionResponse {
 - `FetchTicker` (8): Get ticker information
 - `FetchCurrency` (9): Get currency metadata (networks, fees, etc.) for a symbol
 - `Call` (10): Generic method invocation on the underlying broker instance. Provide `functionName`, optional `args` array, and optional `params` object.
+- `FetchAccountId` (11): Get account identity from the exchange
+- `FetchFees` (12): Get market and token funding fee metadata
+- `InternalTransfer` (13): Transfer funds between configured broker accounts.
+- `FetchAccounting` (14): Read-only Binance accounting data for ETL. Payload:
+  `{ kind, params }`, where `params` is a JSON object string. Supported kinds
+  are `all_orders`, `my_trades`, `withdrawals`, `deposits`,
+  `sub_account_deposits`, `account_snapshot`, `account_info`,
+  `sub_account_assets`, `universal_transfer`, `sub_account_spot_transfer`, and
+  `klines`.
+
+### Vault-backed local container
+
+From `~/projects/chain-research`, generate an ignored env file from Vault and
+run this repo as the local CEX gateway:
+
+```bash
+npm run cex-broker:env
+npm run cex-broker:vault
+```
+
+The generated env maps `BINANCE_PRIMARY_READ_*` to the broker primary/master
+Binance account and `BINANCE_MAKER_READ_*` to `CEX_BROKER_BINANCE_*_1` with
+`CEX_BROKER_BINANCE_ROLE_1=subaccount`. Do not commit the generated env file.
 
 **Example Usage:**
 

--- a/src/helpers/accounting.ts
+++ b/src/helpers/accounting.ts
@@ -1,57 +1,138 @@
-import type { Exchange } from "@usherlabs/ccxt";
+import ccxt, { type Exchange } from "@usherlabs/ccxt";
 
 export const ACCOUNTING_KINDS = [
-	"all_orders",
-	"my_trades",
-	"withdrawals",
+	"orders",
+	"open_orders",
+	"closed_orders",
+	"trades",
 	"deposits",
-	"sub_account_deposits",
-	"account_snapshot",
-	"account_info",
-	"sub_account_assets",
-	"universal_transfer",
-	"sub_account_spot_transfer",
-	"klines",
+	"withdrawals",
+	"transfers",
+	"ledger",
+	"balances",
+	"ohlcv",
 ] as const;
 
 export type AccountingKind = (typeof ACCOUNTING_KINDS)[number];
 
-const BINANCE_ACCOUNTING_METHODS: Record<AccountingKind, string> = {
-	all_orders: "privateGetAllOrders",
-	my_trades: "privateGetMyTrades",
-	withdrawals: "sapiGetCapitalWithdrawHistory",
-	deposits: "sapiGetCapitalDepositHisrec",
-	sub_account_deposits: "sapiGetCapitalDepositSubHisrec",
-	account_snapshot: "sapiGetAccountSnapshot",
-	account_info: "privateGetAccount",
-	sub_account_assets: "sapiV4GetSubAccountAssets",
-	universal_transfer: "sapiGetSubAccountUniversalTransfer",
-	sub_account_spot_transfer: "sapiGetSubAccountSubTransferHistory",
-	klines: "publicGetKlines",
+type AccountingMethod =
+	| "fetchOrders"
+	| "fetchOpenOrders"
+	| "fetchClosedOrders"
+	| "fetchMyTrades"
+	| "fetchDeposits"
+	| "fetchWithdrawals"
+	| "fetchTransfers"
+	| "fetchLedger"
+	| "fetchBalance"
+	| "fetchOHLCV";
+
+const ACCOUNTING_METHODS: Record<AccountingKind, AccountingMethod> = {
+	orders: "fetchOrders",
+	open_orders: "fetchOpenOrders",
+	closed_orders: "fetchClosedOrders",
+	trades: "fetchMyTrades",
+	deposits: "fetchDeposits",
+	withdrawals: "fetchWithdrawals",
+	transfers: "fetchTransfers",
+	ledger: "fetchLedger",
+	balances: "fetchBalance",
+	ohlcv: "fetchOHLCV",
 };
 
 export async function fetchAccountingData(args: {
 	cex: string;
 	broker: Exchange;
 	kind: AccountingKind;
+	symbol?: string;
+	code?: string;
+	since?: number;
+	limit?: number;
+	timeframe?: string;
 	params?: Record<string, unknown>;
 }): Promise<unknown> {
-	const cex = args.cex.trim().toLowerCase();
-	if (cex !== "binance") {
-		throw new Error(`Accounting action is not implemented for ${args.cex}`);
-	}
-
-	const methodName = BINANCE_ACCOUNTING_METHODS[args.kind];
+	const methodName = ACCOUNTING_METHODS[args.kind];
+	assertAccountingCapability(args.cex, args.broker, methodName);
 	const method = (args.broker as unknown as Record<string, unknown>)[
 		methodName
 	];
 	if (typeof method !== "function") {
-		throw new Error(`Accounting method unavailable on ${cex}: ${methodName}`);
+		throw new ccxt.NotSupported(
+			`${args.cex} does not expose ${methodName} in this CCXT build`,
+		);
 	}
 
-	return await (
-		method as (params: Record<string, unknown>) => Promise<unknown>
-	).call(args.broker, compactParams(args.params ?? {}));
+	const params = compactParams(args.params ?? {});
+	switch (args.kind) {
+		case "orders":
+		case "open_orders":
+		case "closed_orders":
+		case "trades":
+			return await callAccountingMethod(method, args.broker, [
+				args.symbol,
+				args.since,
+				args.limit,
+				params,
+			]);
+		case "deposits":
+		case "withdrawals":
+		case "transfers":
+		case "ledger":
+			return await callAccountingMethod(method, args.broker, [
+				args.code,
+				args.since,
+				args.limit,
+				params,
+			]);
+		case "balances":
+			return await callAccountingMethod(method, args.broker, [params]);
+		case "ohlcv": {
+			const symbol = requireAccountingString(args.symbol, "symbol", args.kind);
+			return await callAccountingMethod(method, args.broker, [
+				symbol,
+				args.timeframe ?? "1m",
+				args.since,
+				args.limit,
+				params,
+			]);
+		}
+	}
+}
+
+function assertAccountingCapability(
+	cex: string,
+	broker: Exchange,
+	methodName: AccountingMethod,
+): void {
+	const has =
+		(broker as unknown as { has?: Record<string, unknown> }).has ?? {};
+	if (!has[methodName]) {
+		throw new ccxt.NotSupported(
+			`${cex} does not support ${methodName} through CCXT`,
+		);
+	}
+}
+
+async function callAccountingMethod(
+	method: unknown,
+	broker: Exchange,
+	args: unknown[],
+): Promise<unknown> {
+	return await (method as (...args: unknown[]) => Promise<unknown>).apply(
+		broker,
+		args,
+	);
+}
+
+function requireAccountingString(
+	value: string | undefined,
+	field: string,
+	kind: AccountingKind,
+): string {
+	if (value && value.trim().length > 0) {
+		return value;
+	}
+	throw new ccxt.BadRequest(`FetchAccounting ${kind} requires ${field}`);
 }
 
 function compactParams(

--- a/src/helpers/accounting.ts
+++ b/src/helpers/accounting.ts
@@ -1,0 +1,63 @@
+import type { Exchange } from "@usherlabs/ccxt";
+
+export const ACCOUNTING_KINDS = [
+	"all_orders",
+	"my_trades",
+	"withdrawals",
+	"deposits",
+	"sub_account_deposits",
+	"account_snapshot",
+	"account_info",
+	"sub_account_assets",
+	"universal_transfer",
+	"sub_account_spot_transfer",
+	"klines",
+] as const;
+
+export type AccountingKind = (typeof ACCOUNTING_KINDS)[number];
+
+const BINANCE_ACCOUNTING_METHODS: Record<AccountingKind, string> = {
+	all_orders: "privateGetAllOrders",
+	my_trades: "privateGetMyTrades",
+	withdrawals: "sapiGetCapitalWithdrawHistory",
+	deposits: "sapiGetCapitalDepositHisrec",
+	sub_account_deposits: "sapiGetCapitalDepositSubHisrec",
+	account_snapshot: "sapiGetAccountSnapshot",
+	account_info: "privateGetAccount",
+	sub_account_assets: "sapiV4GetSubAccountAssets",
+	universal_transfer: "sapiGetSubAccountUniversalTransfer",
+	sub_account_spot_transfer: "sapiGetSubAccountSubTransferHistory",
+	klines: "publicGetKlines",
+};
+
+export async function fetchAccountingData(args: {
+	cex: string;
+	broker: Exchange;
+	kind: AccountingKind;
+	params?: Record<string, unknown>;
+}): Promise<unknown> {
+	const cex = args.cex.trim().toLowerCase();
+	if (cex !== "binance") {
+		throw new Error(`Accounting action is not implemented for ${args.cex}`);
+	}
+
+	const methodName = BINANCE_ACCOUNTING_METHODS[args.kind];
+	const method = (args.broker as unknown as Record<string, unknown>)[
+		methodName
+	];
+	if (typeof method !== "function") {
+		throw new Error(`Accounting method unavailable on ${cex}: ${methodName}`);
+	}
+
+	return await (
+		method as (params: Record<string, unknown>) => Promise<unknown>
+	).call(args.broker, compactParams(args.params ?? {}));
+}
+
+function compactParams(
+	params: Record<string, unknown>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(params).filter(([, value]) => value !== undefined),
+	);
+}

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -5,10 +5,17 @@ export const CCXT_METHODS_WITH_VERITY = [
 	"fetchDepositAddresses",
 	"fetchDepositAddressesByNetwork",
 	"fetchDeposits",
+	"fetchOrders",
+	"fetchOpenOrders",
+	"fetchClosedOrders",
+	"fetchMyTrades",
 	"withdraw",
 	"fetchFundingHistory",
 	"fetchWithdrawals",
 	"fetchWithdrawal",
+	"fetchTransfers",
+	"fetchLedger",
+	"fetchOHLCV",
 	"fetchAccountId",
 ];
 

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -28,6 +28,7 @@ export const Action = {
 	FetchAccountId: 11,
 	FetchFees: 12,
 	InternalTransfer: 13,
+	FetchAccounting: 14,
 } as const;
 
 export const SubscriptionType = {

--- a/src/proto/node.descriptor.ts
+++ b/src/proto/node.descriptor.ts
@@ -117,6 +117,7 @@ const descriptor = {
 						FetchAccountId: 11,
 						FetchFees: 12,
 						InternalTransfer: 13,
+						FetchAccounting: 14,
 					},
 				},
 			},

--- a/src/proto/node.proto
+++ b/src/proto/node.proto
@@ -58,4 +58,5 @@ enum Action {
   FetchAccountId=11;
   FetchFees= 12;
   InternalTransfer= 13;
+  FetchAccounting=14;
 }

--- a/src/schemas/action-payloads.ts
+++ b/src/schemas/action-payloads.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ACCOUNTING_KINDS } from "../helpers/accounting";
 
 const parseJsonString = (value: unknown): unknown => {
 	if (typeof value !== "string") {
@@ -91,19 +92,12 @@ export const FetchFeesPayloadSchema = z.object({
 });
 
 export const AccountingPayloadSchema = z.object({
-	kind: z.enum([
-		"all_orders",
-		"my_trades",
-		"withdrawals",
-		"deposits",
-		"sub_account_deposits",
-		"account_snapshot",
-		"account_info",
-		"sub_account_assets",
-		"universal_transfer",
-		"sub_account_spot_transfer",
-		"klines",
-	]),
+	kind: z.enum(ACCOUNTING_KINDS),
+	symbol: z.string().min(1).optional(),
+	code: z.string().min(1).optional(),
+	since: z.coerce.number().int().nonnegative().optional(),
+	limit: z.coerce.number().int().positive().optional(),
+	timeframe: z.string().min(1).optional(),
 	params: z
 		.preprocess(parseJsonString, z.record(z.string(), z.unknown()))
 		.default({}),

--- a/src/schemas/action-payloads.ts
+++ b/src/schemas/action-payloads.ts
@@ -90,6 +90,25 @@ export const FetchFeesPayloadSchema = z.object({
 	includeFundingFees: booleanLikeSchema.optional(),
 });
 
+export const AccountingPayloadSchema = z.object({
+	kind: z.enum([
+		"all_orders",
+		"my_trades",
+		"withdrawals",
+		"deposits",
+		"sub_account_deposits",
+		"account_snapshot",
+		"account_info",
+		"sub_account_assets",
+		"universal_transfer",
+		"sub_account_spot_transfer",
+		"klines",
+	]),
+	params: z
+		.preprocess(parseJsonString, z.record(z.string(), z.unknown()))
+		.default({}),
+});
+
 export type DepositPayload = z.infer<typeof DepositPayloadSchema>;
 export type CallPayload = z.infer<typeof CallPayloadSchema>;
 export type FetchDepositAddressesPayload = z.infer<
@@ -105,3 +124,4 @@ export type GetOrderDetailsPayload = z.infer<
 >;
 export type CancelOrderPayload = z.infer<typeof CancelOrderPayloadSchema>;
 export type FetchFeesPayload = z.infer<typeof FetchFeesPayloadSchema>;
+export type AccountingPayload = z.infer<typeof AccountingPayloadSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -614,13 +614,15 @@ export function getServer(
 						const accountingValue = parsedPayload.data;
 						try {
 							const params = { ...(accountingValue.params ?? {}) };
-							if (symbol && params.symbol === undefined) {
-								params.symbol = symbol;
-							}
 							const result = await fetchAccountingData({
 								cex,
 								broker,
 								kind: accountingValue.kind,
+								symbol: accountingValue.symbol ?? symbol,
+								code: accountingValue.code,
+								since: accountingValue.since,
+								limit: accountingValue.limit,
+								timeframe: accountingValue.timeframe,
 								params,
 							});
 							wrappedCallback(null, {
@@ -632,7 +634,7 @@ export function getServer(
 							const message = getErrorMessage(error);
 							wrappedCallback(
 								{
-									code: grpc.status.INTERNAL,
+									code: mapCcxtErrorToGrpcStatus(error) ?? grpc.status.INTERNAL,
 									message: `FetchAccounting failed: ${message}`,
 								},
 								null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import {
 	validateWithdraw,
 	verityHttpClientOverridePredicate,
 } from "./helpers";
+import { fetchAccountingData } from "./helpers/accounting";
 import {
 	Action,
 	type ActionName,
@@ -42,6 +43,7 @@ import {
 	CancelOrderPayloadSchema,
 	CreateOrderPayloadSchema,
 	DepositPayloadSchema,
+	AccountingPayloadSchema,
 	FetchDepositAddressesPayloadSchema,
 	FetchFeesPayloadSchema,
 	GetOrderDetailsPayloadSchema,
@@ -588,6 +590,50 @@ export function getServer(
 								{
 									code: grpc.status.INTERNAL,
 									message: `Error fetching fees from ${cex}`,
+								},
+								null,
+							);
+						}
+						break;
+					}
+
+					case Action.FetchAccounting: {
+						const parsedPayload = parsePayload(
+							AccountingPayloadSchema,
+							call.request.payload,
+						);
+						if (!parsedPayload.success) {
+							return wrappedCallback(
+								{
+									code: grpc.status.INVALID_ARGUMENT,
+									message: parsedPayload.message,
+								},
+								null,
+							);
+						}
+						const accountingValue = parsedPayload.data;
+						try {
+							const params = { ...(accountingValue.params ?? {}) };
+							if (symbol && params.symbol === undefined) {
+								params.symbol = symbol;
+							}
+							const result = await fetchAccountingData({
+								cex,
+								broker,
+								kind: accountingValue.kind,
+								params,
+							});
+							wrappedCallback(null, {
+								proof: verityProof,
+								result: JSON.stringify(result),
+							});
+						} catch (error) {
+							safeLogError("FetchAccounting failed", error);
+							const message = getErrorMessage(error);
+							wrappedCallback(
+								{
+									code: grpc.status.INTERNAL,
+									message: `FetchAccounting failed: ${message}`,
 								},
 								null,
 							);

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1146,41 +1146,73 @@ describe("Helper Functions", () => {
 	});
 
 	describe("accounting reads", () => {
-		test("should route allowed Binance accounting kinds to raw read methods", async () => {
+		test("should route canonical accounting kinds to CCXT unified methods", async () => {
 			const calls: Array<{ method: string; params: Record<string, unknown> }> =
 				[];
 			const broker = {
-				privateGetAllOrders: async (params: Record<string, unknown>) => {
-					calls.push({ method: "privateGetAllOrders", params });
+				has: { fetchMyTrades: true },
+				fetchMyTrades: async (
+					symbol: string | undefined,
+					since: number | undefined,
+					limit: number | undefined,
+					params: Record<string, unknown>,
+				) => {
+					calls.push({
+						method: "fetchMyTrades",
+						params: { symbol, since, limit, ...params },
+					});
 					return [{ orderId: 1 }];
 				},
 			} as unknown as Exchange;
 
 			const result = await fetchAccountingData({
-				cex: "binance",
+				cex: "bybit",
 				broker,
-				kind: "all_orders",
-				params: { symbol: "ARBUSDT", startTime: 1, endTime: 2 },
+				kind: "trades",
+				symbol: "ARB/USDT",
+				since: 1,
+				limit: 100,
+				params: { type: "spot", endTime: 2 },
 			});
 
 			expect(result).toEqual([{ orderId: 1 }]);
 			expect(calls).toEqual([
 				{
-					method: "privateGetAllOrders",
-					params: { symbol: "ARBUSDT", startTime: 1, endTime: 2 },
+					method: "fetchMyTrades",
+					params: {
+						symbol: "ARB/USDT",
+						since: 1,
+						limit: 100,
+						type: "spot",
+						endTime: 2,
+					},
 				},
 			]);
 		});
 
-		test("should reject accounting reads for unsupported exchanges", async () => {
+		test("should reject accounting reads when CCXT capability is unavailable", async () => {
 			await expect(
 				fetchAccountingData({
-					cex: "kraken",
-					broker: {} as Exchange,
+					cex: "bitfinex",
+					broker: { has: { fetchDeposits: false } } as unknown as Exchange,
 					kind: "deposits",
 					params: {},
 				}),
-			).rejects.toThrow("Accounting action is not implemented for kraken");
+			).rejects.toThrow("bitfinex does not support fetchDeposits through CCXT");
+		});
+
+		test("should require symbol for OHLCV accounting reads", async () => {
+			await expect(
+				fetchAccountingData({
+					cex: "mexc",
+					broker: {
+						has: { fetchOHLCV: true },
+						fetchOHLCV: async () => [],
+					} as unknown as Exchange,
+					kind: "ohlcv",
+					params: {},
+				}),
+			).rejects.toThrow("FetchAccounting ohlcv requires symbol");
 		});
 	});
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -16,6 +16,7 @@ import {
 	validateOrder,
 	validateWithdraw,
 } from "../src/helpers/index";
+import { fetchAccountingData } from "../src/helpers/accounting";
 import {
 	InternalTransferPayloadSchema,
 	WithdrawPayloadSchema,
@@ -1141,6 +1142,45 @@ describe("Helper Functions", () => {
 					1,
 				),
 			).rejects.toThrow("universal transfer is unavailable");
+		});
+	});
+
+	describe("accounting reads", () => {
+		test("should route allowed Binance accounting kinds to raw read methods", async () => {
+			const calls: Array<{ method: string; params: Record<string, unknown> }> =
+				[];
+			const broker = {
+				privateGetAllOrders: async (params: Record<string, unknown>) => {
+					calls.push({ method: "privateGetAllOrders", params });
+					return [{ orderId: 1 }];
+				},
+			} as unknown as Exchange;
+
+			const result = await fetchAccountingData({
+				cex: "binance",
+				broker,
+				kind: "all_orders",
+				params: { symbol: "ARBUSDT", startTime: 1, endTime: 2 },
+			});
+
+			expect(result).toEqual([{ orderId: 1 }]);
+			expect(calls).toEqual([
+				{
+					method: "privateGetAllOrders",
+					params: { symbol: "ARBUSDT", startTime: 1, endTime: 2 },
+				},
+			]);
+		});
+
+		test("should reject accounting reads for unsupported exchanges", async () => {
+			await expect(
+				fetchAccountingData({
+					cex: "kraken",
+					broker: {} as Exchange,
+					kind: "deposits",
+					params: {},
+				}),
+			).rejects.toThrow("Accounting action is not implemented for kraken");
 		});
 	});
 });


### PR DESCRIPTION
Summary:
- Standardize `FetchAccounting` action 14 around CCXT unified methods instead of Binance raw endpoint names.
- Add canonical accounting kinds for orders, trades, deposits, withdrawals, transfers, ledger, balances, and OHLCV with typed top-level payload fields.
- Return CCXT capability errors as `UNIMPLEMENTED` so unsupported exchange/accounting combinations are explicit.
- Extend Verity method allow-list and tests for the new accounting method routing.

Tests:
- `bun run build:ts`
- `bun test`