### PR TITLE
ci(archive): publish the archive-forwarder image

### DIFF
--- a/.github/workflows/publish-archive-forwarder.yml
+++ b/.github/workflows/publish-archive-forwarder.yml
@@ -1,0 +1,57 @@
+# Publishes the archive-forwarder image (services/archive-forwarder).
+# The forwarder is repo-runtime only — it is NOT part of the npm package
+# (files: ["dist"]), so it ships as its own container image.
+#
+# Triggers: semver tags (alongside the broker publish) and manual dispatch
+# (to publish from a branch without cutting an npm release).
+
+name: Publish Archive Forwarder
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*-*'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/usherlabs/cex-broker-archive-forwarder
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=match,pattern=v(\d+\.\d+\.\d+.*),group=1
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/archive-forwarder/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
The archive-forwarder (`services/archive-forwarder`) has a Dockerfile since #55 but no CI job builds it — it is excluded from the npm package (`files: ["dist"]`), so the container image is its only distribution. This blocks the production deployment of the archive plane.

Adds `publish-archive-forwarder.yml`: builds `services/archive-forwarder/Dockerfile` from the repo root (schema/ in context) and pushes `ghcr.io/usherlabs/cex-broker-archive-forwarder` on semver tags (aligned with the broker publish) and on `workflow_dispatch` (so the image can be published from `develop` without cutting an npm release). Dockerfile build verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new release workflow to automatically build and publish the Archive Forwarder Docker image on version tag releases.
  * Enabled manual triggering for the same publishing process when needed.
  * Updated the workflow to sign in to the container registry and tag images consistently during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->