### PR TITLE
fix(travel-rule): sign localentity withdraw with rawencode (fixes -1022)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "fietcexbroker",
@@ -44,6 +43,7 @@
     },
   },
   "patchedDependencies": {
+    "@usherlabs/ccxt@0.0.14": "patches/@usherlabs%2Fccxt@0.0.14.patch",
     "@protobufjs/inquire@1.1.0": "patches/@protobufjs%2Finquire@1.1.0.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.15",
+	"version": "0.2.16",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",
@@ -83,6 +83,7 @@
 		"Oki Ayobami (https://github.com/xlassix)"
 	],
 	"patchedDependencies": {
-		"@protobufjs/inquire@1.1.0": "patches/@protobufjs%2Finquire@1.1.0.patch"
+		"@protobufjs/inquire@1.1.0": "patches/@protobufjs%2Finquire@1.1.0.patch",
+		"@usherlabs/ccxt@0.0.14": "patches/@usherlabs%2Fccxt@0.0.14.patch"
 	}
 }

--- a/patches/@usherlabs%2Fccxt@0.0.14.patch
+++ b/patches/@usherlabs%2Fccxt@0.0.14.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/@usherlabs/ccxt/.bun-tag-a296b4edbb70d359 b/.bun-tag-a296b4edbb70d359
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/cjs/src/binance.js b/dist/cjs/src/binance.js
+index 40b4c4e8989fcbcdc693216cdb0d43bf0f553a88..2d1083354341ee778318c53332c03897558b5137 100644
+--- a/dist/cjs/src/binance.js
++++ b/dist/cjs/src/binance.js
+@@ -12045,7 +12045,7 @@ class binance extends binance$1 {
+             if ((api === 'sapi') && (path === 'asset/dust')) {
+                 query = this.urlencodeWithArrayRepeat(extendedParams);
+             }
+-            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
++            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path === 'localentity/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
+                 if ((method === 'DELETE') && (path === 'batchOrders')) {
+                     const orderidlist = this.safeList(extendedParams, 'orderidlist', []);
+                     const origclientorderidlist = this.safeList(extendedParams, 'origclientorderidlist', []);
+diff --git a/js/src/binance.js b/js/src/binance.js
+index 9a472db82ff35f67c16bfde11b34831f503d00f9..70b1cd355fe31be954f0bd673f9b5896081a8ddc 100644
+--- a/js/src/binance.js
++++ b/js/src/binance.js
+@@ -12048,7 +12048,7 @@ export default class binance extends Exchange {
+             if ((api === 'sapi') && (path === 'asset/dust')) {
+                 query = this.urlencodeWithArrayRepeat(extendedParams);
+             }
+-            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
++            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path === 'localentity/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
+                 if ((method === 'DELETE') && (path === 'batchOrders')) {
+                     const orderidlist = this.safeList(extendedParams, 'orderidlist', []);
+                     const origclientorderidlist = this.safeList(extendedParams, 'origclientorderidlist', []);

--- a/test/travel-rule.test.ts
+++ b/test/travel-rule.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Exchange } from "@usherlabs/ccxt";
+import ccxt, { type Exchange } from "@usherlabs/ccxt";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -320,5 +320,37 @@ describe("loadPolicy travel-rule validation", () => {
 		} finally {
 			fs.unlinkSync(tempPath);
 		}
+	});
+});
+
+describe("binance localentity withdraw signing (ccxt patch)", () => {
+	// Guards the @usherlabs/ccxt patch: the localentity withdraw endpoint must be
+	// signed with rawencode (raw questionnaire JSON), exactly like
+	// capital/withdraw/apply. Signing with urlencode percent-encodes the JSON and
+	// Binance rejects it with -1022 "Signature for this request is not valid" —
+	// which is what a live withdrawal actually hit before the patch. Uses the real
+	// ccxt so this fails if the patch is ever dropped (e.g. on a version bump).
+	test("signs the questionnaire raw, not percent-encoded", () => {
+		const exchange = new ccxt.binance({ apiKey: "k", secret: "s" });
+		const params = {
+			coin: "ARB",
+			address: "0x0000000000000000000000000000000000000000",
+			amount: "10",
+			network: "ARBITRUM",
+			questionnaire: JSON.stringify({
+				isAddressOwner: 1,
+				sendTo: 1,
+				declaration: true,
+			}),
+		};
+		const signed = exchange.sign(
+			"localentity/withdraw/apply",
+			"sapi",
+			"POST",
+			params,
+		);
+		const body = String(signed.body ?? "");
+		expect(body).toContain('questionnaire={"isAddressOwner":1');
+		expect(body).not.toContain("questionnaire=%7B");
 	});
 });


### PR DESCRIPTION
## Problem

A **live** Binance withdrawal through the travel-rule endpoint (added in #51) was rejected with **-1022 "Signature for this request is not valid."** The travel-rule routing itself worked — we got past -4104 and reached `localentity/withdraw/apply` with the questionnaire — but the request failed signature validation.

## Root cause

Binance computes the withdraw signature over the **raw-encoded** request body. ccxt's binance `sign()` only special-cases `capital/withdraw/apply` (and a few others) for `rawencode`; `localentity/withdraw/apply` fell through to `urlencode`, which percent-encodes the questionnaire JSON:

- urlencode: `questionnaire=%7B%22isAddressOwner%22%3A1...%7D`
- rawencode: `questionnaire={"isAddressOwner":1,...}` ← what Binance expects

So the signature was computed over a string Binance doesn't reconstruct → -1022. (My original assumption that the questionnaire should be URL-encoded was wrong — it must be raw, like every other Binance withdraw.)

## Fix

Patch `@usherlabs/ccxt` (via the existing Bun `patchedDependencies` mechanism) to add `localentity/withdraw/apply` to the rawencode branch of binance `sign()`, in both the ESM (`js/src/binance.js`) and CJS (`dist/cjs/src/binance.js`) builds so it holds regardless of how the package is bundled.

Adds a regression test that instantiates the **real** ccxt and asserts the questionnaire is signed raw, not percent-encoded — the mocked tests can't catch this, and only a live call surfaced it.

Bumps to **0.2.16**. Full suite: 294 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request handling for certain Binance withdrawal flows so the required questionnaire data is sent in the expected format.
  * Improved compatibility for a specific exchange integration path used during withdrawal requests.

* **Chores**
  * Bumped the package version to `0.2.16`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->