### PR TITLE
feat(deposit): auto-clear Binance travel-rule frozen deposits (0.2.17)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,3 +17,15 @@ OTEL_SERVICE_NAME=cex-broker
 # CEX_BROKER_OTEL_HOST=otel-collector
 # CEX_BROKER_OTEL_PORT=4318
 # CEX_BROKER_OTEL_PROTOCOL=http
+
+# Travel-rule deposit auto-clear reconciler (only used when a policy has
+# travelRule.rule[].deposits.enabled). One RPC URL per Binance network code
+# (suffix must match the deposit's `network`, e.g. ARBITRUM), used to prove a
+# frozen deposit's on-chain sender before auto-submitting its questionnaire. A
+# frozen deposit on a network with no RPC configured is left frozen (fail-closed).
+# These are intentionally NOT CEX_BROKER_-prefixed so the credential scan skips them.
+# TRAVEL_RULE_RPC_URL_ARBITRUM=https://arb1.arbitrum.io/rpc
+# Optional overrides (defaults shown):
+# TRAVEL_RULE_DEPOSIT_POLL_ACTIVE_SECS=60
+# TRAVEL_RULE_DEPOSIT_POLL_IDLE_SECS=600
+# TRAVEL_RULE_QUESTIONNAIRE_COUNTRY=AU

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.16",
+	"version": "0.2.17",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",

--- a/patches/@usherlabs%2Fccxt@0.0.14.patch
+++ b/patches/@usherlabs%2Fccxt@0.0.14.patch
@@ -1,8 +1,11 @@
 diff --git a/node_modules/@usherlabs/ccxt/.bun-tag-a296b4edbb70d359 b/.bun-tag-a296b4edbb70d359
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@usherlabs/ccxt/.bun-tag-e1eca9fb87d1075f b/.bun-tag-e1eca9fb87d1075f
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/cjs/src/binance.js b/dist/cjs/src/binance.js
-index 40b4c4e8989fcbcdc693216cdb0d43bf0f553a88..2d1083354341ee778318c53332c03897558b5137 100644
+index 40b4c4e8989fcbcdc693216cdb0d43bf0f553a88..6c7cda095c614de0527fa225ed321671488cbef9 100644
 --- a/dist/cjs/src/binance.js
 +++ b/dist/cjs/src/binance.js
 @@ -12045,7 +12045,7 @@ class binance extends binance$1 {
@@ -10,12 +13,12 @@ index 40b4c4e8989fcbcdc693216cdb0d43bf0f553a88..2d1083354341ee778318c53332c03897
                  query = this.urlencodeWithArrayRepeat(extendedParams);
              }
 -            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
-+            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path === 'localentity/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
++            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path === 'localentity/withdraw/apply') || (path === 'localentity/deposit/provide-info') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
                  if ((method === 'DELETE') && (path === 'batchOrders')) {
                      const orderidlist = this.safeList(extendedParams, 'orderidlist', []);
                      const origclientorderidlist = this.safeList(extendedParams, 'origclientorderidlist', []);
 diff --git a/js/src/binance.js b/js/src/binance.js
-index 9a472db82ff35f67c16bfde11b34831f503d00f9..70b1cd355fe31be954f0bd673f9b5896081a8ddc 100644
+index 9a472db82ff35f67c16bfde11b34831f503d00f9..7e7696cac61e08ac469d4d7c2b9c6fb861c84b3c 100644
 --- a/js/src/binance.js
 +++ b/js/src/binance.js
 @@ -12048,7 +12048,7 @@ export default class binance extends Exchange {
@@ -23,7 +26,7 @@ index 9a472db82ff35f67c16bfde11b34831f503d00f9..70b1cd355fe31be954f0bd673f9b5896
                  query = this.urlencodeWithArrayRepeat(extendedParams);
              }
 -            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
-+            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path === 'localentity/withdraw/apply') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
++            else if ((path === 'batchOrders') || (path.indexOf('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path === 'localentity/withdraw/apply') || (path === 'localentity/deposit/provide-info') || (path.indexOf('staking') >= 0) || (path.indexOf('simple-earn') >= 0)) {
                  if ((method === 'DELETE') && (path === 'batchOrders')) {
                      const orderidlist = this.safeList(extendedParams, 'orderidlist', []);
                      const origclientorderidlist = this.safeList(extendedParams, 'origclientorderidlist', []);

--- a/src/helpers/broker.ts
+++ b/src/helpers/broker.ts
@@ -4,7 +4,10 @@ import ccxt from "@usherlabs/ccxt";
 import type { BrokerAccountRole, BrokerCredentials } from "../types";
 import { buildCcxtConfig } from "./exchange-credentials";
 import { log } from "./logger";
-import { registerBinanceTravelRuleWithdrawEndpoint } from "./travel-rule";
+import {
+	registerBinanceTravelRuleDepositEndpoints,
+	registerBinanceTravelRuleWithdrawEndpoint,
+} from "./travel-rule";
 
 export type BrokerAccount = {
 	exchange: Exchange;
@@ -52,8 +55,12 @@ export function applyCommonExchangeConfig(exchange: Exchange) {
 		recvWindow: 60000,
 		adjustForTimeDifference: true,
 	});
-	// Register Binance's travel-rule withdraw endpoint (no-op for other exchanges).
+	// Register Binance's travel-rule endpoints (no-op for other exchanges): the
+	// withdraw apply endpoint and the deposit reconciler's read/provide-info
+	// endpoints. Registered here so every account instance carries them before the
+	// reconciler's first tick.
 	registerBinanceTravelRuleWithdrawEndpoint(exchange);
+	registerBinanceTravelRuleDepositEndpoints(exchange);
 }
 
 export function createBroker(

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -14,7 +14,10 @@ import {
 	parseMarketPattern,
 	parseMarketType,
 } from "./market-type";
-import { australiaQuestionnaireSchema } from "./travel-rule";
+import {
+	australiaDepositQuestionnaireSchema,
+	australiaQuestionnaireSchema,
+} from "./travel-rule";
 
 export { authenticateRequest } from "./auth";
 export {
@@ -31,12 +34,21 @@ export {
 	selectBrokerAccount,
 } from "./broker";
 export {
+	australiaDepositQuestionnaireSchema,
 	australiaQuestionnaireSchema,
+	getEnabledTravelRuleDepositConfig,
+	registerBinanceTravelRuleDepositEndpoints,
 	registerBinanceTravelRuleWithdrawEndpoint,
+	resolveDepositOriginatorQuestionnaire,
 	resolveTravelRuleDecision,
 	type TravelRuleDecision,
 	withdrawViaLocalEntity,
 } from "./travel-rule";
+export {
+	loadTravelRuleDepositReconcilerConfigFromEnv,
+	resolveOnChainSender,
+	TravelRuleDepositReconciler,
+} from "./travel-rule-deposit-reconciler";
 export {
 	buildHttpClientOverrideFromMetadata,
 	createVerityHttpClientOverride,
@@ -97,6 +109,21 @@ export function loadPolicy(policyPath: string): PolicyConfig {
 					}),
 				)
 				.required(),
+			// Deposit auto-clear config, keyed by on-chain sender (originator). Uses
+			// the deposit questionnaire schema, which is deliberately distinct from
+			// the withdraw one so a copy-paste of the wrong shape fails at load time.
+			deposits: Joi.object({
+				enabled: Joi.boolean().required(),
+				description: Joi.string().optional(),
+				originators: Joi.object()
+					.pattern(
+						Joi.string(),
+						Joi.object({
+							questionnaire: australiaDepositQuestionnaireSchema.required(),
+						}),
+					)
+					.required(),
+			}).optional(),
 		});
 
 		// Full PolicyConfig schema

--- a/src/helpers/travel-rule-deposit-reconciler.ts
+++ b/src/helpers/travel-rule-deposit-reconciler.ts
@@ -63,7 +63,10 @@ function toBool(value: unknown): boolean {
 export function parseLocalEntityDeposit(
 	raw: Record<string, unknown>,
 ): LocalEntityDeposit | null {
-	const tranId = depositField(raw, ["tranId", "trId", "id"]);
+	// Only `tranId` is accepted: it is the sole id `provide-info` recognizes. A
+	// generic `id` fallback risks the `capital/deposit/hisrec` id space, which
+	// provide-info rejects with "Deposit request not found".
+	const tranId = depositField(raw, ["tranId"]);
 	if (tranId === undefined) return null;
 	return {
 		tranId: String(tranId),
@@ -106,18 +109,29 @@ const EVM_TX_HASH = /^0x[0-9a-fA-F]{64}$/;
 export async function resolveOnChainSender(
 	rpcUrl: string,
 	txHash: string,
+	timeoutMs = 10_000,
 ): Promise<string | null> {
 	if (!EVM_TX_HASH.test(txHash)) return null;
-	const response = await fetch(rpcUrl, {
-		method: "POST",
-		headers: { "content-type": "application/json" },
-		body: JSON.stringify({
-			jsonrpc: "2.0",
-			id: 1,
-			method: "eth_getTransactionByHash",
-			params: [txHash],
-		}),
-	});
+	// Bound the request: a hung RPC would otherwise stall the whole reconciler
+	// tick (candidates are resolved sequentially) and block the next poll.
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	let response: Response;
+	try {
+		response = await fetch(rpcUrl, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			signal: controller.signal,
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "eth_getTransactionByHash",
+				params: [txHash],
+			}),
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
 	if (!response.ok) {
 		throw new Error(`travel_rule_rpc_http_${response.status}`);
 	}
@@ -353,6 +367,10 @@ export async function reconcileAccountOnce(
 	}
 
 	for (const deposit of candidates) {
+		// A rate-limit signal from an earlier candidate this cycle set an
+		// account-wide cooldown; stop hitting the API for the rest and let the next
+		// tick wait it out rather than compounding the -1003.
+		if (now < state.rateLimitedUntil) break;
 		let sender: string | null = null;
 		try {
 			sender = await deps.resolveSender(deposit.network, deposit.txId);

--- a/src/helpers/travel-rule-deposit-reconciler.ts
+++ b/src/helpers/travel-rule-deposit-reconciler.ts
@@ -1,0 +1,836 @@
+import type { Exchange } from "@usherlabs/ccxt";
+import type {
+	PolicyConfig,
+	TravelRuleDepositConfig,
+	TravelRuleDepositQuestionnaire,
+} from "../types";
+import type { BrokerAccount, BrokerPoolEntry } from "./broker";
+import { depositField } from "./deposit";
+import { log } from "./logger";
+import type { OtelMetrics } from "./otel";
+import {
+	getEnabledTravelRuleDepositConfig,
+	resolveDepositOriginatorQuestionnaire,
+} from "./travel-rule";
+
+/**
+ * Auto-clear reconciler for Binance travel-rule-frozen DEPOSITS.
+ *
+ * Under the AUSTRAC travel rule Binance credits an inbound deposit but holds it
+ * in `getUserAsset.freeze` (invisible to free+locked balances) until a per-deposit
+ * questionnaire is answered. This reconciler polls `localentity/deposit/history`
+ * for such frozen deposits and submits the questionnaire — but only for deposits
+ * whose on-chain sender is PROVEN (via `eth_getTransactionByHash`) to be one of
+ * our configured originator wallets. Everything else is left frozen and surfaced.
+ *
+ * Compliance invariant: a deposit is NEVER auto-declared unless its origin is
+ * proven ours. Undeclared origin, unresolvable sender, entity drift, or any
+ * uncertainty all fail closed (skip + surface), never "declare anyway".
+ *
+ * This runs entirely broker-internal (not through the gRPC verity path), so
+ * provide-info carries no verity proof — acceptable for a compliance attestation
+ * that is not a trading action; see the plan's edge-case notes.
+ */
+
+// ---------------------------------------------------------------------------
+// Parsed deposit record
+// ---------------------------------------------------------------------------
+
+export type LocalEntityDeposit = {
+	tranId: string;
+	coin: string;
+	amount: string;
+	network: string;
+	txId: string;
+	// travelRuleStatusV2, uppercased: PENDING | PASSED | FAILED (others pass through).
+	travelRuleStatus: string;
+	requireQuestionnaire: boolean;
+	raw: Record<string, unknown>;
+};
+
+function toBool(value: unknown): boolean {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "number") return value !== 0;
+	if (typeof value === "string") return value.trim().toLowerCase() === "true";
+	return false;
+}
+
+/**
+ * Parses one raw `localentity/deposit/history` row. Returns null when the row
+ * lacks a tranId (the only id valid for provide-info — the `capital/deposit/hisrec`
+ * id is a different id space and yields "Deposit request not found").
+ */
+export function parseLocalEntityDeposit(
+	raw: Record<string, unknown>,
+): LocalEntityDeposit | null {
+	const tranId = depositField(raw, ["tranId", "trId", "id"]);
+	if (tranId === undefined) return null;
+	return {
+		tranId: String(tranId),
+		coin: String(depositField(raw, ["coin", "asset"]) ?? ""),
+		amount: String(depositField(raw, ["amount"]) ?? ""),
+		network: String(depositField(raw, ["network"]) ?? ""),
+		txId: String(
+			depositField(raw, ["txId", "txid", "tx_hash", "txHash"]) ?? "",
+		),
+		travelRuleStatus: String(
+			depositField(raw, ["travelRuleStatusV2", "travelRuleStatus"]) ?? "",
+		)
+			.trim()
+			.toUpperCase(),
+		requireQuestionnaire: toBool(
+			raw.requireQuestionnaire ?? raw.requireQuestionnaireV2,
+		),
+		raw,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// On-chain origin proof
+// ---------------------------------------------------------------------------
+
+const EVM_TX_HASH = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Resolves the on-chain sender (`tx.from`) of a deposit's transaction hash via a
+ * JSON-RPC `eth_getTransactionByHash`. Returns the lowercased sender, or null
+ * when the hash is not a well-formed EVM tx hash or the tx is not found (pruned
+ * node / reorg / not yet mined) — both of which mean the origin is UNPROVEN and
+ * the caller must skip rather than assume.
+ *
+ * `tx.from` is the EOA that signed the deposit transaction. For our funding
+ * churn (owner wallet → Binance via a direct ERC20 transfer) that equals the
+ * token originator. A transfer routed through a contract could differ; hardening
+ * to the ERC20 Transfer event's `from` is possible later if that case arises.
+ */
+export async function resolveOnChainSender(
+	rpcUrl: string,
+	txHash: string,
+): Promise<string | null> {
+	if (!EVM_TX_HASH.test(txHash)) return null;
+	const response = await fetch(rpcUrl, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "eth_getTransactionByHash",
+			params: [txHash],
+		}),
+	});
+	if (!response.ok) {
+		throw new Error(`travel_rule_rpc_http_${response.status}`);
+	}
+	const json = (await response.json()) as {
+		result?: { from?: unknown } | null;
+		error?: unknown;
+	};
+	if (json.error) {
+		throw new Error(`travel_rule_rpc_error: ${JSON.stringify(json.error)}`);
+	}
+	const from = json.result?.from;
+	return typeof from === "string" && from.length > 0
+		? from.toLowerCase()
+		: null;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+function errorText(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
+
+/** Binance rate-limit signals (-1003 / HTTP 429 / DDoS guard). */
+export function isRateLimitError(error: unknown): boolean {
+	const text = errorText(error).toLowerCase();
+	return (
+		text.includes("-1003") ||
+		text.includes("too many requests") ||
+		text.includes("429") ||
+		text.includes("ddosprotection") ||
+		text.includes("ratelimitexceeded")
+	);
+}
+
+/**
+ * A provide-info call that Binance treats as already-satisfied. Re-submitting a
+ * tranId that was already provided (a manual release, or a reconciler restart)
+ * must be idempotent, so these responses/errors count as success.
+ */
+export function isAlreadyProvidedError(error: unknown): boolean {
+	const text = errorText(error).toLowerCase();
+	return (
+		text.includes("already") &&
+		(text.includes("provided") ||
+			text.includes("processed") ||
+			text.includes("passed") ||
+			text.includes("submit"))
+	);
+}
+
+function isAcceptedResponse(response: Record<string, unknown>): boolean {
+	// { "accepted": true } on success. Some paths return no explicit flag; treat
+	// an absent `accepted` as accepted (no error was thrown) but an explicit
+	// `accepted: false` as a content rejection.
+	return response.accepted !== false;
+}
+
+// ---------------------------------------------------------------------------
+// Per-account reconcile core (pure orchestration over injected I/O)
+// ---------------------------------------------------------------------------
+
+export type ReconcilerAccountState = {
+	// tranIds we have successfully submitted (or that Binance reported already
+	// provided). Skipped on subsequent cycles — idempotency keyed by tranId.
+	submittedTranIds: Set<string>;
+	// FAILED deposits already surfaced once (terminal; not re-logged every cycle).
+	surfacedFailed: Set<string>;
+	// tranId → epoch-ms before which we will not re-attempt. Prevents hot-looping
+	// on content errors, unresolved senders, and undeclared origins.
+	backoffUntil: Map<string, number>;
+	// account-wide cooldown after a rate-limit signal (epoch-ms).
+	rateLimitedUntil: number;
+};
+
+export function createAccountState(): ReconcilerAccountState {
+	return {
+		submittedTranIds: new Set(),
+		surfacedFailed: new Set(),
+		backoffUntil: new Map(),
+		rateLimitedUntil: 0,
+	};
+}
+
+export type ReconcileOutcome =
+	| { kind: "submitted"; deposit: LocalEntityDeposit; sender: string }
+	| { kind: "already-provided"; deposit: LocalEntityDeposit; sender: string }
+	| { kind: "undeclared-origin"; deposit: LocalEntityDeposit; sender: string }
+	| { kind: "unproven-origin"; deposit: LocalEntityDeposit }
+	| {
+			kind: "entity-drift";
+			deposit: LocalEntityDeposit;
+			country: string | null;
+	  }
+	| { kind: "failed-terminal"; deposit: LocalEntityDeposit }
+	| { kind: "submit-error"; deposit: LocalEntityDeposit; error: string }
+	| { kind: "poll-error"; error: string };
+
+export type ReconcileAccountReport = {
+	accountLabel: string;
+	frozenDeposits: LocalEntityDeposit[];
+	outcomes: ReconcileOutcome[];
+	// Whether there was actionable work this cycle — drives active vs idle cadence.
+	hadActionableWork: boolean;
+};
+
+export type ReconcileAccountDeps = {
+	accountLabel: string;
+	depositConfig: TravelRuleDepositConfig;
+	expectedCountry: string;
+	failureBackoffMs: number;
+	rateLimitCooldownMs: number;
+	now: number;
+	state: ReconcilerAccountState;
+	fetchDepositHistory: () => Promise<Array<Record<string, unknown>>>;
+	fetchQuestionnaireCountry: () => Promise<string | null>;
+	resolveSender: (network: string, txId: string) => Promise<string | null>;
+	submitProvideInfo: (
+		tranId: string,
+		questionnaire: TravelRuleDepositQuestionnaire,
+	) => Promise<Record<string, unknown>>;
+	resolveQuestionnaire: (
+		config: TravelRuleDepositConfig,
+		sender: string,
+	) => TravelRuleDepositQuestionnaire | null;
+};
+
+function isInBackoff(
+	state: ReconcilerAccountState,
+	tranId: string,
+	now: number,
+): boolean {
+	const until = state.backoffUntil.get(tranId);
+	return until !== undefined && now < until;
+}
+
+/**
+ * Reconciles a single account once. Pure orchestration: all I/O is injected so
+ * the compliance invariants (never submit an unproven/undeclared/entity-drifted
+ * deposit) are unit-testable without a network. Fetch/poll errors are captured
+ * as outcomes rather than thrown so one bad account never stalls the loop.
+ */
+export async function reconcileAccountOnce(
+	deps: ReconcileAccountDeps,
+): Promise<ReconcileAccountReport> {
+	const { state, now, accountLabel } = deps;
+	const outcomes: ReconcileOutcome[] = [];
+
+	if (now < state.rateLimitedUntil) {
+		return {
+			accountLabel,
+			frozenDeposits: [],
+			outcomes,
+			hadActionableWork: false,
+		};
+	}
+
+	let rawDeposits: Array<Record<string, unknown>>;
+	try {
+		rawDeposits = await deps.fetchDepositHistory();
+	} catch (error) {
+		if (isRateLimitError(error)) {
+			state.rateLimitedUntil = now + deps.rateLimitCooldownMs;
+		}
+		return {
+			accountLabel,
+			frozenDeposits: [],
+			outcomes: [{ kind: "poll-error", error: errorText(error) }],
+			hadActionableWork: false,
+		};
+	}
+
+	const deposits = rawDeposits
+		.map(parseLocalEntityDeposit)
+		.filter((d): d is LocalEntityDeposit => d !== null);
+	const frozen = deposits.filter(
+		(d) => d.requireQuestionnaire && d.travelRuleStatus === "PENDING",
+	);
+
+	// Terminal FAILED deposits: surface once, never auto-submit.
+	for (const deposit of deposits) {
+		if (
+			deposit.travelRuleStatus === "FAILED" &&
+			!state.surfacedFailed.has(deposit.tranId)
+		) {
+			state.surfacedFailed.add(deposit.tranId);
+			outcomes.push({ kind: "failed-terminal", deposit });
+		}
+	}
+
+	const candidates = frozen.filter(
+		(d) =>
+			!state.submittedTranIds.has(d.tranId) &&
+			!isInBackoff(state, d.tranId, now),
+	);
+	if (candidates.length === 0) {
+		return {
+			accountLabel,
+			frozenDeposits: frozen,
+			outcomes,
+			hadActionableWork: false,
+		};
+	}
+
+	// Entity gate: only submit AU-shaped answers to an AU entity. Checked once per
+	// cycle, only when there is a candidate, and fail-closed on drift/unavailable.
+	let country: string | null = null;
+	try {
+		country = await deps.fetchQuestionnaireCountry();
+	} catch (error) {
+		if (isRateLimitError(error)) {
+			state.rateLimitedUntil = now + deps.rateLimitCooldownMs;
+		}
+		country = null;
+	}
+	if (country !== deps.expectedCountry) {
+		for (const deposit of candidates) {
+			outcomes.push({ kind: "entity-drift", deposit, country });
+		}
+		return {
+			accountLabel,
+			frozenDeposits: frozen,
+			outcomes,
+			hadActionableWork: true,
+		};
+	}
+
+	for (const deposit of candidates) {
+		let sender: string | null = null;
+		try {
+			sender = await deps.resolveSender(deposit.network, deposit.txId);
+		} catch (error) {
+			sender = null;
+			if (isRateLimitError(error)) {
+				state.rateLimitedUntil = now + deps.rateLimitCooldownMs;
+			}
+		}
+		if (!sender) {
+			state.backoffUntil.set(deposit.tranId, now + deps.failureBackoffMs);
+			outcomes.push({ kind: "unproven-origin", deposit });
+			continue;
+		}
+
+		const questionnaire = deps.resolveQuestionnaire(deps.depositConfig, sender);
+		if (!questionnaire) {
+			state.backoffUntil.set(deposit.tranId, now + deps.failureBackoffMs);
+			outcomes.push({ kind: "undeclared-origin", deposit, sender });
+			continue;
+		}
+
+		try {
+			const response = await deps.submitProvideInfo(
+				deposit.tranId,
+				questionnaire,
+			);
+			if (isAcceptedResponse(response)) {
+				state.submittedTranIds.add(deposit.tranId);
+				state.backoffUntil.delete(deposit.tranId);
+				outcomes.push({ kind: "submitted", deposit, sender });
+			} else {
+				state.backoffUntil.set(deposit.tranId, now + deps.failureBackoffMs);
+				outcomes.push({
+					kind: "submit-error",
+					deposit,
+					error: JSON.stringify(response),
+				});
+			}
+		} catch (error) {
+			if (isAlreadyProvidedError(error)) {
+				state.submittedTranIds.add(deposit.tranId);
+				state.backoffUntil.delete(deposit.tranId);
+				outcomes.push({ kind: "already-provided", deposit, sender });
+			} else {
+				if (isRateLimitError(error)) {
+					state.rateLimitedUntil = now + deps.rateLimitCooldownMs;
+				}
+				state.backoffUntil.set(deposit.tranId, now + deps.failureBackoffMs);
+				outcomes.push({
+					kind: "submit-error",
+					deposit,
+					error: errorText(error),
+				});
+			}
+		}
+	}
+
+	return {
+		accountLabel,
+		frozenDeposits: frozen,
+		outcomes,
+		hadActionableWork: true,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export type TravelRuleDepositReconcilerConfig = {
+	// Upper-cased Binance network code (e.g. "ARBITRUM") → EVM JSON-RPC URL used to
+	// prove a deposit's on-chain sender. A frozen deposit on a network with no RPC
+	// configured is treated as unproven and left frozen (fail-closed).
+	rpcUrlsByNetwork: Record<string, string>;
+	pollIntervalActiveMs: number;
+	pollIntervalIdleMs: number;
+	expectedQuestionnaireCountry: string;
+	failureBackoffMs: number;
+	rateLimitCooldownMs: number;
+};
+
+const DEFAULTS = {
+	pollIntervalActiveMs: 60_000,
+	pollIntervalIdleMs: 600_000,
+	expectedQuestionnaireCountry: "AU",
+	failureBackoffMs: 15 * 60_000,
+	rateLimitCooldownMs: 5 * 60_000,
+};
+
+function envSecondsToMs(
+	env: Record<string, string | undefined>,
+	key: string,
+	fallbackMs: number,
+): number {
+	const raw = env[key];
+	if (raw === undefined) return fallbackMs;
+	const secs = Number(raw);
+	return Number.isFinite(secs) && secs > 0 ? secs * 1000 : fallbackMs;
+}
+
+/**
+ * Builds reconciler config from the environment. RPC URLs are read from
+ * `TRAVEL_RULE_RPC_URL_<NETWORK>` vars (network suffix must match Binance's
+ * network code, e.g. `TRAVEL_RULE_RPC_URL_ARBITRUM`). These are intentionally NOT
+ * `CEX_BROKER_`-prefixed so the credential env scan ignores them. Cadence and the
+ * expected questionnaire country are overridable but default to the AU rollout.
+ */
+export function loadTravelRuleDepositReconcilerConfigFromEnv(
+	env: Record<string, string | undefined>,
+): TravelRuleDepositReconcilerConfig {
+	const rpcUrlsByNetwork: Record<string, string> = {};
+	const prefix = "TRAVEL_RULE_RPC_URL_";
+	for (const [key, value] of Object.entries(env)) {
+		if (key.startsWith(prefix) && value) {
+			rpcUrlsByNetwork[key.slice(prefix.length).toUpperCase()] = value;
+		}
+	}
+	return {
+		rpcUrlsByNetwork,
+		pollIntervalActiveMs: envSecondsToMs(
+			env,
+			"TRAVEL_RULE_DEPOSIT_POLL_ACTIVE_SECS",
+			DEFAULTS.pollIntervalActiveMs,
+		),
+		pollIntervalIdleMs: envSecondsToMs(
+			env,
+			"TRAVEL_RULE_DEPOSIT_POLL_IDLE_SECS",
+			DEFAULTS.pollIntervalIdleMs,
+		),
+		expectedQuestionnaireCountry:
+			env.TRAVEL_RULE_QUESTIONNAIRE_COUNTRY?.trim().toUpperCase() ||
+			DEFAULTS.expectedQuestionnaireCountry,
+		failureBackoffMs: envSecondsToMs(
+			env,
+			"TRAVEL_RULE_DEPOSIT_FAILURE_BACKOFF_SECS",
+			DEFAULTS.failureBackoffMs,
+		),
+		rateLimitCooldownMs: envSecondsToMs(
+			env,
+			"TRAVEL_RULE_DEPOSIT_RATE_LIMIT_COOLDOWN_SECS",
+			DEFAULTS.rateLimitCooldownMs,
+		),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Binance localentity implicit-method surface (registered via defineRestApi)
+// ---------------------------------------------------------------------------
+
+type BinanceLocalEntityDeposit = Exchange & {
+	sapiGetLocalentityDepositHistory?: (
+		params: Record<string, unknown>,
+	) => Promise<unknown>;
+	sapiGetLocalentityQuestionnaireRequirements?: (
+		params: Record<string, unknown>,
+	) => Promise<unknown>;
+	sapiPutLocalentityDepositProvideInfo?: (
+		params: Record<string, unknown>,
+	) => Promise<Record<string, unknown>>;
+};
+
+function parseQuestionnaireCountry(response: unknown): string | null {
+	if (!response || typeof response !== "object") return null;
+	const code = (response as Record<string, unknown>).questionnaireCountryCode;
+	return typeof code === "string" ? code.trim().toUpperCase() : null;
+}
+
+// ---------------------------------------------------------------------------
+// Reconciler loop
+// ---------------------------------------------------------------------------
+
+type ReconcilerTarget = {
+	exchangeId: string;
+	account: BrokerAccount;
+	depositConfig: TravelRuleDepositConfig;
+};
+
+export class TravelRuleDepositReconciler {
+	#timer: ReturnType<typeof setTimeout> | null = null;
+	#stopped = false;
+	#running = false;
+	readonly #states = new Map<string, ReconcilerAccountState>();
+
+	constructor(
+		private readonly params: {
+			policy: PolicyConfig;
+			brokers: Record<string, BrokerPoolEntry>;
+			config: TravelRuleDepositReconcilerConfig;
+			metrics?: OtelMetrics;
+		},
+	) {}
+
+	/** True when at least one exchange has deposit auto-clear enabled in policy. */
+	static hasEnabledExchange(policy: PolicyConfig): boolean {
+		return (policy.travelRule?.rule ?? []).some((rule) =>
+			getEnabledTravelRuleDepositConfig(policy, rule.exchange),
+		);
+	}
+
+	start(): void {
+		if (this.#timer || this.#stopped) return;
+		if (!TravelRuleDepositReconciler.hasEnabledExchange(this.params.policy)) {
+			return;
+		}
+		if (Object.keys(this.params.config.rpcUrlsByNetwork).length === 0) {
+			log.warn(
+				"⚠️ Travel-rule deposit auto-clear is enabled but no TRAVEL_RULE_RPC_URL_<NETWORK> is configured; every frozen deposit will be treated as unproven (left frozen).",
+			);
+		}
+		log.info("🛂 Travel-rule deposit auto-clear reconciler started");
+		this.#scheduleImmediate();
+	}
+
+	stop(): void {
+		this.#stopped = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = null;
+		}
+	}
+
+	#scheduleImmediate(): void {
+		this.#timer = setTimeout(() => void this.#tick(), 0);
+	}
+
+	#stateFor(key: string): ReconcilerAccountState {
+		let state = this.#states.get(key);
+		if (!state) {
+			state = createAccountState();
+			this.#states.set(key, state);
+		}
+		return state;
+	}
+
+	#targets(): ReconcilerTarget[] {
+		const targets: ReconcilerTarget[] = [];
+		for (const rule of this.params.policy.travelRule?.rule ?? []) {
+			const depositConfig = getEnabledTravelRuleDepositConfig(
+				this.params.policy,
+				rule.exchange,
+			);
+			if (!depositConfig) continue;
+			const exchangeId = rule.exchange.trim().toLowerCase();
+			const pool = this.params.brokers[exchangeId];
+			if (!pool) continue;
+			// Reconcile every account: the origin-proof gate makes it safe, and a
+			// frozen deposit that landed on the wrong account (master) still releases.
+			for (const account of [pool.primary, ...pool.secondaryBrokers]) {
+				targets.push({ exchangeId, account, depositConfig });
+			}
+		}
+		return targets;
+	}
+
+	async #tick(): Promise<void> {
+		if (this.#stopped || this.#running) return;
+		this.#running = true;
+		let anyActionable = false;
+		try {
+			for (const target of this.#targets()) {
+				if (this.#stopped) break;
+				const report = await this.#reconcileTarget(target);
+				this.#emit(target, report);
+				if (report.hadActionableWork) anyActionable = true;
+			}
+		} catch (error) {
+			log.error("Travel-rule deposit reconciler tick failed", error);
+		} finally {
+			this.#running = false;
+			if (!this.#stopped) {
+				const delay = anyActionable
+					? this.params.config.pollIntervalActiveMs
+					: this.params.config.pollIntervalIdleMs;
+				this.#timer = setTimeout(() => void this.#tick(), delay);
+			}
+		}
+	}
+
+	#reconcileTarget(target: ReconcilerTarget): Promise<ReconcileAccountReport> {
+		const exchange = target.account.exchange as BinanceLocalEntityDeposit;
+		const accountLabel = `${target.exchangeId}:${target.account.label}`;
+		const { config } = this.params;
+		return reconcileAccountOnce({
+			accountLabel,
+			depositConfig: target.depositConfig,
+			expectedCountry: config.expectedQuestionnaireCountry,
+			failureBackoffMs: config.failureBackoffMs,
+			rateLimitCooldownMs: config.rateLimitCooldownMs,
+			now: Date.now(),
+			state: this.#stateFor(accountLabel),
+			fetchDepositHistory: async () => {
+				if (typeof exchange.sapiGetLocalentityDepositHistory !== "function") {
+					throw new Error(
+						"binance_localentity_deposit_history_unavailable: endpoint not registered",
+					);
+				}
+				const result = await exchange.sapiGetLocalentityDepositHistory({});
+				return Array.isArray(result)
+					? (result as Array<Record<string, unknown>>)
+					: [];
+			},
+			fetchQuestionnaireCountry: async () => {
+				if (
+					typeof exchange.sapiGetLocalentityQuestionnaireRequirements !==
+					"function"
+				) {
+					return null;
+				}
+				const result =
+					await exchange.sapiGetLocalentityQuestionnaireRequirements({});
+				return parseQuestionnaireCountry(result);
+			},
+			resolveSender: (network, txId) => {
+				const url = config.rpcUrlsByNetwork[network.trim().toUpperCase()];
+				if (!url) return Promise.resolve(null);
+				return resolveOnChainSender(url, txId);
+			},
+			submitProvideInfo: (tranId, questionnaire) => {
+				if (
+					typeof exchange.sapiPutLocalentityDepositProvideInfo !== "function"
+				) {
+					throw new Error(
+						"binance_localentity_provide_info_unavailable: endpoint not registered",
+					);
+				}
+				return exchange.sapiPutLocalentityDepositProvideInfo({
+					tranId,
+					questionnaire: JSON.stringify(questionnaire),
+				});
+			},
+			resolveQuestionnaire: resolveDepositOriginatorQuestionnaire,
+		});
+	}
+
+	#emit(target: ReconcilerTarget, report: ReconcileAccountReport): void {
+		const { metrics } = this.params;
+		const base = { exchange: target.exchangeId, account: target.account.label };
+
+		void metrics?.recordGauge(
+			"travel_rule_frozen_deposits",
+			report.frozenDeposits.length,
+			base,
+		);
+
+		for (const outcome of report.outcomes) {
+			switch (outcome.kind) {
+				case "submitted":
+				case "already-provided": {
+					// Compliance attestation — must be auditable.
+					log.info("🛂 Travel-rule deposit auto-declared", {
+						result: outcome.kind,
+						account: report.accountLabel,
+						tranId: outcome.deposit.tranId,
+						coin: outcome.deposit.coin,
+						amount: outcome.deposit.amount,
+						network: outcome.deposit.network,
+						txId: outcome.deposit.txId,
+						originator: outcome.sender,
+					});
+					void metrics?.recordCounter(
+						"travel_rule_deposit_submissions_total",
+						1,
+						{
+							...base,
+							coin: outcome.deposit.coin,
+							result: outcome.kind,
+						},
+					);
+					break;
+				}
+				case "undeclared-origin":
+					log.warn(
+						"🛂 Travel-rule deposit from UNDECLARED originator — left frozen",
+						{
+							account: report.accountLabel,
+							tranId: outcome.deposit.tranId,
+							coin: outcome.deposit.coin,
+							amount: outcome.deposit.amount,
+							sender: outcome.sender,
+						},
+					);
+					void metrics?.recordCounter(
+						"travel_rule_deposit_anomalies_total",
+						1,
+						{
+							...base,
+							reason: "undeclared_origin",
+						},
+					);
+					break;
+				case "unproven-origin":
+					log.warn(
+						"🛂 Travel-rule deposit origin UNPROVEN (tx sender unresolved) — left frozen",
+						{
+							account: report.accountLabel,
+							tranId: outcome.deposit.tranId,
+							coin: outcome.deposit.coin,
+							network: outcome.deposit.network,
+							txId: outcome.deposit.txId,
+						},
+					);
+					void metrics?.recordCounter(
+						"travel_rule_deposit_anomalies_total",
+						1,
+						{
+							...base,
+							reason: "unproven_origin",
+						},
+					);
+					break;
+				case "entity-drift":
+					log.warn(
+						"🛂 Travel-rule deposit skipped — questionnaire entity is not the expected country",
+						{
+							account: report.accountLabel,
+							tranId: outcome.deposit.tranId,
+							observedCountry: outcome.country,
+							expectedCountry: this.params.config.expectedQuestionnaireCountry,
+						},
+					);
+					void metrics?.recordCounter(
+						"travel_rule_deposit_anomalies_total",
+						1,
+						{
+							...base,
+							reason: "entity_drift",
+						},
+					);
+					break;
+				case "failed-terminal":
+					log.warn(
+						"🛂 Travel-rule deposit is FAILED (terminal) — needs manual handling",
+						{
+							account: report.accountLabel,
+							tranId: outcome.deposit.tranId,
+							coin: outcome.deposit.coin,
+						},
+					);
+					void metrics?.recordCounter(
+						"travel_rule_deposit_anomalies_total",
+						1,
+						{
+							...base,
+							reason: "failed_status",
+						},
+					);
+					break;
+				case "submit-error":
+					log.error("🛂 Travel-rule deposit provide-info failed", {
+						account: report.accountLabel,
+						tranId: outcome.deposit.tranId,
+						error: outcome.error,
+					});
+					void metrics?.recordCounter(
+						"travel_rule_deposit_anomalies_total",
+						1,
+						{
+							...base,
+							reason: "submit_error",
+						},
+					);
+					break;
+				case "poll-error":
+					log.error("🛂 Travel-rule deposit history poll failed", {
+						account: report.accountLabel,
+						error: outcome.error,
+					});
+					void metrics?.recordCounter(
+						"travel_rule_deposit_anomalies_total",
+						1,
+						{
+							...base,
+							reason: "poll_error",
+						},
+					);
+					break;
+			}
+		}
+	}
+}

--- a/src/helpers/travel-rule.ts
+++ b/src/helpers/travel-rule.ts
@@ -1,6 +1,11 @@
 import type { Dict, Exchange } from "@usherlabs/ccxt";
 import Joi from "joi";
-import type { PolicyConfig, TravelRuleQuestionnaire } from "../types";
+import type {
+	PolicyConfig,
+	TravelRuleDepositConfig,
+	TravelRuleDepositQuestionnaire,
+	TravelRuleQuestionnaire,
+} from "../types";
 
 /**
  * Binance travel-rule ("local entity") withdrawal support.
@@ -126,6 +131,102 @@ export function registerBinanceTravelRuleWithdrawEndpoint(
 	// by all sapi private POSTs, so no ccxt fork change is needed.
 	exchange.defineRestApi(
 		{ sapi: { post: { "localentity/withdraw/apply": 4.0002 } } },
+		"request",
+	);
+}
+
+// -----------------------------------------------------------------------------
+// Deposit side: auto-clearing travel-rule-frozen deposits.
+//
+// The AUSTRAC travel rule also freezes INBOUND deposits: Binance credits the
+// deposit but holds it in `getUserAsset.freeze` (invisible to free+locked
+// balances) until a per-deposit questionnaire is answered via
+// `PUT /sapi/v1/localentity/deposit/provide-info`. Unlike the withdraw leg the
+// answer is keyed by the on-chain SENDER, not a static destination, so a deposit
+// is only auto-declared when its sender is PROVEN (on-chain) to be one of our
+// configured originator wallets. See travel-rule-deposit-reconciler.ts.
+// -----------------------------------------------------------------------------
+
+// Australia DEPOSIT questionnaire. Distinct shape from the withdraw schema
+// (`depositOriginator`/`receiveFrom` vs `isAddressOwner`/`sendTo`). Restricted
+// to the self-owned case (value 1) because that is the only case the reconciler
+// can attest: it declares a deposit only after proving the sender is our own
+// wallet. Declaring a third-party origin (value 2) would require beneficiary
+// identity fields we do not carry, so reject it at policy-load rather than
+// silently submit an incomplete questionnaire. Unknown keys are rejected by
+// Joi's default so a copy-paste of the withdraw questionnaire fails fast.
+export const australiaDepositQuestionnaireSchema = Joi.object({
+	depositOriginator: Joi.number().valid(1).required(),
+	receiveFrom: Joi.number().valid(1).required(),
+	// Binance requires an affirmative declaration; false can never clear a deposit.
+	declaration: Joi.boolean().valid(true).required(),
+});
+
+/**
+ * Returns the enabled deposit travel-rule config for an exchange, or null when
+ * the feature is absent or disabled. Gated solely by `deposits.enabled` (not the
+ * entry's withdraw `enabled` flag): when null the reconciler does nothing for the
+ * exchange, preserving exact pre-feature behavior.
+ */
+export function getEnabledTravelRuleDepositConfig(
+	policy: PolicyConfig,
+	exchange: string,
+): TravelRuleDepositConfig | null {
+	const rules = policy.travelRule?.rule ?? [];
+	const exchangeNorm = exchange.trim().toUpperCase();
+	const entry = rules.find(
+		(rule) => rule.exchange.trim().toUpperCase() === exchangeNorm,
+	);
+	const deposits = entry?.deposits;
+	if (!deposits || !deposits.enabled) {
+		return null;
+	}
+	return deposits;
+}
+
+/**
+ * Looks up the questionnaire for a PROVEN on-chain sender. Matching is
+ * case-insensitive. Returns null when the sender is not a declared originator —
+ * the reconciler must then leave the deposit frozen and surface an anomaly
+ * rather than attest an origin it cannot prove is ours.
+ */
+export function resolveDepositOriginatorQuestionnaire(
+	config: TravelRuleDepositConfig,
+	senderAddress: string,
+): TravelRuleDepositQuestionnaire | null {
+	const senderNorm = senderAddress.trim().toLowerCase();
+	const match = Object.entries(config.originators).find(
+		([address]) => address.trim().toLowerCase() === senderNorm,
+	);
+	return match ? match[1].questionnaire : null;
+}
+
+/**
+ * Registers Binance's localentity deposit endpoints used by the reconciler:
+ * the two read endpoints (deposit history + questionnaire requirements) and the
+ * provide-info write. No-op for non-Binance exchanges. Idempotent.
+ *
+ * `localentity/deposit/provide-info` must be signed with the questionnaire JSON
+ * RAW (unencoded) — see the @usherlabs/ccxt patch (`binance.sign` rawencode
+ * branch). Signing it url-encoded yields Binance error -1022. The two GETs carry
+ * only simple params and sign fine either way.
+ */
+export function registerBinanceTravelRuleDepositEndpoints(
+	exchange: Exchange,
+): void {
+	if (exchange.id !== "binance") {
+		return;
+	}
+	exchange.defineRestApi(
+		{
+			sapi: {
+				get: {
+					"localentity/deposit/history": 1,
+					"localentity/questionnaire-requirements": 1,
+				},
+				put: { "localentity/deposit/provide-info": 1 },
+			},
+		},
 		"request",
 	);
 }

--- a/src/helpers/travel-rule.ts
+++ b/src/helpers/travel-rule.ts
@@ -210,6 +210,11 @@ export function resolveDepositOriginatorQuestionnaire(
  * RAW (unencoded) — see the @usherlabs/ccxt patch (`binance.sign` rawencode
  * branch). Signing it url-encoded yields Binance error -1022. The two GETs carry
  * only simple params and sign fine either way.
+ *
+ * provide-info is a 600-weight UID-limited write (same class as
+ * capital/withdraw/apply), so it carries ccxt-binance's `4.0002` cost encoding
+ * (`.0002` = charge the UID limiter) rather than a naive `1`, which would
+ * under-throttle the write and invite -1003 once attestation is active.
  */
 export function registerBinanceTravelRuleDepositEndpoints(
 	exchange: Exchange,
@@ -224,7 +229,7 @@ export function registerBinanceTravelRuleDepositEndpoints(
 					"localentity/deposit/history": 1,
 					"localentity/questionnaire-requirements": 1,
 				},
-				put: { "localentity/deposit/provide-info": 1 },
+				put: { "localentity/deposit/provide-info": 4.0002 },
 			},
 		},
 		"request",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ import {
 	type BrokerPoolEntry,
 	createBrokerPool,
 	loadPolicy,
+	loadTravelRuleDepositReconcilerConfigFromEnv,
 	normalizePolicyConfig,
+	TravelRuleDepositReconciler,
 } from "./helpers";
 import { log } from "./helpers/logger";
 import {
@@ -44,6 +46,7 @@ export default class CEXBroker {
 	private useVerity: boolean = false;
 	private otelMetrics?: OtelMetrics;
 	private otelLogs?: OtelLogs;
+	private depositReconciler?: TravelRuleDepositReconciler;
 
 	/**
 	 * Loads environment variables prefixed with CEX_BROKER_
@@ -257,6 +260,10 @@ export default class CEXBroker {
 			unwatchFile(this.#policyFilePath);
 			log.info(`Stopped watching policy file: ${this.#policyFilePath}`);
 		}
+		if (this.depositReconciler) {
+			this.depositReconciler.stop();
+			this.depositReconciler = undefined;
+		}
 		if (this.server) {
 			await this.server.forceShutdown();
 		}
@@ -274,6 +281,12 @@ export default class CEXBroker {
 	public async run(): Promise<CEXBroker> {
 		if (this.server) {
 			await this.server.forceShutdown();
+		}
+		// run() is re-invoked on policy hot-reload; tear down the prior reconciler so
+		// it is rebuilt against the updated policy rather than duplicated.
+		if (this.depositReconciler) {
+			this.depositReconciler.stop();
+			this.depositReconciler = undefined;
 		}
 		log.info(`Running CEXBroker at ${new Date().toISOString()}`);
 
@@ -302,6 +315,17 @@ export default class CEXBroker {
 				log.info(`Your server as started on port ${port}`);
 			},
 		);
+
+		// Start the travel-rule deposit auto-clear reconciler. It self-disables when
+		// no exchange has `travelRule.rule[].deposits.enabled` in policy, so this is a
+		// no-op (exact current behavior) unless the feature is turned on.
+		this.depositReconciler = new TravelRuleDepositReconciler({
+			policy: this.policy,
+			brokers: this.brokers,
+			config: loadTravelRuleDepositReconcilerConfigFromEnv(process.env),
+			metrics: this.otelMetrics,
+		});
+		this.depositReconciler.start();
 		return this;
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,38 @@ export type TravelRuleAddressEntry = {
 	questionnaire: TravelRuleQuestionnaire;
 };
 
+// Binance travel-rule DEPOSIT questionnaire answers (Australia). This is a
+// DIFFERENT shape from the withdraw questionnaire: it uses
+// `depositOriginator`/`receiveFrom` rather than `isAddressOwner`/`sendTo`. Only
+// the self-owned case is exercised by the auto-clear reconciler (which only ever
+// declares deposits provably sent from our own configured wallets); the proven
+// answer for that case is { depositOriginator: 1, receiveFrom: 1, declaration:
+// true }. Validated at policy-load by australiaDepositQuestionnaireSchema.
+export type TravelRuleDepositQuestionnaire = {
+	depositOriginator: number;
+	receiveFrom: number;
+	declaration: boolean;
+};
+
+export type TravelRuleDepositOriginatorEntry = {
+	questionnaire: TravelRuleDepositQuestionnaire;
+};
+
+// Deposit-side travel-rule config, nested under a TravelRuleEntry. Absent or
+// `enabled: false` means the deposit auto-clear reconciler does nothing for the
+// exchange — byte-identical to the pre-feature behavior.
+export type TravelRuleDepositConfig = {
+	enabled: boolean;
+	// Free-text note documenting intent (e.g. that keys are SENDERS, and how to add
+	// a new funding wallet). Ignored by the runtime.
+	description?: string;
+	// Keyed by the on-chain SENDER (originator) address. A travel-rule-frozen
+	// deposit is auto-declared only when its PROVEN on-chain sender matches one of
+	// these entries; matching is case-insensitive. A deposit from any other sender
+	// is left frozen and surfaced — never auto-attested.
+	originators: Record<string, TravelRuleDepositOriginatorEntry>;
+};
+
 export type TravelRuleEntry = {
 	exchange: string;
 	// Opt-in switch: only when true are withdrawals for this exchange routed
@@ -59,6 +91,10 @@ export type TravelRuleEntry = {
 	// Keyed by destination address; the questionnaire is resolved on demand at
 	// withdraw time. Matching is case-insensitive.
 	addresses: Record<string, TravelRuleAddressEntry>;
+	// Deposit-side auto-clear config. Independent of `enabled` (which gates the
+	// withdraw leg only): the deposit reconciler is gated solely by
+	// `deposits.enabled` so the two legs can be toggled separately.
+	deposits?: TravelRuleDepositConfig;
 };
 
 export type PolicyConfig = {

--- a/test/travel-rule-deposit.test.ts
+++ b/test/travel-rule-deposit.test.ts
@@ -190,7 +190,7 @@ describe("registerBinanceTravelRuleDepositEndpoints", () => {
 							"localentity/deposit/history": 1,
 							"localentity/questionnaire-requirements": 1,
 						},
-						put: { "localentity/deposit/provide-info": 1 },
+						put: { "localentity/deposit/provide-info": 4.0002 },
 					},
 				},
 				"request",
@@ -293,6 +293,12 @@ describe("parseLocalEntityDeposit", () => {
 
 	test("returns null when the row has no tranId (wrong id space)", () => {
 		expect(parseLocalEntityDeposit({ coin: "USDC", amount: "1" })).toBeNull();
+	});
+
+	test("does NOT accept a generic `id` as the tranId", () => {
+		// `id` belongs to the capital/deposit/hisrec id space; provide-info rejects
+		// it. Only `tranId` is a valid provide-info identifier.
+		expect(parseLocalEntityDeposit({ id: "999", coin: "USDC" })).toBeNull();
 	});
 });
 
@@ -532,5 +538,23 @@ describe("reconcileAccountOnce", () => {
 		});
 		await reconcileAccountOnce(deps);
 		expect(historyCalls).toBe(0);
+	});
+
+	test("stops the candidate loop after a mid-loop rate-limit signal", async () => {
+		const secondFrozen = { ...FROZEN_DEPOSIT, tranId: "999999999" };
+		let submitCalls = 0;
+		const deps = baseDeps({
+			fetchDepositHistory: async () => [{ ...FROZEN_DEPOSIT }, secondFrozen],
+			submitProvideInfo: async () => {
+				submitCalls++;
+				throw new Error("binance -1003 Too many requests");
+			},
+		});
+		await reconcileAccountOnce(deps);
+		// First candidate trips the cooldown; the second must NOT be attempted.
+		expect(submitCalls).toBe(1);
+		expect(deps.state.rateLimitedUntil).toBe(
+			deps.now + deps.rateLimitCooldownMs,
+		);
 	});
 });

--- a/test/travel-rule-deposit.test.ts
+++ b/test/travel-rule-deposit.test.ts
@@ -1,0 +1,536 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import ccxt, { type Exchange } from "@usherlabs/ccxt";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+	australiaDepositQuestionnaireSchema,
+	getEnabledTravelRuleDepositConfig,
+	loadPolicy,
+	registerBinanceTravelRuleDepositEndpoints,
+	resolveDepositOriginatorQuestionnaire,
+} from "../src/helpers";
+import {
+	createAccountState,
+	loadTravelRuleDepositReconcilerConfigFromEnv,
+	parseLocalEntityDeposit,
+	type ReconcileAccountDeps,
+	reconcileAccountOnce,
+	resolveOnChainSender,
+} from "../src/helpers/travel-rule-deposit-reconciler";
+import type { PolicyConfig, TravelRuleDepositConfig } from "../src/types";
+
+const SELF_OWNED_DEPOSIT = {
+	depositOriginator: 1,
+	receiveFrom: 1,
+	declaration: true,
+};
+// Mixed-case in policy to exercise case-insensitive originator matching.
+const ORIGINATOR = "0xE64B2f840b54C906e8dA26E96DBC9904b3B7f95a";
+const ORIGINATOR_LOWER = ORIGINATOR.toLowerCase();
+const WITHDRAW_DEST = "0xC8319213172c3a608Fb13f570fC7DF5cdA4F84d1";
+
+function policyWithDeposit(
+	depositsEnabled: boolean,
+	withDeposits = true,
+): PolicyConfig {
+	return {
+		withdraw: {
+			rule: [
+				{
+					exchange: "BINANCE",
+					network: "ARBITRUM",
+					whitelist: [WITHDRAW_DEST],
+				},
+			],
+		},
+		deposit: {},
+		order: { rule: { markets: ["*"], limits: [] } },
+		travelRule: {
+			rule: [
+				{
+					exchange: "BINANCE",
+					enabled: true,
+					addresses: {
+						[WITHDRAW_DEST]: {
+							questionnaire: {
+								isAddressOwner: 1,
+								sendTo: 1,
+								declaration: true,
+							},
+						},
+					},
+					...(withDeposits && {
+						deposits: {
+							enabled: depositsEnabled,
+							originators: {
+								[ORIGINATOR]: { questionnaire: SELF_OWNED_DEPOSIT },
+							},
+						},
+					}),
+				},
+			],
+		},
+	};
+}
+
+describe("australiaDepositQuestionnaireSchema", () => {
+	test("accepts the self-owned deposit questionnaire", () => {
+		expect(
+			australiaDepositQuestionnaireSchema.validate(SELF_OWNED_DEPOSIT).error,
+		).toBeUndefined();
+	});
+
+	test("rejects a false declaration", () => {
+		const { error } = australiaDepositQuestionnaireSchema.validate({
+			depositOriginator: 1,
+			receiveFrom: 1,
+			declaration: false,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("rejects a missing declaration", () => {
+		const { error } = australiaDepositQuestionnaireSchema.validate({
+			depositOriginator: 1,
+			receiveFrom: 1,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("rejects a non-self depositOriginator (needs identity fields we lack)", () => {
+		const { error } = australiaDepositQuestionnaireSchema.validate({
+			depositOriginator: 2,
+			receiveFrom: 1,
+			declaration: true,
+		});
+		expect(error).toBeDefined();
+	});
+
+	test("rejects the withdraw questionnaire shape (isAddressOwner/sendTo)", () => {
+		const { error } = australiaDepositQuestionnaireSchema.validate({
+			isAddressOwner: 1,
+			sendTo: 1,
+			declaration: true,
+		});
+		expect(error).toBeDefined();
+	});
+});
+
+describe("getEnabledTravelRuleDepositConfig", () => {
+	test("returns null when there is no travel-rule section", () => {
+		const policy: PolicyConfig = {
+			withdraw: { rule: [] },
+			deposit: {},
+			order: { rule: { markets: [], limits: [] } },
+		};
+		expect(getEnabledTravelRuleDepositConfig(policy, "BINANCE")).toBeNull();
+	});
+
+	test("returns null when the deposits block is absent", () => {
+		expect(
+			getEnabledTravelRuleDepositConfig(
+				policyWithDeposit(true, false),
+				"BINANCE",
+			),
+		).toBeNull();
+	});
+
+	test("returns null when deposits are disabled", () => {
+		expect(
+			getEnabledTravelRuleDepositConfig(policyWithDeposit(false), "BINANCE"),
+		).toBeNull();
+	});
+
+	test("returns the config when enabled (case-insensitive exchange)", () => {
+		const config = getEnabledTravelRuleDepositConfig(
+			policyWithDeposit(true),
+			"binance",
+		);
+		expect(config?.enabled).toBe(true);
+		expect(config?.originators[ORIGINATOR]).toBeDefined();
+	});
+});
+
+describe("resolveDepositOriginatorQuestionnaire", () => {
+	const config: TravelRuleDepositConfig = {
+		enabled: true,
+		originators: { [ORIGINATOR]: { questionnaire: SELF_OWNED_DEPOSIT } },
+	};
+
+	test("matches a declared originator case-insensitively", () => {
+		expect(
+			resolveDepositOriginatorQuestionnaire(config, ORIGINATOR_LOWER),
+		).toEqual(SELF_OWNED_DEPOSIT);
+	});
+
+	test("returns null for an undeclared sender", () => {
+		expect(
+			resolveDepositOriginatorQuestionnaire(
+				config,
+				"0x0000000000000000000000000000000000000000",
+			),
+		).toBeNull();
+	});
+});
+
+describe("registerBinanceTravelRuleDepositEndpoints", () => {
+	test("registers the three localentity endpoints on Binance", () => {
+		const calls: unknown[][] = [];
+		const exchange = {
+			id: "binance",
+			defineRestApi: (...args: unknown[]) => calls.push(args),
+		} as unknown as Exchange;
+		registerBinanceTravelRuleDepositEndpoints(exchange);
+		expect(calls).toEqual([
+			[
+				{
+					sapi: {
+						get: {
+							"localentity/deposit/history": 1,
+							"localentity/questionnaire-requirements": 1,
+						},
+						put: { "localentity/deposit/provide-info": 1 },
+					},
+				},
+				"request",
+			],
+		]);
+	});
+
+	test("is a no-op for non-Binance exchanges", () => {
+		const calls: unknown[][] = [];
+		const exchange = {
+			id: "bybit",
+			defineRestApi: (...args: unknown[]) => calls.push(args),
+		} as unknown as Exchange;
+		registerBinanceTravelRuleDepositEndpoints(exchange);
+		expect(calls).toEqual([]);
+	});
+});
+
+describe("loadPolicy deposit travel-rule validation", () => {
+	function writeTempPolicy(policy: unknown): string {
+		const tempPath = path.join(
+			os.tmpdir(),
+			`policy-deposit-${Date.now()}-${Math.random()}.json`,
+		);
+		fs.writeFileSync(tempPath, JSON.stringify(policy));
+		return tempPath;
+	}
+
+	test("loads a policy with a valid deposits block", () => {
+		const tempPath = writeTempPolicy(policyWithDeposit(true));
+		try {
+			const policy = loadPolicy(tempPath);
+			const deposits = policy.travelRule?.rule[0]?.deposits;
+			expect(deposits?.enabled).toBe(true);
+			expect(deposits?.originators[ORIGINATOR]?.questionnaire).toEqual(
+				SELF_OWNED_DEPOSIT,
+			);
+		} finally {
+			fs.unlinkSync(tempPath);
+		}
+	});
+
+	test("rejects a deposits block whose questionnaire is the withdraw shape", () => {
+		const bad = policyWithDeposit(true);
+		// biome-ignore lint/suspicious/noExplicitAny: intentionally invalid config
+		(bad.travelRule as any).rule[0].deposits.originators[
+			ORIGINATOR
+		].questionnaire = { isAddressOwner: 1, sendTo: 1, declaration: true };
+		const tempPath = writeTempPolicy(bad);
+		try {
+			expect(() => loadPolicy(tempPath)).toThrow();
+		} finally {
+			fs.unlinkSync(tempPath);
+		}
+	});
+});
+
+describe("binance localentity deposit provide-info signing (ccxt patch)", () => {
+	// Guards the @usherlabs/ccxt patch: provide-info must sign the questionnaire
+	// with rawencode (raw JSON). urlencode percent-encodes the JSON and Binance
+	// rejects it with -1022. This uses the real ccxt so it fails if the patch is
+	// ever dropped on a version bump (edge case 11).
+	test("signs the questionnaire raw, not percent-encoded, on the PUT", () => {
+		const exchange = new ccxt.binance({ apiKey: "k", secret: "s" });
+		const params = {
+			tranId: "387083631169",
+			questionnaire: JSON.stringify(SELF_OWNED_DEPOSIT),
+		};
+		const signed = exchange.sign(
+			"localentity/deposit/provide-info",
+			"sapi",
+			"PUT",
+			params,
+		);
+		const body = String(signed.body ?? "");
+		expect(body).toContain('questionnaire={"depositOriginator":1');
+		expect(body).not.toContain("questionnaire=%7B");
+	});
+});
+
+describe("parseLocalEntityDeposit", () => {
+	test("parses a frozen deposit row", () => {
+		const parsed = parseLocalEntityDeposit({
+			tranId: 387083631169,
+			coin: "USDC",
+			amount: "1",
+			network: "ARBITRUM",
+			txId: `0x${"a".repeat(64)}`,
+			travelRuleStatusV2: "PENDING",
+			requireQuestionnaire: true,
+		});
+		expect(parsed).toMatchObject({
+			tranId: "387083631169",
+			coin: "USDC",
+			network: "ARBITRUM",
+			travelRuleStatus: "PENDING",
+			requireQuestionnaire: true,
+		});
+	});
+
+	test("returns null when the row has no tranId (wrong id space)", () => {
+		expect(parseLocalEntityDeposit({ coin: "USDC", amount: "1" })).toBeNull();
+	});
+});
+
+describe("resolveOnChainSender", () => {
+	const originalFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	const HASH = `0x${"b".repeat(64)}`;
+
+	test("returns the lowercased tx.from", async () => {
+		globalThis.fetch = (async () =>
+			new Response(
+				JSON.stringify({ result: { from: ORIGINATOR } }),
+			)) as typeof fetch;
+		expect(await resolveOnChainSender("http://rpc", HASH)).toBe(
+			ORIGINATOR_LOWER,
+		);
+	});
+
+	test("returns null when the tx is not found (result null)", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ result: null }))) as typeof fetch;
+		expect(await resolveOnChainSender("http://rpc", HASH)).toBeNull();
+	});
+
+	test("returns null (no RPC call) for a malformed tx hash", async () => {
+		let called = false;
+		globalThis.fetch = (async () => {
+			called = true;
+			return new Response("{}");
+		}) as typeof fetch;
+		expect(await resolveOnChainSender("http://rpc", "not-a-hash")).toBeNull();
+		expect(called).toBe(false);
+	});
+});
+
+describe("loadTravelRuleDepositReconcilerConfigFromEnv", () => {
+	test("parses per-network RPC URLs and applies defaults", () => {
+		const config = loadTravelRuleDepositReconcilerConfigFromEnv({
+			TRAVEL_RULE_RPC_URL_ARBITRUM: "http://arb-rpc",
+			OTHER: "ignored",
+		});
+		expect(config.rpcUrlsByNetwork).toEqual({ ARBITRUM: "http://arb-rpc" });
+		expect(config.expectedQuestionnaireCountry).toBe("AU");
+		expect(config.pollIntervalActiveMs).toBe(60_000);
+	});
+
+	test("honors cadence and country overrides", () => {
+		const config = loadTravelRuleDepositReconcilerConfigFromEnv({
+			TRAVEL_RULE_DEPOSIT_POLL_ACTIVE_SECS: "30",
+			TRAVEL_RULE_QUESTIONNAIRE_COUNTRY: "au",
+		});
+		expect(config.pollIntervalActiveMs).toBe(30_000);
+		expect(config.expectedQuestionnaireCountry).toBe("AU");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reconcileAccountOnce — the compliance-critical core
+// ---------------------------------------------------------------------------
+
+const FROZEN_DEPOSIT = {
+	tranId: "387083631169",
+	coin: "USDC",
+	amount: "1",
+	network: "ARBITRUM",
+	txId: `0x${"a".repeat(64)}`,
+	travelRuleStatusV2: "PENDING",
+	requireQuestionnaire: true,
+};
+
+function baseDeps(
+	overrides: Partial<ReconcileAccountDeps> = {},
+): ReconcileAccountDeps {
+	return {
+		accountLabel: "binance:secondary:1",
+		depositConfig: {
+			enabled: true,
+			originators: { [ORIGINATOR]: { questionnaire: SELF_OWNED_DEPOSIT } },
+		},
+		expectedCountry: "AU",
+		failureBackoffMs: 900_000,
+		rateLimitCooldownMs: 300_000,
+		now: 1_000_000,
+		state: createAccountState(),
+		fetchDepositHistory: async () => [{ ...FROZEN_DEPOSIT }],
+		fetchQuestionnaireCountry: async () => "AU",
+		resolveSender: async () => ORIGINATOR_LOWER,
+		submitProvideInfo: async () => ({ accepted: true }),
+		resolveQuestionnaire: resolveDepositOriginatorQuestionnaire,
+		...overrides,
+	};
+}
+
+describe("reconcileAccountOnce", () => {
+	test("submits provide-info for a declared-originator frozen deposit", async () => {
+		let submitCalls = 0;
+		const deps = baseDeps({
+			submitProvideInfo: async () => {
+				submitCalls++;
+				return { accepted: true };
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(submitCalls).toBe(1);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["submitted"]);
+		expect(deps.state.submittedTranIds.has(FROZEN_DEPOSIT.tranId)).toBe(true);
+	});
+
+	test("does not re-submit an already-submitted deposit on the next cycle", async () => {
+		let submitCalls = 0;
+		const deps = baseDeps({
+			submitProvideInfo: async () => {
+				submitCalls++;
+				return { accepted: true };
+			},
+		});
+		await reconcileAccountOnce(deps);
+		const second = await reconcileAccountOnce(deps);
+		expect(submitCalls).toBe(1);
+		expect(second.hadActionableWork).toBe(false);
+		// Still counted as frozen until Binance releases it asynchronously.
+		expect(second.frozenDeposits).toHaveLength(1);
+	});
+
+	test("NEVER submits when the origin is undeclared", async () => {
+		let submitCalls = 0;
+		const deps = baseDeps({
+			resolveSender: async () => "0x000000000000000000000000000000000000dead",
+			submitProvideInfo: async () => {
+				submitCalls++;
+				return { accepted: true };
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(submitCalls).toBe(0);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["undeclared-origin"]);
+		expect(deps.state.backoffUntil.has(FROZEN_DEPOSIT.tranId)).toBe(true);
+	});
+
+	test("NEVER submits when the on-chain sender is unresolved", async () => {
+		let submitCalls = 0;
+		const deps = baseDeps({
+			resolveSender: async () => null,
+			submitProvideInfo: async () => {
+				submitCalls++;
+				return { accepted: true };
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(submitCalls).toBe(0);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["unproven-origin"]);
+	});
+
+	test("NEVER submits when the entity country is not the expected one", async () => {
+		let submitCalls = 0;
+		const deps = baseDeps({
+			fetchQuestionnaireCountry: async () => "DE",
+			submitProvideInfo: async () => {
+				submitCalls++;
+				return { accepted: true };
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(submitCalls).toBe(0);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["entity-drift"]);
+	});
+
+	test("treats an 'already provided' error as idempotent success", async () => {
+		const deps = baseDeps({
+			submitProvideInfo: async () => {
+				throw new Error("Questionnaire already provided for this deposit");
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["already-provided"]);
+		expect(deps.state.submittedTranIds.has(FROZEN_DEPOSIT.tranId)).toBe(true);
+	});
+
+	test("backs off (does not mark submitted) on a content rejection", async () => {
+		const deps = baseDeps({
+			submitProvideInfo: async () => ({
+				accepted: false,
+				msg: "Questionnaire format not valid",
+			}),
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["submit-error"]);
+		expect(deps.state.submittedTranIds.has(FROZEN_DEPOSIT.tranId)).toBe(false);
+		expect(deps.state.backoffUntil.get(FROZEN_DEPOSIT.tranId)).toBe(
+			deps.now + deps.failureBackoffMs,
+		);
+	});
+
+	test("surfaces a FAILED deposit as terminal and never submits it", async () => {
+		let submitCalls = 0;
+		const deps = baseDeps({
+			fetchDepositHistory: async () => [
+				{ ...FROZEN_DEPOSIT, travelRuleStatusV2: "FAILED" },
+			],
+			submitProvideInfo: async () => {
+				submitCalls++;
+				return { accepted: true };
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(submitCalls).toBe(0);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["failed-terminal"]);
+	});
+
+	test("enters an account-wide cooldown on a rate-limit poll error", async () => {
+		const deps = baseDeps({
+			fetchDepositHistory: async () => {
+				throw new Error("binance -1003 Too many requests");
+			},
+		});
+		const report = await reconcileAccountOnce(deps);
+		expect(report.outcomes.map((o) => o.kind)).toEqual(["poll-error"]);
+		expect(deps.state.rateLimitedUntil).toBe(
+			deps.now + deps.rateLimitCooldownMs,
+		);
+	});
+
+	test("skips entirely while inside the rate-limit cooldown", async () => {
+		let historyCalls = 0;
+		const state = createAccountState();
+		state.rateLimitedUntil = 2_000_000;
+		const deps = baseDeps({
+			state,
+			now: 1_500_000,
+			fetchDepositHistory: async () => {
+				historyCalls++;
+				return [];
+			},
+		});
+		await reconcileAccountOnce(deps);
+		expect(historyCalls).toBe(0);
+	});
+});


### PR DESCRIPTION
## Why

AUSTRAC's travel rule (live 2026-07-01) freezes **inbound** Binance deposits too: the deposit is credited but held in `getUserAsset.freeze` — invisible to the `free`+`locked` balances that `FetchBalances`, the maker, HB lanes, and diagnostics read, so the capital looks *gone*. The maker's funding churn (master-withdraw → owner wallet → sub-redeposit) re-freezes capital **every cycle**. The withdraw leg was solved in v0.2.15/v0.2.16 (#51, #52); this adds the deposit counterpart.

## What

A broker-internal **origin-proved reconciler** that auto-answers the deposit questionnaire so churn-frozen capital self-releases within minutes — policy-driven and fail-closed.

- Polls `GET /sapi/v1/localentity/deposit/history` for `requireQuestionnaire && travelRuleStatusV2=PENDING`, and submits `PUT /sapi/v1/localentity/deposit/provide-info` **only** when a deposit's on-chain sender (`eth_getTransactionByHash().from`, via a configured RPC) is a policy-declared originator.
- **Compliance invariant:** undeclared origin, unresolvable sender, non-AU entity, and `FAILED` status all fail closed (skip + surface) — it never attests an origin it cannot prove is ours.
- `reconcileAccountOnce` is a pure core with all I/O injected, so these invariants are unit-tested without a network.

### Changes
- `src/helpers/travel-rule.ts` — `australiaDepositQuestionnaireSchema` (self-owned only; **distinct** shape from the withdraw questionnaire — `depositOriginator`/`receiveFrom` vs `isAddressOwner`/`sendTo` — so a copy-paste fails at policy-load), `getEnabledTravelRuleDepositConfig`, `resolveDepositOriginatorQuestionnaire`, `registerBinanceTravelRuleDepositEndpoints`.
- `src/helpers/travel-rule-deposit-reconciler.ts` (new) — reconciler + on-chain origin proof + env config. Idempotent by `tranId`, per-tranId backoff (no hot-loop on content errors), account-wide rate-limit cooldown, active 60s / idle 600s cadence, AU entity gate via `questionnaire-requirements`.
- **ccxt patch** extended: `localentity/deposit/provide-info` signs the questionnaire raw (else `-1022`), mirroring the withdraw fix. Guarded by a real-ccxt regression test.
- Wired into `applyCommonExchangeConfig` (endpoint registration) and `CEXBroker.run()`/`stop()` (lifecycle; restarts on policy hot-reload). **Self-disables** when no policy has `travelRule.rule[].deposits.enabled` → byte-identical current behavior.
- Observability: `travel_rule_frozen_deposits` gauge + `travel_rule_deposit_submissions_total` / `travel_rule_deposit_anomalies_total` counters; every submission audit-logged. Chose metrics over changing the `FetchBalances` gRPC contract.
- Bump to **0.2.17**; document `TRAVEL_RULE_RPC_URL_<NETWORK>` in `.env.sample`.

## Deploy note

`TRAVEL_RULE_RPC_URL_ARBITRUM` is deliberately **not** `CEX_BROKER_`-prefixed (the credential scan skips it), so under SGX it must be added to the Gramine manifest passthrough allowlist — done on the fiet-maker side.

## Tests

`bun test` — **327 pass, 0 fail**. New deposit-signing regression guards the ccxt patch across version bumps; existing withdraw regression still green. `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added travel-rule deposit auto-clear handling for Binance localentity deposits, including questionnaire-based submission.
  * Added configuration guidance for per-network RPC URLs, polling/idle timing overrides, and optional questionnaire country override.
  * Enabled separate deposit-side travel-rule settings from existing withdraw-side configuration.

* **Bug Fixes**
  * Improved fail-closed behavior for frozen deposits when deposit provenance, originator declaration, or required configuration is missing.
  * Added stricter startup validation for deposit questionnaire/config shape to prevent incorrect provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->