### PR TITLE
feat(withdraw): Binance travel-rule (localentity) withdrawal support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.14",
+	"version": "0.2.15",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",

--- a/policy/policy.example.json
+++ b/policy/policy.example.json
@@ -44,5 +44,23 @@
 				{ "from": "USDT", "to": "ARB", "min": 1, "max": 10000 }
 			]
 		}
+	},
+	"travelRule": {
+		"rule": [
+			{
+				"exchange": "BINANCE",
+				"enabled": true,
+				"description": "Enable for jurisdictions that require travel-rule metadata on Binance withdrawals (e.g. Australia/AUSTRAC), where the standard withdraw endpoint returns error -4104. Each address needs a questionnaire; self-owned destinations use isAddressOwner=1, sendTo=1, declaration=true.",
+				"addresses": {
+					"0x9d467fa9062b6e9b1a46e26007ad82db116c67cb": {
+						"questionnaire": {
+							"isAddressOwner": 1,
+							"sendTo": 1,
+							"declaration": true
+						}
+					}
+				}
+			}
+		]
 	}
 }

--- a/src/handlers/execute-action/withdraw.ts
+++ b/src/handlers/execute-action/withdraw.ts
@@ -108,6 +108,7 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 						address: transferValue.recipientAddress,
 						network: withdrawNetwork.exchangeNetworkId,
 						questionnaire: travelRule.questionnaire,
+						params: transferValue.params,
 					})
 				: await broker.withdraw(
 						symbol,

--- a/src/handlers/execute-action/withdraw.ts
+++ b/src/handlers/execute-action/withdraw.ts
@@ -1,5 +1,9 @@
 import * as grpc from "@grpc/grpc-js";
-import { validateWithdraw } from "../../helpers";
+import {
+	resolveTravelRuleDecision,
+	validateWithdraw,
+	withdrawViaLocalEntity,
+} from "../../helpers";
 import {
 	mapCcxtErrorToGrpcStatus,
 	stableGrpcErrorCode,
@@ -79,17 +83,42 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 			null,
 		);
 	}
-	try {
-		const transaction = await broker.withdraw(
-			symbol,
-			transferValue.amount,
-			transferValue.recipientAddress,
-			undefined,
+
+	const travelRule = resolveTravelRuleDecision(
+		policy,
+		cex,
+		transferValue.recipientAddress,
+	);
+	if (travelRule.mode === "denied") {
+		return ctx.wrappedCallback(
 			{
-				...(transferValue.params ?? {}),
-				network: withdrawNetwork.exchangeNetworkId,
+				code: grpc.status.FAILED_PRECONDITION,
+				message: `travel_rule_denied: ${travelRule.error}`,
 			},
+			null,
 		);
+	}
+
+	try {
+		const transaction =
+			travelRule.mode === "localentity"
+				? await withdrawViaLocalEntity(broker, {
+						code: symbol,
+						amount: transferValue.amount,
+						address: transferValue.recipientAddress,
+						network: withdrawNetwork.exchangeNetworkId,
+						questionnaire: travelRule.questionnaire,
+					})
+				: await broker.withdraw(
+						symbol,
+						transferValue.amount,
+						transferValue.recipientAddress,
+						undefined,
+						{
+							...(transferValue.params ?? {}),
+							network: withdrawNetwork.exchangeNetworkId,
+						},
+					);
 		log.info(`Withdraw Result: ${JSON.stringify(transaction)}`);
 		ctx.wrappedCallback(null, {
 			proof: ctx.verity.proof,

--- a/src/helpers/broker.ts
+++ b/src/helpers/broker.ts
@@ -4,6 +4,7 @@ import ccxt from "@usherlabs/ccxt";
 import type { BrokerAccountRole, BrokerCredentials } from "../types";
 import { buildCcxtConfig } from "./exchange-credentials";
 import { log } from "./logger";
+import { registerBinanceTravelRuleWithdrawEndpoint } from "./travel-rule";
 
 export type BrokerAccount = {
 	exchange: Exchange;
@@ -51,6 +52,8 @@ export function applyCommonExchangeConfig(exchange: Exchange) {
 		recvWindow: 60000,
 		adjustForTimeDifference: true,
 	});
+	// Register Binance's travel-rule withdraw endpoint (no-op for other exchanges).
+	registerBinanceTravelRuleWithdrawEndpoint(exchange);
 }
 
 export function createBroker(

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -14,6 +14,7 @@ import {
 	parseMarketPattern,
 	parseMarketType,
 } from "./market-type";
+import { australiaQuestionnaireSchema } from "./travel-rule";
 
 export { authenticateRequest } from "./auth";
 export {
@@ -29,6 +30,13 @@ export {
 	selectBroker,
 	selectBrokerAccount,
 } from "./broker";
+export {
+	australiaQuestionnaireSchema,
+	registerBinanceTravelRuleWithdrawEndpoint,
+	resolveTravelRuleDecision,
+	type TravelRuleDecision,
+	withdrawViaLocalEntity,
+} from "./travel-rule";
 export {
 	buildHttpClientOverrideFromMetadata,
 	createVerityHttpClientOverride,
@@ -71,6 +79,23 @@ export function loadPolicy(policyPath: string): PolicyConfig {
 				.default([]),
 		});
 
+		// Travel-rule config: per-exchange opt-in flag plus static questionnaire
+		// answers keyed by destination address, validated against the AU schema at
+		// load time so a malformed questionnaire fails startup, not a live withdraw.
+		const travelRuleEntrySchema = Joi.object({
+			exchange: Joi.string().required(),
+			enabled: Joi.boolean().required(),
+			description: Joi.string().optional(),
+			addresses: Joi.object()
+				.pattern(
+					Joi.string(),
+					Joi.object({
+						questionnaire: australiaQuestionnaireSchema.required(),
+					}),
+				)
+				.required(),
+		});
+
 		// Full PolicyConfig schema
 		const policyConfigSchema = Joi.object({
 			withdraw: Joi.object({
@@ -84,6 +109,10 @@ export function loadPolicy(policyPath: string): PolicyConfig {
 			order: Joi.object({
 				rule: orderRuleSchema.required(),
 			}).required(),
+
+			travelRule: Joi.object({
+				rule: Joi.array().items(travelRuleEntrySchema).required(),
+			}).optional(),
 		});
 
 		const { error, value } = policyConfigSchema.validate(

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -83,7 +83,10 @@ export function loadPolicy(policyPath: string): PolicyConfig {
 		// answers keyed by destination address, validated against the AU schema at
 		// load time so a malformed questionnaire fails startup, not a live withdraw.
 		const travelRuleEntrySchema = Joi.object({
-			exchange: Joi.string().required(),
+			// Only Binance implements the travel-rule (localentity) withdraw endpoint,
+			// so reject other exchanges at load time rather than failing at withdraw
+			// time with a cryptic "endpoint not registered" error.
+			exchange: Joi.string().uppercase().valid("BINANCE").required(),
 			enabled: Joi.boolean().required(),
 			description: Joi.string().optional(),
 			addresses: Joi.object()

--- a/src/helpers/travel-rule.ts
+++ b/src/helpers/travel-rule.ts
@@ -1,0 +1,182 @@
+import type { Dict, Exchange } from "@usherlabs/ccxt";
+import Joi from "joi";
+import type { PolicyConfig, TravelRuleQuestionnaire } from "../types";
+
+/**
+ * Binance travel-rule ("local entity") withdrawal support.
+ *
+ * Some jurisdictions (Australia from 2026-07-01 under AUSTRAC) require Binance
+ * withdrawals to carry beneficiary metadata. Binance enforces this by rejecting
+ * the standard `POST /sapi/v1/capital/withdraw/apply` endpoint with error -4104
+ * and only accepting `POST /sapi/v1/localentity/withdraw/apply`, which takes an
+ * extra required `questionnaire` field (a JSON string of beneficiary answers).
+ *
+ * ccxt has no wrapper for the localentity endpoint, so we register it at runtime
+ * via the exchange's own `defineRestApi` and call the generated implicit method.
+ * The questionnaire answers are static per destination address and are validated
+ * at policy-load time by {@link australiaQuestionnaireSchema}.
+ */
+
+// Australia questionnaire shape per Binance's travel-rule docs. Conditional
+// requirements mirror the official spec:
+//   - bnfType required only when sending to another beneficiary (isAddressOwner=2)
+//   - individual name/location fields required only for bnfType=0 (individual)
+//   - corporate fields required only for bnfType=1 (corporate/entity)
+//   - vasp required only when sending to another VASP (sendTo=2)
+//   - vaspName required only when the VASP is not in Binance's list (vasp="others")
+// Inapplicable fields are forbidden so config mistakes fail fast at startup.
+// `is` schemas are explicitly `.required()` so that an ABSENT referenced field
+// does not match (an optional Joi schema treats `undefined` as valid, which would
+// otherwise wrongly trigger the required branch when e.g. bnfType is omitted).
+const isAnotherBeneficiary = Joi.number().valid(2).required();
+const isIndividual = Joi.number().valid(0).required();
+const isCorporate = Joi.number().valid(1).required();
+const isSendToVasp = Joi.number().valid(2).required();
+const isVaspOthers = Joi.string().valid("others").required();
+
+/** `base`, made required when sibling `ref` matches `is`, and forbidden otherwise. */
+function requiredWhen(
+	base: Joi.Schema,
+	ref: string,
+	is: Joi.Schema,
+): Joi.Schema {
+	return base.when(ref, {
+		is,
+		// biome-ignore lint/suspicious/noThenProperty: Joi .when() options object, not a thenable
+		then: Joi.required(),
+		otherwise: Joi.forbidden(),
+	});
+}
+
+export const australiaQuestionnaireSchema = Joi.object({
+	isAddressOwner: Joi.number().valid(1, 2).required(),
+	sendTo: Joi.number().valid(1, 2).required(),
+	// Binance requires an affirmative declaration; a false value can never yield a
+	// successful withdrawal, so reject it when the static config is loaded.
+	declaration: Joi.boolean().valid(true).required(),
+	bnfType: requiredWhen(
+		Joi.number().valid(0, 1),
+		"isAddressOwner",
+		isAnotherBeneficiary,
+	),
+	bnfFirstName: requiredWhen(Joi.string(), "bnfType", isIndividual),
+	bnfLastName: requiredWhen(Joi.string(), "bnfType", isIndividual),
+	country: requiredWhen(Joi.string(), "bnfType", isIndividual),
+	city: requiredWhen(Joi.string(), "bnfType", isIndividual),
+	bnfCorpName: requiredWhen(Joi.string(), "bnfType", isCorporate),
+	bnfCorpCountry: requiredWhen(Joi.string(), "bnfType", isCorporate),
+	bnfCorpCity: requiredWhen(Joi.string(), "bnfType", isCorporate),
+	vasp: requiredWhen(Joi.string(), "sendTo", isSendToVasp),
+	vaspName: requiredWhen(Joi.string(), "vasp", isVaspOthers),
+});
+
+export type TravelRuleDecision =
+	| { mode: "standard" }
+	| { mode: "localentity"; questionnaire: TravelRuleQuestionnaire }
+	| { mode: "denied"; error: string };
+
+/**
+ * Decides whether a withdrawal must use Binance's travel-rule endpoint.
+ *
+ * Travel rule is opt-in per exchange via the `enabled` flag, so a non-AU account
+ * keeps using the standard endpoint. When enabled, the destination address must
+ * have a configured questionnaire; if it does not we fail closed rather than fall
+ * back to the standard endpoint (which would just reproduce the -4104 rejection).
+ */
+export function resolveTravelRuleDecision(
+	policy: PolicyConfig,
+	exchange: string,
+	recipientAddress: string,
+): TravelRuleDecision {
+	const rules = policy.travelRule?.rule ?? [];
+	const exchangeNorm = exchange.trim().toUpperCase();
+	const entry = rules.find(
+		(rule) => rule.exchange.trim().toUpperCase() === exchangeNorm,
+	);
+	if (!entry || !entry.enabled) {
+		return { mode: "standard" };
+	}
+
+	const addressNorm = recipientAddress.trim().toLowerCase();
+	const match = Object.entries(entry.addresses).find(
+		([address]) => address.trim().toLowerCase() === addressNorm,
+	);
+	if (!match) {
+		return {
+			mode: "denied",
+			error: `no travel-rule questionnaire configured for ${exchangeNorm} address ${recipientAddress}`,
+		};
+	}
+
+	return { mode: "localentity", questionnaire: match[1].questionnaire };
+}
+
+/**
+ * Registers Binance's `localentity/withdraw/apply` endpoint on the exchange
+ * instance. No-op for non-Binance exchanges. Idempotent — ccxt just reassigns
+ * the generated implicit method if called again.
+ */
+export function registerBinanceTravelRuleWithdrawEndpoint(
+	exchange: Exchange,
+): void {
+	if (exchange.id !== "binance") {
+		return;
+	}
+	// Same rate-limit weight as capital/withdraw/apply; the signing path is shared
+	// by all sapi private POSTs, so no ccxt fork change is needed.
+	exchange.defineRestApi(
+		{ sapi: { post: { "localentity/withdraw/apply": 4.0002 } } },
+		"request",
+	);
+}
+
+type LocalEntityWithdrawArgs = {
+	code: string;
+	amount: number;
+	address: string;
+	network: string;
+	questionnaire: TravelRuleQuestionnaire;
+};
+
+type BinanceLocalEntityWithdraw = {
+	sapiPostLocalentityWithdrawApply?: (
+		params: Record<string, unknown>,
+	) => Promise<Dict>;
+};
+
+/**
+ * Mirrors ccxt's `binance.withdraw` currency/network/precision handling, but
+ * targets the travel-rule endpoint and attaches the questionnaire. ccxt's
+ * `urlencode` applies `encodeURIComponent` to the value, satisfying Binance's
+ * requirement that the questionnaire JSON be URL-encoded in the request body.
+ */
+export async function withdrawViaLocalEntity(
+	broker: Exchange,
+	args: LocalEntityWithdrawArgs,
+) {
+	const exchange = broker as Exchange & BinanceLocalEntityWithdraw;
+	if (typeof exchange.sapiPostLocalentityWithdrawApply !== "function") {
+		throw new Error(
+			"binance_localentity_withdraw_unavailable: travel-rule withdraw endpoint is not registered on this exchange instance",
+		);
+	}
+
+	broker.checkAddress(args.address);
+	await broker.loadMarkets();
+	const currency = broker.currency(args.code);
+
+	const networks = broker.safeDict(broker.options, "networks", {});
+	const networkUpper = args.network.trim().toUpperCase();
+	const mappedNetwork = broker.safeString(networks, networkUpper, networkUpper);
+
+	const request: Record<string, unknown> = {
+		coin: currency.id,
+		address: args.address,
+		amount: broker.currencyToPrecision(args.code, args.amount),
+		network: mappedNetwork,
+		questionnaire: JSON.stringify(args.questionnaire),
+	};
+
+	const response = await exchange.sapiPostLocalentityWithdrawApply(request);
+	return broker.parseTransaction(response, currency);
+}

--- a/src/helpers/travel-rule.ts
+++ b/src/helpers/travel-rule.ts
@@ -136,6 +136,10 @@ type LocalEntityWithdrawArgs = {
 	address: string;
 	network: string;
 	questionnaire: TravelRuleQuestionnaire;
+	// Extra caller params (memo/tag, withdrawOrderId, etc.), forwarded to keep
+	// parity with the standard withdraw path. The fixed fields below win on
+	// collision so params can never override coin/amount/network/questionnaire.
+	params?: Record<string, string | number>;
 };
 
 type BinanceLocalEntityWithdraw = {
@@ -170,6 +174,7 @@ export async function withdrawViaLocalEntity(
 	const mappedNetwork = broker.safeString(networks, networkUpper, networkUpper);
 
 	const request: Record<string, unknown> = {
+		...args.params,
 		coin: currency.id,
 		address: args.address,
 		amount: broker.currencyToPrecision(args.code, args.amount),

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,41 @@ export type OrderRule = {
 	}>;
 };
 
+// Binance travel-rule questionnaire answers (Australia). Optional fields are
+// conditionally required; see australiaQuestionnaireSchema for the exact rules.
+export type TravelRuleQuestionnaire = {
+	isAddressOwner: number;
+	sendTo: number;
+	declaration: boolean;
+	bnfType?: number;
+	bnfFirstName?: string;
+	bnfLastName?: string;
+	country?: string;
+	city?: string;
+	bnfCorpName?: string;
+	bnfCorpCountry?: string;
+	bnfCorpCity?: string;
+	vasp?: string;
+	vaspName?: string;
+};
+
+export type TravelRuleAddressEntry = {
+	questionnaire: TravelRuleQuestionnaire;
+};
+
+export type TravelRuleEntry = {
+	exchange: string;
+	// Opt-in switch: only when true are withdrawals for this exchange routed
+	// through the travel-rule endpoint. Keeps non-AU accounts on the standard path.
+	enabled: boolean;
+	// Free-text note explaining why this entry exists (e.g. which jurisdiction
+	// requires it). Ignored by the runtime; documents intent next to the config.
+	description?: string;
+	// Keyed by destination address; the questionnaire is resolved on demand at
+	// withdraw time. Matching is case-insensitive.
+	addresses: Record<string, TravelRuleAddressEntry>;
+};
+
 export type PolicyConfig = {
 	withdraw: {
 		rule: WithdrawRuleEntry[];
@@ -35,6 +70,9 @@ export type PolicyConfig = {
 	};
 	order: {
 		rule: OrderRule;
+	};
+	travelRule?: {
+		rule: TravelRuleEntry[];
 	};
 };
 

--- a/test/travel-rule.test.ts
+++ b/test/travel-rule.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+import type { Exchange } from "@usherlabs/ccxt";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+	australiaQuestionnaireSchema,
+	loadPolicy,
+	registerBinanceTravelRuleWithdrawEndpoint,
+	resolveTravelRuleDecision,
+	withdrawViaLocalEntity,
+} from "../src/helpers";
+import type { PolicyConfig } from "../src/types";
+
+const SELF_OWNED = { isAddressOwner: 1, sendTo: 1, declaration: true };
+const ADDRESS = "0xC8319213172c3a608Fb13f570fC7DF5cdA4F84d1";
+
+function policyWithTravelRule(enabled: boolean): PolicyConfig {
+	return {
+		withdraw: {
+			rule: [
+				{ exchange: "BINANCE", network: "ARBITRUM", whitelist: [ADDRESS] },
+			],
+		},
+		deposit: {},
+		order: { rule: { markets: ["*"], limits: [] } },
+		travelRule: {
+			rule: [
+				{
+					exchange: "BINANCE",
+					enabled,
+					description: "Australia (AUSTRAC) travel-rule requirement",
+					addresses: { [ADDRESS]: { questionnaire: SELF_OWNED } },
+				},
+			],
+		},
+	};
+}
+
+describe("australiaQuestionnaireSchema", () => {
+	test("accepts a self-owned questionnaire", () => {
+		expect(
+			australiaQuestionnaireSchema.validate(SELF_OWNED).error,
+		).toBeUndefined();
+	});
+
+	test("rejects a false declaration", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 1,
+			sendTo: 1,
+			declaration: false,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("rejects a missing declaration", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 1,
+			sendTo: 1,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("requires bnfType when sending to another beneficiary", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 2,
+			sendTo: 1,
+			declaration: true,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("requires individual name fields for bnfType individual", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 2,
+			bnfType: 0,
+			sendTo: 1,
+			declaration: true,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("accepts a full individual-beneficiary questionnaire", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 2,
+			bnfType: 0,
+			bnfFirstName: "Jane",
+			bnfLastName: "Doe",
+			country: "au",
+			city: "Sydney",
+			sendTo: 1,
+			declaration: true,
+		});
+		expect(error).toBeUndefined();
+	});
+
+	test("requires vasp when sending to another VASP", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 1,
+			sendTo: 2,
+			declaration: true,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("requires vaspName when vasp is 'others'", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 1,
+			sendTo: 2,
+			vasp: "others",
+			declaration: true,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("forbids beneficiary fields on a self-owned questionnaire", () => {
+		const { error } = australiaQuestionnaireSchema.validate({
+			isAddressOwner: 1,
+			sendTo: 1,
+			declaration: true,
+			bnfType: 0,
+		});
+		expect(error).toBeDefined();
+	});
+});
+
+describe("resolveTravelRuleDecision", () => {
+	test("returns standard when there is no travel-rule section", () => {
+		const policy: PolicyConfig = {
+			withdraw: { rule: [] },
+			deposit: {},
+			order: { rule: { markets: [], limits: [] } },
+		};
+		expect(resolveTravelRuleDecision(policy, "BINANCE", ADDRESS).mode).toBe(
+			"standard",
+		);
+	});
+
+	test("returns standard when the exchange entry is disabled", () => {
+		expect(
+			resolveTravelRuleDecision(policyWithTravelRule(false), "BINANCE", ADDRESS)
+				.mode,
+		).toBe("standard");
+	});
+
+	test("returns localentity with the questionnaire when enabled (case-insensitive)", () => {
+		const decision = resolveTravelRuleDecision(
+			policyWithTravelRule(true),
+			"binance",
+			ADDRESS.toLowerCase(),
+		);
+		expect(decision).toEqual({
+			mode: "localentity",
+			questionnaire: SELF_OWNED,
+		});
+	});
+
+	test("fails closed when enabled but the address has no questionnaire", () => {
+		const decision = resolveTravelRuleDecision(
+			policyWithTravelRule(true),
+			"BINANCE",
+			"0x0000000000000000000000000000000000000000",
+		);
+		expect(decision.mode).toBe("denied");
+	});
+});
+
+describe("registerBinanceTravelRuleWithdrawEndpoint", () => {
+	test("registers the endpoint on a Binance instance", () => {
+		const calls: unknown[][] = [];
+		const exchange = {
+			id: "binance",
+			defineRestApi: (...args: unknown[]) => calls.push(args),
+		} as unknown as Exchange;
+		registerBinanceTravelRuleWithdrawEndpoint(exchange);
+		expect(calls).toEqual([
+			[{ sapi: { post: { "localentity/withdraw/apply": 4.0002 } } }, "request"],
+		]);
+	});
+
+	test("is a no-op for non-Binance exchanges", () => {
+		const calls: unknown[][] = [];
+		const exchange = {
+			id: "bybit",
+			defineRestApi: (...args: unknown[]) => calls.push(args),
+		} as unknown as Exchange;
+		registerBinanceTravelRuleWithdrawEndpoint(exchange);
+		expect(calls).toEqual([]);
+	});
+});
+
+describe("withdrawViaLocalEntity", () => {
+	function createMockBinance() {
+		const captured: { request?: Record<string, unknown> } = {};
+		const exchange = {
+			options: { networks: { ARBITRUM: "ARBITRUM" } },
+			checkAddress: (address: string) => address,
+			loadMarkets: async () => undefined,
+			currency: (code: string) => ({ id: code, code }),
+			currencyToPrecision: (_code: string, amount: number) => String(amount),
+			safeDict: (obj: Record<string, unknown>, key: string) => obj?.[key] ?? {},
+			safeString: (
+				obj: Record<string, unknown>,
+				key: string,
+				fallback: string,
+			) => (typeof obj?.[key] === "string" ? (obj[key] as string) : fallback),
+			parseTransaction: (tx: Record<string, unknown>) => ({ parsed: tx }),
+			sapiPostLocalentityWithdrawApply: async (
+				request: Record<string, unknown>,
+			) => {
+				captured.request = request;
+				return { id: "withdrawal-123" };
+			},
+		} as unknown as Exchange;
+		return { exchange, captured };
+	}
+
+	test("calls the localentity endpoint with a URL-serializable questionnaire", async () => {
+		const { exchange, captured } = createMockBinance();
+		const result = await withdrawViaLocalEntity(exchange, {
+			code: "USDC",
+			amount: 100,
+			address: ADDRESS,
+			network: "ARBITRUM",
+			questionnaire: SELF_OWNED,
+		});
+
+		expect(captured.request).toEqual({
+			coin: "USDC",
+			address: ADDRESS,
+			amount: "100",
+			network: "ARBITRUM",
+			questionnaire: JSON.stringify(SELF_OWNED),
+		});
+		expect(result).toEqual({ parsed: { id: "withdrawal-123" } });
+	});
+
+	test("throws when the endpoint is not registered", async () => {
+		const exchange = {
+			checkAddress: (address: string) => address,
+			loadMarkets: async () => undefined,
+			currency: (code: string) => ({ id: code }),
+		} as unknown as Exchange;
+		await expect(
+			withdrawViaLocalEntity(exchange, {
+				code: "USDC",
+				amount: 100,
+				address: ADDRESS,
+				network: "ARBITRUM",
+				questionnaire: SELF_OWNED,
+			}),
+		).rejects.toThrow("binance_localentity_withdraw_unavailable");
+	});
+});
+
+describe("loadPolicy travel-rule validation", () => {
+	function writeTempPolicy(policy: unknown): string {
+		const tempPath = path.join(
+			os.tmpdir(),
+			`policy-travel-${Date.now()}-${Math.random()}.json`,
+		);
+		fs.writeFileSync(tempPath, JSON.stringify(policy));
+		return tempPath;
+	}
+
+	test("loads a policy with a valid travel-rule section", () => {
+		const tempPath = writeTempPolicy(policyWithTravelRule(true));
+		try {
+			const policy = loadPolicy(tempPath);
+			expect(policy.travelRule?.rule[0]?.enabled).toBe(true);
+			expect(policy.travelRule?.rule[0]?.description).toBe(
+				"Australia (AUSTRAC) travel-rule requirement",
+			);
+			expect(
+				policy.travelRule?.rule[0]?.addresses[ADDRESS]?.questionnaire,
+			).toEqual(SELF_OWNED);
+		} finally {
+			fs.unlinkSync(tempPath);
+		}
+	});
+
+	test("rejects a policy whose questionnaire is malformed", () => {
+		const bad = policyWithTravelRule(true);
+		// biome-ignore lint/suspicious/noExplicitAny: intentionally invalid config
+		(bad.travelRule as any).rule[0].addresses[ADDRESS].questionnaire = {
+			isAddressOwner: 1,
+			sendTo: 1,
+			declaration: false,
+		};
+		const tempPath = writeTempPolicy(bad);
+		try {
+			expect(() => loadPolicy(tempPath)).toThrow();
+		} finally {
+			fs.unlinkSync(tempPath);
+		}
+	});
+});

--- a/test/travel-rule.test.ts
+++ b/test/travel-rule.test.ts
@@ -235,6 +235,21 @@ describe("withdrawViaLocalEntity", () => {
 		expect(result).toEqual({ parsed: { id: "withdrawal-123" } });
 	});
 
+	test("forwards caller params but never lets them override fixed fields", async () => {
+		const { exchange, captured } = createMockBinance();
+		await withdrawViaLocalEntity(exchange, {
+			code: "USDC",
+			amount: 100,
+			address: ADDRESS,
+			network: "ARBITRUM",
+			questionnaire: SELF_OWNED,
+			params: { withdrawOrderId: "order-1", coin: "SHOULD_NOT_WIN" },
+		});
+		expect(captured.request?.withdrawOrderId).toBe("order-1");
+		// Fixed fields take precedence over any colliding param.
+		expect(captured.request?.coin).toBe("USDC");
+	});
+
 	test("throws when the endpoint is not registered", async () => {
 		const exchange = {
 			checkAddress: (address: string) => address,
@@ -287,6 +302,18 @@ describe("loadPolicy travel-rule validation", () => {
 			sendTo: 1,
 			declaration: false,
 		};
+		const tempPath = writeTempPolicy(bad);
+		try {
+			expect(() => loadPolicy(tempPath)).toThrow();
+		} finally {
+			fs.unlinkSync(tempPath);
+		}
+	});
+
+	test("rejects a travel-rule entry for a non-Binance exchange", () => {
+		const bad = policyWithTravelRule(true);
+		// biome-ignore lint/suspicious/noExplicitAny: intentionally invalid config
+		(bad.travelRule as any).rule[0].exchange = "BYBIT";
 		const tempPath = writeTempPolicy(bad);
 		try {
 			expect(() => loadPolicy(tempPath)).toThrow();


### PR DESCRIPTION
## Problem

Binance rejects the standard `POST /sapi/v1/capital/withdraw/apply` endpoint with **error -4104** ("withdrawals are not permitted due to travel rule restrictions") for accounts in jurisdictions that require travel-rule metadata — e.g. Australia under AUSTRAC from 2026-07-01. Once an account's jurisdiction requires it, the standard endpoint stops accepting withdrawals entirely; Binance only accepts `POST /sapi/v1/localentity/withdraw/apply`, which carries an extra required `questionnaire` field (a JSON string of beneficiary answers).

ccxt has no wrapper for the `localentity` endpoint.

## Change

Opt-in support for the travel-rule withdraw endpoint:

- **Runtime endpoint registration** (`travel-rule.ts`): registers `localentity/withdraw/apply` on the Binance instance via ccxt's own `defineRestApi`. No ccxt fork change — binance's `sign()` already signs all `sapi` private POSTs, and the path falls into the `urlencode` branch (which URL-encodes the questionnaire JSON, as the spec requires).
- **Policy schema** (`types.ts`, `index.ts`): new optional `travelRule` section — a per-exchange `enabled` flag plus static `questionnaire` answers keyed by destination address. The **Australia** questionnaire is validated at policy-load time (`australiaQuestionnaireSchema`), so a malformed questionnaire fails startup, not a live withdrawal. Includes an optional `description` field so operators can document *why* an entry exists.
- **Dispatch** (`withdraw.ts`): when travel rule is enabled for the exchange, resolve the questionnaire by destination address (case-insensitive) and route to the localentity endpoint. **Fails closed** — if enabled but no questionnaire is configured for the address, returns `FAILED_PRECONDITION` rather than falling back to the standard endpoint (which would just reproduce -4104).

Non-Binance exchanges and accounts with `enabled: false` keep using the standard endpoint unchanged.

## Tests

New `test/travel-rule.test.ts` (19 tests): AU questionnaire validation (self-owned, individual, corporate, VASP branches + conditional-required/forbidden rules), decision resolution (standard / localentity / fail-closed), endpoint registration (Binance vs no-op), the localentity request shape (incl. questionnaire JSON serialization), and `loadPolicy` acceptance/rejection.

Full suite: 291 pass / 0 fail. `tsc` and `biome` clean.

## Notes

- Version bumped to **0.2.15**. Consumers (fiet-maker) must upgrade to this before adding a `travelRule` section, since older `loadPolicy` rejects the unknown key.
- Only the **Australia** questionnaire validator is implemented for now (YAGNI); other jurisdictions can be added later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy-driven travel-rule configuration for withdrawals, including per-destination Australia questionnaire data for eligible Binance transfers.
  * Registered a Binance “localentity/withdraw/apply” route and added automatic routing to it when enabled and a matching questionnaire is available.

* **Bug Fixes**
  * Withdrawals now stop early with a clear failure when travel-rule mode is denied or when a required destination questionnaire is missing.

* **Tests**
  * Added end-to-end coverage for policy validation, decision resolution, and localentity withdrawal behavior.

* **Chores**
  * Bumped the package version to `0.2.15`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->