### PR TITLE
Handle gRPC stream backpressure in subscribe handler and add Binance user-data stream buffering limits

### DIFF
--- a/src/handlers/subscribe/handler.ts
+++ b/src/handlers/subscribe/handler.ts
@@ -56,25 +56,64 @@ function isBinanceSpotAccountSubscription(
 	);
 }
 
-function writeSubscribeFrame(
+function waitForSubscribeDrain(
+	call: SubscribeCall,
+	isClosed: () => boolean,
+): Promise<boolean> {
+	if (isClosed() || call.destroyed) {
+		return Promise.resolve(false);
+	}
+
+	return new Promise((resolve) => {
+		let settled = false;
+		const cleanup = () => {
+			call.off("drain", onDrain);
+			call.off("close", onClosed);
+			call.off("cancelled", onClosed);
+			call.off("end", onClosed);
+			call.off("error", onClosed);
+		};
+		const settle = (drained: boolean) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			cleanup();
+			resolve(drained && !isClosed() && !call.destroyed);
+		};
+		const onDrain = () => settle(true);
+		const onClosed = () => settle(false);
+
+		call.once("drain", onDrain);
+		call.once("close", onClosed);
+		call.once("cancelled", onClosed);
+		call.once("end", onClosed);
+		call.once("error", onClosed);
+	});
+}
+
+async function writeSubscribeFrame(
 	call: SubscribeCall,
 	isClosed: () => boolean,
 	frame: SubscribeResponse,
-): boolean {
+): Promise<boolean> {
 	if (isClosed() || call.destroyed) {
 		return false;
 	}
-	call.write(frame);
-	return true;
+	const canContinue = call.write(frame);
+	if (canContinue) {
+		return true;
+	}
+	return waitForSubscribeDrain(call, isClosed);
 }
 
-function writeSubscribeError(
+async function writeSubscribeError(
 	call: SubscribeCall,
 	isClosed: () => boolean,
 	frame: SubscribeResponse,
-): void {
-	writeSubscribeFrame(call, isClosed, frame);
-	if (!isClosed() && !call.destroyed) {
+): Promise<void> {
+	const frameWritten = await writeSubscribeFrame(call, isClosed, frame);
+	if (frameWritten && !isClosed() && !call.destroyed) {
 		call.end();
 	}
 }
@@ -145,7 +184,7 @@ async function streamBinanceUserData(
 			}
 
 			if (
-				!writeSubscribeFrame(call, isClosed, {
+				!(await writeSubscribeFrame(call, isClosed, {
 					data: JSON.stringify({
 						subscriptionId: message.subscriptionId,
 						event,
@@ -153,7 +192,7 @@ async function streamBinanceUserData(
 					timestamp: Date.now(),
 					symbol,
 					type: subscriptionType,
-				})
+				}))
 			) {
 				break;
 			}
@@ -173,12 +212,12 @@ async function runCcxtSubscribeLoop(
 	while (!isClosed()) {
 		const data = await watch();
 		if (
-			!writeSubscribeFrame(call, isClosed, {
+			!(await writeSubscribeFrame(call, isClosed, {
 				data: JSON.stringify(data),
 				timestamp: Date.now(),
 				symbol,
 				type: subscriptionType,
-			})
+			}))
 		) {
 			break;
 		}
@@ -255,7 +294,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 			});
 
 			if (!cex || !symbol) {
-				writeSubscribeError(call, isStreamClosed, {
+				await writeSubscribeError(call, isStreamClosed, {
 					data: JSON.stringify({
 						error: "cex, symbol, and type are required",
 					}),
@@ -275,7 +314,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 			const broker = selectedBroker ?? createPublicBroker(normalizedCex);
 
 			if (!broker) {
-				writeSubscribeError(call, isStreamClosed, {
+				await writeSubscribeError(call, isStreamClosed, {
 					data: JSON.stringify({
 						error: "Exchange not registered and no API metadata found",
 					}),
@@ -300,7 +339,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 				)
 			) {
 				if (!selectedBroker) {
-					writeSubscribeError(call, isStreamClosed, {
+					await writeSubscribeError(call, isStreamClosed, {
 						data: JSON.stringify({
 							error: "Binance account subscriptions require API credentials",
 						}),
@@ -333,7 +372,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 									: await broker.watchOrderBook(resolvedSymbol, depthLimit);
 							const receivedTimestamp = Date.now();
 							if (
-								!writeSubscribeFrame(call, isStreamClosed, {
+								!(await writeSubscribeFrame(call, isStreamClosed, {
 									data: JSON.stringify(
 										normalizeOrderBookSnapshot(orderbook, {
 											exchange: normalizedCex,
@@ -354,7 +393,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 									timestamp: receivedTimestamp,
 									symbol: resolvedSymbol,
 									type: subscriptionType,
-								})
+								}))
 							) {
 								break;
 							}
@@ -365,7 +404,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 							error,
 						);
 						const message = getErrorMessage(error);
-						writeSubscribeError(call, isStreamClosed, {
+						await writeSubscribeError(call, isStreamClosed, {
 							data: JSON.stringify({
 								error: `Failed to fetch orderbook: ${message}`,
 							}),
@@ -391,7 +430,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 							`Error fetching trades for ${resolvedSymbol} on ${cex}:`,
 							error,
 						);
-						writeSubscribeError(call, isStreamClosed, {
+						await writeSubscribeError(call, isStreamClosed, {
 							data: JSON.stringify({
 								error: `Failed to fetch trades: ${message}`,
 							}),
@@ -417,7 +456,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 							`Error fetching ticker for ${resolvedSymbol} on ${cex}:`,
 							error,
 						);
-						writeSubscribeError(call, isStreamClosed, {
+						await writeSubscribeError(call, isStreamClosed, {
 							data: JSON.stringify({
 								error: `Failed to fetch ticker: ${message}`,
 							}),
@@ -444,7 +483,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 							error,
 						);
 						const message = getErrorMessage(error);
-						writeSubscribeError(call, isStreamClosed, {
+						await writeSubscribeError(call, isStreamClosed, {
 							data: JSON.stringify({
 								error: `Failed to fetch OHLCV: ${message}`,
 							}),
@@ -467,7 +506,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 					} catch (error: unknown) {
 						const message = getErrorMessage(error);
 						log.error(`Error fetching balance for ${cex}:`, error);
-						writeSubscribeError(call, isStreamClosed, {
+						await writeSubscribeError(call, isStreamClosed, {
 							data: JSON.stringify({
 								error: `Failed to fetch balance: ${message}`,
 							}),
@@ -493,7 +532,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 							error,
 						);
 						const message = getErrorMessage(error);
-						writeSubscribeError(call, isStreamClosed, {
+						await writeSubscribeError(call, isStreamClosed, {
 							data: JSON.stringify({
 								error: `Failed to fetch orders: ${message}`,
 							}),
@@ -505,7 +544,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 					break;
 
 				default:
-					writeSubscribeError(call, isStreamClosed, {
+					await writeSubscribeError(call, isStreamClosed, {
 						data: JSON.stringify({ error: "Invalid subscription type" }),
 						timestamp: Date.now(),
 						symbol,
@@ -515,7 +554,7 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 		} catch (error) {
 			log.error("Error in Subscribe stream:", error);
 			const message = getErrorMessage(error);
-			writeSubscribeError(call, isStreamClosed, {
+			await writeSubscribeError(call, isStreamClosed, {
 				data: JSON.stringify({ error: `Internal server error: ${message}` }),
 				timestamp: Date.now(),
 				symbol: "",

--- a/src/helpers/binance-user-data-stream.ts
+++ b/src/helpers/binance-user-data-stream.ts
@@ -4,6 +4,7 @@ import type { Exchange } from "@usherlabs/ccxt";
 import WebSocket from "ws";
 
 export const BINANCE_SPOT_WS_API_URL = "wss://ws-api.binance.com:443/ws-api/v3";
+export const DEFAULT_BINANCE_USER_DATA_MAX_BUFFERED_EVENTS = 16;
 
 export type BinanceUserDataEvent = {
 	subscriptionId: number;
@@ -35,6 +36,10 @@ type WebSocketLike = {
 };
 
 type WebSocketFactory = (url: string) => WebSocketLike;
+
+type BinanceSpotUserDataStreamOptions = {
+	maxBufferedEvents?: number;
+};
 
 let createWebSocket: WebSocketFactory = (url) =>
 	new WebSocket(url) as WebSocketLike;
@@ -230,6 +235,7 @@ export class BinanceSpotUserDataStream
 	private readonly ws: WebSocketLike;
 	private readonly secretValues: string[];
 	private readonly requestId = `user-data-${Date.now()}-${Math.random()}`;
+	private readonly maxBufferedEvents: number;
 	private readonly queue: BinanceUserDataEvent[] = [];
 	private readonly waiters: Array<{
 		resolve: (event: BinanceUserDataEvent | null) => void;
@@ -239,7 +245,13 @@ export class BinanceSpotUserDataStream
 	private closeError: Error | null = null;
 	private subscriptionId: number | null = null;
 
-	constructor(private readonly exchange: Exchange) {
+	constructor(
+		private readonly exchange: Exchange,
+		options: BinanceSpotUserDataStreamOptions = {},
+	) {
+		this.maxBufferedEvents =
+			options.maxBufferedEvents ??
+			DEFAULT_BINANCE_USER_DATA_MAX_BUFFERED_EVENTS;
 		this.secretValues = [
 			getOptionalExchangeString(exchange, "apiKey"),
 			getOptionalExchangeString(exchange, "secret"),
@@ -268,6 +280,7 @@ export class BinanceSpotUserDataStream
 			return;
 		}
 		this.closed = true;
+		this.queue.length = 0;
 		try {
 			this.ws.close();
 		} catch {
@@ -301,6 +314,10 @@ export class BinanceSpotUserDataStream
 	}
 
 	private handleMessage(data: unknown): void {
+		if (this.closed) {
+			return;
+		}
+
 		let message: BinanceUserDataMessage;
 		try {
 			const decodedData = decodeMessageData(data);
@@ -343,9 +360,21 @@ export class BinanceSpotUserDataStream
 	}
 
 	private push(event: BinanceUserDataEvent): void {
+		if (this.closed) {
+			return;
+		}
+
 		const waiter = this.waiters.shift();
 		if (waiter) {
 			waiter.resolve(event);
+			return;
+		}
+		if (this.queue.length >= this.maxBufferedEvents) {
+			this.fail(
+				new Error(
+					`Binance user-data stream buffered event limit exceeded (${this.maxBufferedEvents}); downstream consumer is not keeping up`,
+				),
+			);
 			return;
 		}
 		this.queue.push(event);
@@ -373,6 +402,7 @@ export class BinanceSpotUserDataStream
 		}
 		this.closeError = error;
 		this.closed = true;
+		this.queue.length = 0;
 		this.flushWaiters();
 		try {
 			this.ws.close();

--- a/test/subscribe-handler.test.ts
+++ b/test/subscribe-handler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
 import { createSubscribeHandler } from "../src/handlers/subscribe/handler";
@@ -15,34 +16,133 @@ import {
 type MockCallState = {
 	writes: SubscribeResponse[];
 	endCount: number;
+	destroyed: boolean;
 };
 
-function createSubscribeCall(request: SubscribeRequest) {
+function createSubscribeCall(
+	request: SubscribeRequest,
+	options: { writeResults?: boolean[] } = {},
+) {
+	const emitter = new EventEmitter();
 	const state: MockCallState = {
 		writes: [],
 		endCount: 0,
+		destroyed: false,
 	};
-	const call = {
+	const writeResults = [...(options.writeResults ?? [])];
+	const call = Object.assign(emitter, {
 		metadata: new grpc.Metadata(),
 		request,
 		getPeer: () => "127.0.0.1:1234",
 		write: (response: SubscribeResponse) => {
 			state.writes.push(response);
-			return true;
+			return writeResults.shift() ?? true;
 		},
 		end: () => {
 			state.endCount += 1;
+			emitter.emit("end");
 		},
-		on: () => call,
-		once: () => call,
-		emit: () => true,
-		destroy: () => undefined,
-	} as unknown as grpc.ServerWritableStream<
-		SubscribeRequest,
-		SubscribeResponse
-	>;
+		destroy: (error?: Error) => {
+			state.destroyed = true;
+			if (error) {
+				emitter.emit("error", error);
+			}
+			emitter.emit("close");
+		},
+	});
+	Object.defineProperty(call, "destroyed", {
+		get: () => state.destroyed,
+	});
 
-	return { call, state };
+	return {
+		call: call as unknown as grpc.ServerWritableStream<
+			SubscribeRequest,
+			SubscribeResponse
+		>,
+		state,
+	};
+}
+
+function nextTick(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		if (condition()) {
+			return;
+		}
+		await nextTick();
+	}
+	throw new Error("Timed out waiting for test condition");
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+	return { promise, resolve };
+}
+
+function createControlledWatch() {
+	const calls: unknown[][] = [];
+	const resolvers: Array<(value: unknown) => void> = [];
+	return {
+		calls,
+		resolvers,
+		watch: (...args: unknown[]) => {
+			const deferred = createDeferred<unknown>();
+			calls.push(args);
+			resolvers.push(deferred.resolve);
+			return deferred.promise;
+		},
+	};
+}
+
+async function expectBackpressureWaitsForDrain({
+	type,
+	method,
+	firstValue,
+	secondValue,
+}: {
+	type: SubscriptionTypeValue;
+	method: "watchOrderBook" | "watchTrades";
+	firstValue: unknown;
+	secondValue: unknown;
+}) {
+	const controlledWatch = createControlledWatch();
+	const exchange = {
+		[method]: controlledWatch.watch,
+	} as unknown as Exchange;
+	const { call, state } = createSubscribeCall(
+		{
+			cex: "binance",
+			symbol: "BTC/USDT",
+			type,
+		},
+		{ writeResults: [false] },
+	);
+	const handler = createSubscribeHandler({
+		brokers: createPool(exchange),
+		whitelistIps: ["*"],
+	});
+
+	const handlerPromise = handler(call);
+	await waitFor(() => controlledWatch.calls.length === 1);
+	controlledWatch.resolvers[0]?.(firstValue);
+	await waitFor(() => state.writes.length === 1);
+
+	await nextTick();
+	expect(controlledWatch.calls).toHaveLength(1);
+
+	call.emit("drain");
+	await waitFor(() => controlledWatch.calls.length === 2);
+	call.emit("close");
+	controlledWatch.resolvers[1]?.(secondValue);
+	await handlerPromise;
+
+	expect(state.writes).toHaveLength(1);
 }
 
 function createPool(
@@ -77,6 +177,38 @@ function createThrowingExchange(
 }
 
 describe("subscribe handler", () => {
+	test.each([
+		{
+			type: SubscriptionType.TRADES,
+			method: "watchTrades",
+			firstValue: [{ id: "trade-1" }],
+			secondValue: [{ id: "trade-2" }],
+		},
+		{
+			type: SubscriptionType.ORDERBOOK,
+			method: "watchOrderBook",
+			firstValue: { bids: [[1, 2]], asks: [[3, 4]] },
+			secondValue: { bids: [[5, 6]], asks: [[7, 8]] },
+		},
+	] satisfies Array<{
+		type: SubscriptionTypeValue;
+		method: "watchOrderBook" | "watchTrades";
+		firstValue: unknown;
+		secondValue: unknown;
+	}>)("waits for drain before consuming another $method event after write backpressure", async ({
+		type,
+		method,
+		firstValue,
+		secondValue,
+	}) => {
+		await expectBackpressureWaitsForDrain({
+			type,
+			method,
+			firstValue,
+			secondValue,
+		});
+	});
+
 	test.each([
 		{
 			type: SubscriptionType.ORDERBOOK,

--- a/test/subscribe-user-stream.test.ts
+++ b/test/subscribe-user-stream.test.ts
@@ -3,7 +3,10 @@ import { Buffer } from "node:buffer";
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type { Exchange } from "@usherlabs/ccxt";
-import { setBinanceUserDataWebSocketFactoryForTests } from "../src/helpers/binance-user-data-stream";
+import {
+	BinanceSpotUserDataStream,
+	setBinanceUserDataWebSocketFactoryForTests,
+} from "../src/helpers/binance-user-data-stream";
 import type { BrokerPoolEntry } from "../src/helpers/broker";
 import { SubscriptionType } from "../src/helpers/constants";
 import { PROTO_LOADER_OPTIONS } from "../src/proto-loader-options";
@@ -272,6 +275,43 @@ describe("Binance Subscribe user-data streams", () => {
 		);
 		return client;
 	}
+
+	test("closes Binance user-data stream when unread WebSocket events exceed the bounded buffer", async () => {
+		const primary = createBinanceExchange("primary-key", "primary-secret");
+		const stream = new BinanceSpotUserDataStream(primary.exchange, {
+			maxBufferedEvents: 1,
+		});
+
+		try {
+			const iterator = stream[Symbol.asyncIterator]();
+			const socket = await waitForSocket();
+			socket.emitEvent({
+				e: "outboundAccountPosition",
+				E: 1,
+				B: [{ a: "BTC", f: "1.0", l: "0.0" }],
+			});
+			socket.emitEvent({
+				e: "outboundAccountPosition",
+				E: 2,
+				B: [{ a: "ETH", f: "2.0", l: "0.0" }],
+			});
+
+			let error: unknown;
+			try {
+				await iterator.next();
+			} catch (caught) {
+				error = caught;
+			}
+
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toContain(
+				"Binance user-data stream buffered event limit exceeded (1)",
+			);
+			expect(socket.closed).toBe(true);
+		} finally {
+			stream.close();
+		}
+	});
 
 	test("streams Binance BALANCE frames through WebSocket API user-data subscription", async () => {
 		expect(globalThis.WebSocket).toBeUndefined();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `maxBufferedEvents` configuration option for Binance user-data streams to control backpressure buffering behavior.

* **Bug Fixes**
  * Enhanced gRPC stream backpressure handling to improve stability during high-frequency data streams and prevent data loss when streams cannot keep up with incoming events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->