### PR TITLE
chore(ci): gate PRs on the publish build + pin the archive wire contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Run tests
         run: bun test
+
+      # Gate PRs on the same strict build the publish workflow runs on tag push
+      # (dts-bundle-generator + strict tsc). Without this, develop can merge code
+      # that only fails at publish time, blocking releases.
+      - name: Build project
+        run: bun run build

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
 	},
 	"files": {
 		"ignoreUnknown": true,
-		"includes": ["src/**", "policy/**", "test/**", "scripts/**", "examples/**"],
+		"includes": [
+			"src/**",
+			"policy/**",
+			"test/**",
+			"scripts/**",
+			"examples/**",
+			"!test/fixtures/**"
+		],
 		"experimentalScannerIgnores": ["src/proto/**"]
 	},
 	"formatter": {

--- a/test/archive-forwarder-contract.test.ts
+++ b/test/archive-forwarder-contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parseArchiveBatchRequest } from "../services/archive-forwarder/router";
+import { isSupportedTable } from "../services/archive-forwarder/types";
+
+// Golden envelope authored by the HB-runtime ArchiveEmitter (fiet-maker:
+// packages/hb-maker-shared/tests/fixtures/archive_forwarder_envelope.json) and
+// copied here byte-for-byte. It pins the cross-repo wire contract: the emitter
+// produces this shape and this forwarder must accept it. The contract was
+// broken once (emitter sent flat rows -> every strategy_data batch 400'd), so a
+// drift on either side must break a test in both repos.
+const fixture = JSON.parse(
+	readFileSync(
+		path.join(import.meta.dir, "fixtures", "archive_forwarder_envelope.json"),
+		"utf-8",
+	),
+) as unknown;
+
+describe("archive forwarder wire contract (shared golden fixture)", () => {
+	test("parseArchiveBatchRequest accepts the emitter envelope with no rejected rows", () => {
+		const parsed = parseArchiveBatchRequest(fixture);
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) {
+			return;
+		}
+		expect(parsed.rejectedRowCount).toBe(0);
+		expect(parsed.inputRowCount).toBe(parsed.batch.rows.length);
+		expect(parsed.batch.source).toBe("hb_runtime");
+	});
+
+	test("every fixture row targets a supported table, covering all strategy_data tables", () => {
+		const parsed = parseArchiveBatchRequest(fixture);
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) {
+			return;
+		}
+
+		for (const row of parsed.batch.rows) {
+			expect(isSupportedTable(row.table)).toBe(true);
+		}
+		const tables = new Set(parsed.batch.rows.map((row) => row.table));
+		expect(tables).toEqual(
+			new Set([
+				"strategy_data.policy_evaluation_events",
+				"strategy_data.strategy_policy_snapshots",
+				"strategy_data.inventory_settlement_events",
+			]),
+		);
+	});
+});

--- a/test/fixtures/archive_forwarder_envelope.json
+++ b/test/fixtures/archive_forwarder_envelope.json
@@ -1,0 +1,73 @@
+{
+  "deployment_id": "arb-usdc-015",
+  "rows": [
+    {
+      "row": {
+        "connector_name": "fiet_cex",
+        "controller_id": "layer12-live-arb-usdc-015",
+        "controller_type": "layer12_live",
+        "decision_kind": "dex_lead",
+        "deployment_id": "arb-usdc-015",
+        "emitted_at_ms": 1720000000000,
+        "event_time_ms": 1719999999988,
+        "exchange": "binance",
+        "fidelity": "hb_runtime_policy_clock",
+        "lag_ms": 12,
+        "market_id": "arb-usdc-015",
+        "payload_json": "{\"execution_role\":\"dex_lead\",\"mid_price\":\"1.0234\"}",
+        "policy_epoch": "42",
+        "run_id": "run-2026-07-02T00-00-00Z",
+        "schema_version": "1",
+        "source": "hb_runtime",
+        "trading_pair": "ARB-USDC"
+      },
+      "table": "strategy_data.policy_evaluation_events"
+    },
+    {
+      "row": {
+        "config_file_path": "conf/controllers/layer12_live_arb_usdc_015.yml",
+        "connector_name": "fiet_cex",
+        "controller_id": "layer12-live-arb-usdc-015",
+        "controller_type": "layer12_live",
+        "deployment_id": "arb-usdc-015",
+        "emitted_at_ms": 1720000000000,
+        "event_time_ms": 1719999999995,
+        "exchange": "binance",
+        "market_id": "arb-usdc-015",
+        "payload_json": "{\"lower_tick_offset\":-60,\"position_type\":\"OffsetFromCurrent\",\"upper_tick_offset\":60}",
+        "policy_epoch": "42",
+        "run_id": "run-2026-07-02T00-00-00Z",
+        "schema_version": "1",
+        "snapshot_reason": "content_change",
+        "source": "hb_runtime",
+        "source_hash": "1ed025b4ae41b0865651beb829e16eb62119ecb867c5148858fbe4bfe35e547e",
+        "trading_pair": "ARB-USDC"
+      },
+      "table": "strategy_data.strategy_policy_snapshots"
+    },
+    {
+      "row": {
+        "account": "secondary:1",
+        "connector_name": "fiet_cex",
+        "controller_id": "layer12-live-arb-usdc-015",
+        "controller_type": "layer12_live",
+        "deployment_id": "arb-usdc-015",
+        "emitted_at_ms": 1720000000000,
+        "event_kind": "reservation_release",
+        "event_time_ms": 1719999999997,
+        "exchange": "binance",
+        "market_id": "arb-usdc-015",
+        "payload_json": "{\"amount\":\"99.81\",\"reason\":\"fill\"}",
+        "reservation_id": "resv-0001",
+        "run_id": "run-2026-07-02T00-00-00Z",
+        "schema_version": "1",
+        "source": "hb_runtime",
+        "token": "ARB",
+        "trading_pair": "ARB-USDC",
+        "workflow_state": "released"
+      },
+      "table": "strategy_data.inventory_settlement_events"
+    }
+  ],
+  "source": "hb_runtime"
+}


### PR DESCRIPTION
## Why

**PR CI did not gate the release build.** CI gated PRs on biome lint + `bun test`, but the strict publish build (`bun run build`: dts-bundle-generator + strict `tsc`, including `noUncheckedIndexedAccess`) ran only on tag push. develop merged code that passed `bun test` but failed the publish build, leaving develop unpublishable and breaking the v0.2.19 publish.

**The archive wire contract was unpinned.** The HB-runtime `ArchiveEmitter` (fiet-maker) POSTs `strategy_data` batches over the envelope contract `{source, deployment_id, rows:[{table, row:{columns}}]}`, consumed here by `parseArchiveBatchRequest`. That contract broke once (emitter sent flat rows, so every `strategy_data` batch 400'd). Nothing tied the accept side to a concrete emitter payload.

## What

- **CI build gate.** Added `bun run build` to PR CI (same bun version as the publish workflow) so the release build is exercised on every PR. Verified `bun run build` passes locally on this branch.
- **Accept-side contract test.** `test/fixtures/archive_forwarder_envelope.json` is the golden envelope authored by the real emitter in fiet-maker, copied here byte-for-byte. `test/archive-forwarder-contract.test.ts` asserts `parseArchiveBatchRequest(fixture)` accepts it with `rejectedRowCount === 0` and that every row targets a supported table, covering all three `strategy_data` tables. The fixture is excluded from biome (`!test/fixtures/**`) so it stays byte-identical with the authoring repo. Drift on either side now fails a test in both repos.

## Tests

- `bun test` — 387 passed, 0 failed.
- `bun run build` — passes.
- biome lint — clean (pre-existing warnings only); the shared fixture is excluded from the formatter.