### PR TITLE
fix(deposit): enclave-safe on-chain sender proof via node:https (0.2.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",

--- a/src/helpers/travel-rule-deposit-reconciler.ts
+++ b/src/helpers/travel-rule-deposit-reconciler.ts
@@ -1,3 +1,5 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import type { Exchange } from "@usherlabs/ccxt";
 import type {
 	PolicyConfig,
@@ -105,47 +107,83 @@ const EVM_TX_HASH = /^0x[0-9a-fA-F]{64}$/;
  * churn (owner wallet → Binance via a direct ERC20 transfer) that equals the
  * token originator. A transfer routed through a contract could differ; hardening
  * to the ERC20 Transfer event's `from` is possible later if that case arises.
+ *
+ * Uses `node:https` rather than the global `fetch`: inside the Gramine SGX
+ * enclave undici (which backs global fetch) fails to establish outbound
+ * connections — the same failure mode as the enclave's dead Binance user-data
+ * WebSocket — while the ccxt HTTP path (node http/https) works. Using node's
+ * request keeps this on the transport that is proven to work in the enclave.
  */
-export async function resolveOnChainSender(
+export function resolveOnChainSender(
 	rpcUrl: string,
 	txHash: string,
 	timeoutMs = 10_000,
 ): Promise<string | null> {
-	if (!EVM_TX_HASH.test(txHash)) return null;
-	// Bound the request: a hung RPC would otherwise stall the whole reconciler
-	// tick (candidates are resolved sequentially) and block the next poll.
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), timeoutMs);
-	let response: Response;
-	try {
-		response = await fetch(rpcUrl, {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			signal: controller.signal,
-			body: JSON.stringify({
-				jsonrpc: "2.0",
-				id: 1,
-				method: "eth_getTransactionByHash",
-				params: [txHash],
-			}),
+	if (!EVM_TX_HASH.test(txHash)) return Promise.resolve(null);
+	const body = JSON.stringify({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "eth_getTransactionByHash",
+		params: [txHash],
+	});
+	const url = new URL(rpcUrl);
+	const doRequest = url.protocol === "http:" ? httpRequest : httpsRequest;
+	return new Promise<string | null>((resolve, reject) => {
+		const req = doRequest(
+			url,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"content-length": Buffer.byteLength(body),
+				},
+				// Bound the request: a hung RPC would otherwise stall the whole
+				// reconciler tick (candidates resolve sequentially) and block the next poll.
+				timeout: timeoutMs,
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on("data", (chunk) => chunks.push(chunk as Buffer));
+				res.on("end", () => {
+					const status = res.statusCode ?? 0;
+					if (status < 200 || status >= 300) {
+						reject(new Error(`travel_rule_rpc_http_${status}`));
+						return;
+					}
+					try {
+						const json = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+							result?: { from?: unknown } | null;
+							error?: unknown;
+						};
+						if (json.error) {
+							reject(
+								new Error(
+									`travel_rule_rpc_error: ${JSON.stringify(json.error)}`,
+								),
+							);
+							return;
+						}
+						const from = json.result?.from;
+						resolve(
+							typeof from === "string" && from.length > 0
+								? from.toLowerCase()
+								: null,
+						);
+					} catch (parseError) {
+						reject(
+							new Error(`travel_rule_rpc_parse_error: ${String(parseError)}`),
+						);
+					}
+				});
+			},
+		);
+		req.on("error", reject);
+		req.on("timeout", () => {
+			req.destroy(new Error("travel_rule_rpc_timeout"));
 		});
-	} finally {
-		clearTimeout(timeout);
-	}
-	if (!response.ok) {
-		throw new Error(`travel_rule_rpc_http_${response.status}`);
-	}
-	const json = (await response.json()) as {
-		result?: { from?: unknown } | null;
-		error?: unknown;
-	};
-	if (json.error) {
-		throw new Error(`travel_rule_rpc_error: ${JSON.stringify(json.error)}`);
-	}
-	const from = json.result?.from;
-	return typeof from === "string" && from.length > 0
-		? from.toLowerCase()
-		: null;
+		req.write(body);
+		req.end();
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -227,7 +265,7 @@ export type ReconcileOutcome =
 	| { kind: "submitted"; deposit: LocalEntityDeposit; sender: string }
 	| { kind: "already-provided"; deposit: LocalEntityDeposit; sender: string }
 	| { kind: "undeclared-origin"; deposit: LocalEntityDeposit; sender: string }
-	| { kind: "unproven-origin"; deposit: LocalEntityDeposit }
+	| { kind: "unproven-origin"; deposit: LocalEntityDeposit; error?: string }
 	| {
 			kind: "entity-drift";
 			deposit: LocalEntityDeposit;
@@ -372,17 +410,22 @@ export async function reconcileAccountOnce(
 		// tick wait it out rather than compounding the -1003.
 		if (now < state.rateLimitedUntil) break;
 		let sender: string | null = null;
+		let resolveError: string | undefined;
 		try {
 			sender = await deps.resolveSender(deposit.network, deposit.txId);
 		} catch (error) {
 			sender = null;
+			// Capture the underlying RPC failure so the anomaly log distinguishes a
+			// real call failure (http/timeout/network) from a legitimately absent
+			// sender (no RPC configured, or tx not found).
+			resolveError = errorText(error);
 			if (isRateLimitError(error)) {
 				state.rateLimitedUntil = now + deps.rateLimitCooldownMs;
 			}
 		}
 		if (!sender) {
 			state.backoffUntil.set(deposit.tranId, now + deps.failureBackoffMs);
-			outcomes.push({ kind: "unproven-origin", deposit });
+			outcomes.push({ kind: "unproven-origin", deposit, error: resolveError });
 			continue;
 		}
 
@@ -771,6 +814,9 @@ export class TravelRuleDepositReconciler {
 							coin: outcome.deposit.coin,
 							network: outcome.deposit.network,
 							txId: outcome.deposit.txId,
+							// undefined when there was simply no RPC / tx not found; set when
+							// the RPC call itself failed (the reason it couldn't be proven).
+							rpcError: outcome.error ?? null,
 						},
 					);
 					void metrics?.recordCounter(

--- a/test/travel-rule-deposit.test.ts
+++ b/test/travel-rule-deposit.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import http from "node:http";
 import ccxt, { type Exchange } from "@usherlabs/ccxt";
 import fs from "fs";
 import os from "os";
@@ -303,37 +304,79 @@ describe("parseLocalEntityDeposit", () => {
 });
 
 describe("resolveOnChainSender", () => {
-	const originalFetch = globalThis.fetch;
-	afterEach(() => {
-		globalThis.fetch = originalFetch;
-	});
-
 	const HASH = `0x${"b".repeat(64)}`;
 
+	// Exercise the real node:http transport (the enclave-safe path) against a
+	// local server, rather than mocking global fetch which the function no
+	// longer uses.
+	function startRpc(responder: () => { status?: number; body: string }) {
+		const state = { calls: 0 };
+		const server = http.createServer((_req, res) => {
+			state.calls++;
+			const { status = 200, body } = responder();
+			res.writeHead(status, { "content-type": "application/json" });
+			res.end(body);
+		});
+		return new Promise<{
+			url: string;
+			state: { calls: number };
+			close: () => Promise<void>;
+		}>((resolve) => {
+			server.listen(0, "127.0.0.1", () => {
+				const addr = server.address();
+				const port = typeof addr === "object" && addr ? addr.port : 0;
+				resolve({
+					url: `http://127.0.0.1:${port}`,
+					state,
+					close: () => new Promise<void>((r) => server.close(() => r())),
+				});
+			});
+		});
+	}
+
 	test("returns the lowercased tx.from", async () => {
-		globalThis.fetch = (async () =>
-			new Response(
-				JSON.stringify({ result: { from: ORIGINATOR } }),
-			)) as typeof fetch;
-		expect(await resolveOnChainSender("http://rpc", HASH)).toBe(
-			ORIGINATOR_LOWER,
-		);
+		const rpc = await startRpc(() => ({
+			body: JSON.stringify({ result: { from: ORIGINATOR } }),
+		}));
+		try {
+			expect(await resolveOnChainSender(rpc.url, HASH)).toBe(ORIGINATOR_LOWER);
+		} finally {
+			await rpc.close();
+		}
 	});
 
 	test("returns null when the tx is not found (result null)", async () => {
-		globalThis.fetch = (async () =>
-			new Response(JSON.stringify({ result: null }))) as typeof fetch;
-		expect(await resolveOnChainSender("http://rpc", HASH)).toBeNull();
+		const rpc = await startRpc(() => ({
+			body: JSON.stringify({ result: null }),
+		}));
+		try {
+			expect(await resolveOnChainSender(rpc.url, HASH)).toBeNull();
+		} finally {
+			await rpc.close();
+		}
+	});
+
+	test("throws on an RPC error payload (becomes the surfaced unproven reason)", async () => {
+		const rpc = await startRpc(() => ({
+			body: JSON.stringify({ error: { code: -32000, message: "boom" } }),
+		}));
+		try {
+			await expect(resolveOnChainSender(rpc.url, HASH)).rejects.toThrow(
+				"travel_rule_rpc_error",
+			);
+		} finally {
+			await rpc.close();
+		}
 	});
 
 	test("returns null (no RPC call) for a malformed tx hash", async () => {
-		let called = false;
-		globalThis.fetch = (async () => {
-			called = true;
-			return new Response("{}");
-		}) as typeof fetch;
-		expect(await resolveOnChainSender("http://rpc", "not-a-hash")).toBeNull();
-		expect(called).toBe(false);
+		const rpc = await startRpc(() => ({ body: "{}" }));
+		try {
+			expect(await resolveOnChainSender(rpc.url, "not-a-hash")).toBeNull();
+			expect(rpc.state.calls).toBe(0);
+		} finally {
+			await rpc.close();
+		}
 	});
 });
 


### PR DESCRIPTION
## Why

rc25 (0.2.17) was deployed to prod eu-sgx. The deposit reconciler started, loaded the production policy, and **correctly identified frozen ARB deposits from the owner wallet on secondary:1** — but logged `origin UNPROVEN (tx sender unresolved) — left frozen`.

Diagnosis (all verified on prod):
- The RPC + endpoint are correct: a container on the same overlay network *and* an external host both get `tx.from = 0xe64b…95a` (our declared originator) for those exact txIds.
- It fails **only inside the Gramine SGX enclave**, fast (~2s). The broker's Binance REST calls work because ccxt uses node http/https; `resolveOnChainSender` used the global `fetch` (undici), which can't establish outbound connections in the enclave — the same failure mode as the enclave's long-known dead Binance user-data WebSocket.

The reconciler failed **closed** (left deposits frozen, no incorrect auto-declares), so this was safe — just non-functional for clearing.

## What

- **`resolveOnChainSender`**: rewritten off global `fetch` onto **`node:https`** (`node:http` for `http://`), the transport ccxt already uses successfully in-enclave. Semantics preserved: `null` on malformed hash / tx-not-found, throws on http/rpc/timeout/network error, request bounded by the timeout.
- **`reconcileAccountOnce`**: the `resolveSender` error was previously swallowed; now captured onto the `unproven-origin` outcome and logged as `rpcError`, so a real call failure is distinguishable from a legitimately absent/not-found sender (closes the observability gap that made this hard to diagnose).
- **Tests**: `resolveOnChainSender` now runs against a real `node:http` server instead of mocking global fetch, plus an RPC-error-payload case. Full suite **330 pass**.
- Bump to **0.2.18**.

## Follow-up

After publish, fiet-maker bumps `^0.2.18` and cuts a new SGX rc for redeploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction sender resolution reliability, with clearer handling for failed or invalid RPC responses.
  * Added more useful error details when a deposit cannot be linked to a proven origin.
  * Updated reconciliation reporting to surface these errors in logs and alerts.

* **Chores**
  * Bumped the package version to `0.2.18`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->