### PR TITLE
fix(build): satisfy strict dts tsc pass blocking v0.2.19 publish

### DIFF
--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -196,10 +196,15 @@ export class BrokerExecutionArchiver {
 		if (this.flushInFlight) {
 			return this.flushInFlight;
 		}
-		this.flushInFlight = this.flushBatch().finally(() => {
-			this.flushInFlight = null;
-		});
-		return this.flushInFlight;
+		// flushBatch resolves a boolean the callers read directly; the in-flight
+		// handle only needs completion, so discard it to keep this a Promise<void>.
+		const inFlight = this.flushBatch()
+			.then(() => undefined)
+			.finally(() => {
+				this.flushInFlight = null;
+			});
+		this.flushInFlight = inFlight;
+		return inFlight;
 	}
 
 	async close(): Promise<void> {

--- a/src/helpers/market-data-archive/ohlcv-bar-tracker.ts
+++ b/src/helpers/market-data-archive/ohlcv-bar-tracker.ts
@@ -52,7 +52,7 @@ export function extractOhlcvBars(payload: unknown): ParsedOhlcvBar[] {
 
 export function extractLatestOhlcvBar(payload: unknown): ParsedOhlcvBar | null {
 	const bars = extractOhlcvBars(payload);
-	return bars.length > 0 ? bars[bars.length - 1] : null;
+	return bars[bars.length - 1] ?? null;
 }
 
 export class OhlcvBarTracker {
@@ -65,7 +65,8 @@ export class OhlcvBarTracker {
 			return [];
 		}
 		if (bars.length === 1) {
-			return this.processSingleBar(bars[0], brokerVersion);
+			const [bar] = bars;
+			return bar ? this.processSingleBar(bar, brokerVersion) : [];
 		}
 		return this.processBatch(bars, brokerVersion);
 	}
@@ -110,22 +111,26 @@ export class OhlcvBarTracker {
 		bars: ParsedOhlcvBar[],
 		brokerVersion: number,
 	): OhlcvArchiveCandidate[] {
+		const firstBar = bars[0];
+		const lastBar = bars[bars.length - 1];
+		if (!firstBar || !lastBar) {
+			return [];
+		}
+
 		if (
 			this.lastOpenTimeMs !== null &&
-			bars.length > 0 &&
-			bars[bars.length - 1].openTimeMs < this.lastOpenTimeMs
+			lastBar.openTimeMs < this.lastOpenTimeMs
 		) {
 			return [];
 		}
 
 		const candidates: OhlcvArchiveCandidate[] = [];
-		const lastBar = bars[bars.length - 1];
 
 		if (
 			this.lastBar !== null &&
 			this.lastOpenTimeMs !== null &&
 			!bars.some((bar) => bar.openTimeMs === this.lastOpenTimeMs) &&
-			this.lastOpenTimeMs < bars[0].openTimeMs
+			this.lastOpenTimeMs < firstBar.openTimeMs
 		) {
 			candidates.push({
 				bar: this.lastBar,
@@ -135,11 +140,14 @@ export class OhlcvBarTracker {
 		}
 
 		for (let index = 0; index < bars.length - 1; index += 1) {
-			candidates.push({
-				bar: bars[index],
-				isClosed: true,
-				brokerVersion,
-			});
+			const bar = bars[index];
+			if (bar) {
+				candidates.push({
+					bar,
+					isClosed: true,
+					brokerVersion,
+				});
+			}
 		}
 
 		candidates.push({

--- a/src/helpers/market-data-archive/orderbook-depth.ts
+++ b/src/helpers/market-data-archive/orderbook-depth.ts
@@ -25,7 +25,12 @@ export function splitOrderBookSide(
 		}
 		const price = level[0];
 		const size = level[1];
-		if (!Number.isFinite(price) || !Number.isFinite(size)) {
+		if (
+			price === undefined ||
+			size === undefined ||
+			!Number.isFinite(price) ||
+			!Number.isFinite(size)
+		) {
 			continue;
 		}
 		prices.push(price);

--- a/src/helpers/market-data-archive/rows.ts
+++ b/src/helpers/market-data-archive/rows.ts
@@ -64,7 +64,12 @@ function topOfBookLevel(
 	}
 	const price = level[0];
 	const size = level[1];
-	if (!Number.isFinite(price) || !Number.isFinite(size)) {
+	if (
+		price === undefined ||
+		size === undefined ||
+		!Number.isFinite(price) ||
+		!Number.isFinite(size)
+	) {
 		return null;
 	}
 	return { price, size };


### PR DESCRIPTION
## Why

The npm publish workflow's `bun run build` runs dts-bundle-generator, which type-checks the sources under a stricter compiler config (notably `noUncheckedIndexedAccess`) than the PR CI gate (`biome lint .` + `bun test`). Several archive helpers failed that strict pass, so `bun run build` errored and **nothing on `develop` can publish** — the v0.2.19 release is blocked. PR CI never exercised this pass, so the errors landed unnoticed.

## Fixes (type-level only, no runtime behavior change)

- **`writer.ts` `flush()`** — `flushBatch()` resolves a `boolean` that callers read directly, but the in-flight handle field is `Promise<void> | null`. Map the handle to `Promise<void>` (`.then(() => undefined)`) and return the local promise so the field/return types are satisfied. The boolean is still consumed via the direct `await this.flushBatch()` in `close()`; the handle's resolved value was never read.
- **`ohlcv-bar-tracker.ts`** — under `noUncheckedIndexedAccess`, `bars[i]` is `ParsedOhlcvBar | undefined`. Guard the first/last/loop element accesses (narrow before use) instead of asserting. Dense arrays make the guards runtime no-ops.
- **`orderbook-depth.ts` / `rows.ts`** — narrow `level[0]` / `level[1]` out of `undefined` before pushing/returning them as `number` (they were already effectively guarded by `Number.isFinite`, which is not a type guard).

## Verification

- `bun run build` completes clean (dts bundle generated, exit 0).
- `bun test` — 385 pass / 0 fail (unchanged).
- `biome lint .` — exit 0.