### PR TITLE
fix(archive): enclave-safe forwarder transport (undici WASM OOM in SGX)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.19",
+	"version": "0.2.20",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",

--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -1,3 +1,5 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { SeverityNumber } from "@opentelemetry/api-logs";
 import { log } from "../logger";
 import { isMarketArchiveTable } from "../market-data-archive/types";
@@ -322,40 +324,65 @@ export class BrokerExecutionArchiver {
 		}
 	}
 
-	private async postToForwarder(batch: BrokerArchiveRow[]): Promise<void> {
+	// Uses node:http/node:https rather than the global fetch: inside the Gramine
+	// SGX enclave undici (which backs fetch) fails on every request when it lazily
+	// instantiates its llhttp WASM parser — `WebAssembly.Instance(): Out of memory`
+	// under the enclave's constrained memory — which silently kills the whole
+	// archive plane. node's request stays on the transport proven to work in the
+	// enclave. Same failure class and mitigation as resolveOnChainSender in
+	// travel-rule-deposit-reconciler.ts.
+	private postToForwarder(batch: BrokerArchiveRow[]): Promise<void> {
 		if (!this.forwarderUrl || batch.length === 0) {
-			return;
+			return Promise.resolve();
 		}
-		const controller = new AbortController();
-		const timeout = setTimeout(
-			() => controller.abort(),
-			this.forwarderTimeoutMs,
-		);
-		const headers: Record<string, string> = {
+		const body = JSON.stringify({
+			source: "broker_write",
+			deployment_id: this.deploymentId,
+			rows: batch,
+		});
+		const url = new URL(this.forwarderUrl);
+		const doRequest = url.protocol === "http:" ? httpRequest : httpsRequest;
+		const headers: Record<string, string | number> = {
 			"content-type": "application/json",
+			"content-length": Buffer.byteLength(body),
 		};
 		if (this.forwarderAuthToken) {
 			headers.authorization = `Bearer ${this.forwarderAuthToken}`;
 		}
-		try {
-			const response = await fetch(this.forwarderUrl, {
-				method: "POST",
-				headers,
-				body: JSON.stringify({
-					source: "broker_write",
-					deployment_id: this.deploymentId,
-					rows: batch,
-				}),
-				signal: controller.signal,
+		return new Promise<void>((resolve, reject) => {
+			const req = doRequest(
+				url,
+				{
+					method: "POST",
+					headers,
+					// Bound the request: a hung forwarder would otherwise stall the flush
+					// loop (flushes are serialized behind flushInFlight) indefinitely.
+					timeout: this.forwarderTimeoutMs,
+				},
+				(res) => {
+					// Drain the body so the socket can be released/reused.
+					res.on("data", () => {});
+					res.on("end", () => {
+						const status = res.statusCode ?? 0;
+						if (status < 200 || status >= 300) {
+							reject(
+								new Error(
+									`Archive forwarder returned ${status} ${res.statusMessage ?? ""}`,
+								),
+							);
+							return;
+						}
+						resolve();
+					});
+				},
+			);
+			req.on("error", reject);
+			req.on("timeout", () => {
+				req.destroy(new Error("Archive forwarder request timed out"));
 			});
-			if (!response.ok) {
-				throw new Error(
-					`Archive forwarder returned ${response.status} ${response.statusText}`,
-				);
-			}
-		} finally {
-			clearTimeout(timeout);
-		}
+			req.write(body);
+			req.end();
+		});
 	}
 }
 

--- a/test/archive-forwarder-server.ts
+++ b/test/archive-forwarder-server.ts
@@ -1,0 +1,69 @@
+import http from "node:http";
+
+export type CapturedRequest = {
+	method: string;
+	headers: http.IncomingHttpHeaders;
+	body: { source?: string; deployment_id?: string; rows?: unknown[] } & Record<
+		string,
+		unknown
+	>;
+};
+
+export type ForwarderReply = { status?: number; destroy?: boolean };
+
+export type ForwarderResponder = (
+	req: CapturedRequest,
+) => ForwarderReply | Promise<ForwarderReply>;
+
+export type ForwarderServer = {
+	url: string;
+	requests: CapturedRequest[];
+	close: () => Promise<void>;
+};
+
+/**
+ * A real local HTTP forwarder for archive-writer tests. Exercises the production
+ * node:http transport end to end (the enclave-safe path) instead of stubbing the
+ * global fetch, which the writer no longer uses. The responder scripts the reply
+ * per request: an HTTP `status`, or `destroy: true` to abort the socket and drive
+ * the client's network-error path. Returning a Promise lets a test hold the
+ * response in flight.
+ */
+export function startForwarderServer(
+	responder: ForwarderResponder = () => ({ status: 200 }),
+): Promise<ForwarderServer> {
+	const requests: CapturedRequest[] = [];
+	const server = http.createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (chunk) => chunks.push(chunk as Buffer));
+		req.on("end", () => {
+			void (async () => {
+				const raw = Buffer.concat(chunks).toString("utf8");
+				const captured: CapturedRequest = {
+					method: req.method ?? "",
+					headers: req.headers,
+					body: raw ? JSON.parse(raw) : {},
+				};
+				requests.push(captured);
+				const { status = 200, destroy = false } = await responder(captured);
+				if (destroy) {
+					res.destroy();
+					return;
+				}
+				res.writeHead(status, { "content-type": "application/json" });
+				res.end("{}");
+			})();
+		});
+	});
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address();
+			const port = typeof addr === "object" && addr ? addr.port : 0;
+			resolve({
+				url: `http://127.0.0.1:${port}/archive`,
+				requests,
+				close: () => new Promise<void>((r) => server.close(() => r())),
+			});
+		});
+	});
+}

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { LogRecord } from "@opentelemetry/api-logs";
+import { startForwarderServer } from "./archive-forwarder-server";
 import {
 	redactSecretLiterals,
 	redactStreamPayload,
@@ -18,6 +19,14 @@ import {
 } from "../src/helpers/broker-execution-archive/writer";
 import { buildOrderExecutionTelemetry } from "../src/helpers/order-telemetry";
 import type { OtelLogs } from "../src/helpers/otel";
+
+function restoreEnv(key: string, original: string | undefined): void {
+	if (original === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = original;
+	}
+}
 
 class MockOtelLogs implements OtelLogs {
 	readonly emits: LogRecord[] = [];
@@ -176,93 +185,126 @@ describe("broker execution archive rows", () => {
 });
 
 describe("broker execution archiver queue", () => {
-	const originalFetch = globalThis.fetch;
+	test("posts JSON with the bearer token over the real node:http transport", async () => {
+		const server = await startForwarderServer();
+		const originalToken = process.env.CEX_BROKER_ARCHIVE_FORWARDER_TOKEN;
+		process.env.CEX_BROKER_ARCHIVE_FORWARDER_TOKEN = "secret-token";
 
-	afterEach(() => {
-		globalThis.fetch = originalFetch;
+		try {
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				deploymentId: "test-deploy",
+				batchSize: 10,
+				flushIntervalMs: 60_000,
+			});
+
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "1" },
+			});
+
+			await archiver.flush();
+
+			expect(server.requests).toHaveLength(1);
+			const request = server.requests[0];
+			expect(request?.method).toBe("POST");
+			expect(request?.headers["content-type"]).toBe("application/json");
+			expect(request?.headers.authorization).toBe("Bearer secret-token");
+			expect(request?.body).toMatchObject({
+				source: "broker_write",
+				deployment_id: "test-deploy",
+			});
+
+			await archiver.close();
+		} finally {
+			await server.close();
+			if (originalToken === undefined) {
+				delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_TOKEN;
+			} else {
+				process.env.CEX_BROKER_ARCHIVE_FORWARDER_TOKEN = originalToken;
+			}
+		}
 	});
 
 	test("enqueue is non-blocking and sheds oldest rows when queue is full", async () => {
-		const posts: unknown[] = [];
-		globalThis.fetch = (async (_url, init) => {
-			posts.push(JSON.parse(String(init?.body)));
-			return new Response(null, { status: 200 });
-		}) as typeof fetch;
+		const server = await startForwarderServer();
+		try {
+			const otelLogs = new MockOtelLogs();
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				otelLogs,
+				deploymentId: "test-deploy",
+				maxQueueSize: 2,
+				batchSize: 10,
+				flushIntervalMs: 60_000,
+			});
 
-		const otelLogs = new MockOtelLogs();
-		const archiver = BrokerExecutionArchiver.create({
-			forwarderUrl: "http://127.0.0.1:9/archive",
-			otelLogs,
-			deploymentId: "test-deploy",
-			maxQueueSize: 2,
-			batchSize: 10,
-			flushIntervalMs: 60_000,
-		});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "1" },
+			});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "2" },
+			});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "3" },
+			});
 
-		archiver.enqueue({
-			table: "broker_execution.order_events",
-			row: { source: "broker_write", order_id: "1" },
-		});
-		archiver.enqueue({
-			table: "broker_execution.order_events",
-			row: { source: "broker_write", order_id: "2" },
-		});
-		archiver.enqueue({
-			table: "broker_execution.order_events",
-			row: { source: "broker_write", order_id: "3" },
-		});
+			expect(archiver.getStats().shed).toBe(1);
+			expect(archiver.getQueueDepth()).toBe(2);
 
-		expect(archiver.getStats().shed).toBe(1);
-		expect(archiver.getQueueDepth()).toBe(2);
+			await archiver.flush();
+			expect(server.requests).toHaveLength(1);
+			expect(server.requests[0]?.body.rows).toHaveLength(2);
+			expect(otelLogs.emits).toHaveLength(2);
 
-		await archiver.flush();
-		expect(posts).toHaveLength(1);
-		expect((posts[0] as { rows: unknown[] }).rows).toHaveLength(2);
-		expect(otelLogs.emits).toHaveLength(2);
-
-		await archiver.close();
+			await archiver.close();
+		} finally {
+			await server.close();
+		}
 	});
 
 	test("mirrors broker_execution rows to OTel logs and posts every table to the forwarder", async () => {
-		const posts: unknown[] = [];
-		globalThis.fetch = (async (_url, init) => {
-			posts.push(JSON.parse(String(init?.body)));
-			return new Response(null, { status: 200 });
-		}) as typeof fetch;
+		const server = await startForwarderServer();
+		try {
+			const otelLogs = new MockOtelLogs();
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				otelLogs,
+				deploymentId: "test-deploy",
+				batchSize: 10,
+				flushIntervalMs: 60_000,
+			});
 
-		const otelLogs = new MockOtelLogs();
-		const archiver = BrokerExecutionArchiver.create({
-			forwarderUrl: "http://127.0.0.1:9/archive",
-			otelLogs,
-			deploymentId: "test-deploy",
-			batchSize: 10,
-			flushIntervalMs: 60_000,
-		});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "1" },
+			});
+			archiver.enqueue({
+				table: "market_data.orderbook_snapshots",
+				row: { source: "broker_write", best_bid: 100 },
+			});
 
-		archiver.enqueue({
-			table: "broker_execution.order_events",
-			row: { source: "broker_write", order_id: "1" },
-		});
-		archiver.enqueue({
-			table: "market_data.orderbook_snapshots",
-			row: { source: "broker_write", best_bid: 100 },
-		});
+			await archiver.flush();
 
-		await archiver.flush();
+			// Only execution rows mirror to OTel (market_data has no OTel schema)...
+			expect(otelLogs.emits).toHaveLength(1);
+			expect(otelLogs.emits[0]?.body).toBe("broker_execution.order_events");
+			// ...but the forwarder is the durable sink for both tables.
+			expect(server.requests).toHaveLength(1);
+			expect(server.requests[0]?.body).toMatchObject({
+				rows: expect.arrayContaining([
+					expect.objectContaining({ table: "broker_execution.order_events" }),
+					expect.objectContaining({ table: "market_data.orderbook_snapshots" }),
+				]),
+			});
 
-		// Only execution rows mirror to OTel (market_data has no OTel schema)...
-		expect(otelLogs.emits).toHaveLength(1);
-		expect(otelLogs.emits[0]?.body).toBe("broker_execution.order_events");
-		// ...but the forwarder is the durable sink for both tables.
-		expect(posts).toHaveLength(1);
-		expect(posts[0]).toMatchObject({
-			rows: expect.arrayContaining([
-				expect.objectContaining({ table: "broker_execution.order_events" }),
-				expect.objectContaining({ table: "market_data.orderbook_snapshots" }),
-			]),
-		});
-
-		await archiver.close();
+			await archiver.close();
+		} finally {
+			await server.close();
+		}
 	});
 
 	test("drops market_data rows when forwarder URL is missing", async () => {
@@ -293,138 +335,143 @@ describe("broker execution archiver queue", () => {
 	});
 
 	test("close exits after forwarder failure instead of retrying forever", async () => {
-		globalThis.fetch = (async () =>
-			new Response(null, { status: 503 })) as typeof fetch;
+		const server = await startForwarderServer(() => ({ status: 503 }));
+		try {
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				deploymentId: "test-deploy",
+				batchSize: 10,
+				flushIntervalMs: 60_000,
+			});
 
-		const archiver = BrokerExecutionArchiver.create({
-			forwarderUrl: "http://127.0.0.1:9/archive",
-			deploymentId: "test-deploy",
-			batchSize: 10,
-			flushIntervalMs: 60_000,
-		});
+			archiver.enqueue({
+				table: "market_data.candles",
+				row: { source: "broker_write", open_time_ms: 1_000 },
+			});
 
-		archiver.enqueue({
-			table: "market_data.candles",
-			row: { source: "broker_write", open_time_ms: 1_000 },
-		});
-
-		await expect(archiver.close()).resolves.toBeUndefined();
-		expect(archiver.getQueueDepth()).toBe(0);
-		expect(archiver.getStats().forwarderFailures).toBeGreaterThan(0);
+			await expect(archiver.close()).resolves.toBeUndefined();
+			expect(archiver.getQueueDepth()).toBe(0);
+			expect(archiver.getStats().forwarderFailures).toBeGreaterThan(0);
+		} finally {
+			await server.close();
+		}
 	});
 
-	test("requeues the whole batch after a forwarder failure", async () => {
-		let postAttempts = 0;
-		globalThis.fetch = (async () => {
-			postAttempts += 1;
-			return new Response(null, { status: 503 });
-		}) as typeof fetch;
+	test("requeues the whole batch after a forwarder network failure", async () => {
+		// Abort the socket so the client's node:http request errors — the network
+		// failure path (distinct from the non-2xx path exercised elsewhere).
+		const server = await startForwarderServer(() => ({ destroy: true }));
+		try {
+			const otelLogs = new MockOtelLogs();
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				otelLogs,
+				deploymentId: "test-deploy",
+				batchSize: 10,
+				flushIntervalMs: 60_000,
+			});
 
-		const otelLogs = new MockOtelLogs();
-		const archiver = BrokerExecutionArchiver.create({
-			forwarderUrl: "http://127.0.0.1:9/archive",
-			otelLogs,
-			deploymentId: "test-deploy",
-			batchSize: 10,
-			flushIntervalMs: 60_000,
-		});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "1" },
+			});
+			archiver.enqueue({
+				table: "market_data.candles",
+				row: { source: "broker_write", open_time_ms: 1_000 },
+			});
 
-		archiver.enqueue({
-			table: "broker_execution.order_events",
-			row: { source: "broker_write", order_id: "1" },
-		});
-		archiver.enqueue({
-			table: "market_data.candles",
-			row: { source: "broker_write", open_time_ms: 1_000 },
-		});
+			await archiver.flush();
+			// The execution row still reached OTel (mirror happens before the post),
+			// and both rows are requeued for a later forwarder retry — neither is lost.
+			expect(otelLogs.emits).toHaveLength(1);
+			expect(archiver.getQueueDepth()).toBe(2);
+			expect(server.requests).toHaveLength(1);
 
-		await archiver.flush();
-		// The execution row still reached OTel (mirror happens before the post),
-		// and both rows are requeued for a later forwarder retry — neither is lost.
-		expect(otelLogs.emits).toHaveLength(1);
-		expect(archiver.getQueueDepth()).toBe(2);
-		expect(postAttempts).toBe(1);
-
-		await archiver.close();
+			await archiver.close();
+		} finally {
+			await server.close();
+		}
 	});
 
 	test("posts broker_execution rows to the forwarder even without OTel logs", async () => {
-		const posts: unknown[] = [];
-		globalThis.fetch = (async (_url, init) => {
-			posts.push(JSON.parse(String(init?.body)));
-			return new Response(null, { status: 200 });
-		}) as typeof fetch;
+		const server = await startForwarderServer();
+		try {
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				deploymentId: "test-deploy",
+				batchSize: 10,
+				flushIntervalMs: 60_000,
+			});
 
-		const archiver = BrokerExecutionArchiver.create({
-			forwarderUrl: "http://127.0.0.1:9/archive",
-			deploymentId: "test-deploy",
-			batchSize: 10,
-			flushIntervalMs: 60_000,
-		});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { source: "broker_write", order_id: "1" },
+			});
 
-		archiver.enqueue({
-			table: "broker_execution.order_events",
-			row: { source: "broker_write", order_id: "1" },
-		});
+			await archiver.flush();
+			expect(server.requests).toHaveLength(1);
+			expect(server.requests[0]?.body).toMatchObject({
+				rows: expect.arrayContaining([
+					expect.objectContaining({ table: "broker_execution.order_events" }),
+				]),
+			});
 
-		await archiver.flush();
-		expect(posts).toHaveLength(1);
-		expect(posts[0]).toMatchObject({
-			rows: expect.arrayContaining([
-				expect.objectContaining({ table: "broker_execution.order_events" }),
-			]),
-		});
-
-		await archiver.close();
+			await archiver.close();
+		} finally {
+			await server.close();
+		}
 	});
 
 	test("keeps the queue within maxQueueSize when a failed batch is requeued after refill", async () => {
 		// Gate the forwarder so a batch stays in flight while new rows refill the
 		// queue, then fail it — the classic over-cap window for the requeue path.
-		let releaseFetch: () => void = () => {};
-		const fetchGate = new Promise<void>((resolve) => {
-			releaseFetch = resolve;
+		let releasePost: () => void = () => {};
+		const postGate = new Promise<void>((resolve) => {
+			releasePost = resolve;
 		});
-		globalThis.fetch = (async () => {
-			await fetchGate;
-			return new Response(null, { status: 503 });
-		}) as typeof fetch;
-
-		const archiver = BrokerExecutionArchiver.create({
-			forwarderUrl: "http://127.0.0.1:9/archive",
-			deploymentId: "test-deploy",
-			maxQueueSize: 3,
-			batchSize: 4, // above the 3 rows we enqueue, so only manual flush drains
-			flushIntervalMs: 60_000,
+		const server = await startForwarderServer(async () => {
+			await postGate;
+			return { status: 503 };
 		});
-		const row = (id: string) =>
-			({
-				table: "broker_execution.order_events",
-				row: { source: "broker_write", order_id: id },
-			}) as const;
+		try {
+			const archiver = BrokerExecutionArchiver.create({
+				forwarderUrl: server.url,
+				deploymentId: "test-deploy",
+				maxQueueSize: 3,
+				batchSize: 4, // above the 3 rows we enqueue, so only manual flush drains
+				flushIntervalMs: 60_000,
+			});
+			const row = (id: string) =>
+				({
+					table: "broker_execution.order_events",
+					row: { source: "broker_write", order_id: id },
+				}) as const;
 
-		archiver.enqueue(row("1"));
-		archiver.enqueue(row("2"));
-		archiver.enqueue(row("3"));
+			archiver.enqueue(row("1"));
+			archiver.enqueue(row("2"));
+			archiver.enqueue(row("3"));
 
-		// Splices [1,2,3] out and blocks on the gated fetch.
-		const flushPromise = archiver.flush();
-		expect(archiver.getQueueDepth()).toBe(0);
+			// Splices [1,2,3] out and blocks on the gated forwarder response.
+			const flushPromise = archiver.flush();
+			expect(archiver.getQueueDepth()).toBe(0);
 
-		// Queue refills to the cap while the batch is in flight.
-		archiver.enqueue(row("4"));
-		archiver.enqueue(row("5"));
-		archiver.enqueue(row("6"));
-		expect(archiver.getQueueDepth()).toBe(3);
+			// Queue refills to the cap while the batch is in flight.
+			archiver.enqueue(row("4"));
+			archiver.enqueue(row("5"));
+			archiver.enqueue(row("6"));
+			expect(archiver.getQueueDepth()).toBe(3);
 
-		releaseFetch();
-		await flushPromise;
+			releasePost();
+			await flushPromise;
 
-		// Without bound enforcement this would be 6 (3 refill + 3 requeued).
-		expect(archiver.getQueueDepth()).toBe(3);
-		expect(archiver.getStats().shed).toBeGreaterThanOrEqual(3);
+			// Without bound enforcement this would be 6 (3 refill + 3 requeued).
+			expect(archiver.getQueueDepth()).toBe(3);
+			expect(archiver.getStats().shed).toBeGreaterThanOrEqual(3);
 
-		await archiver.close();
+			await archiver.close();
+		} finally {
+			await server.close();
+		}
 	});
 
 	test("canPersistMarketMetadataSnapshot is true with a forwarder-only config", () => {
@@ -441,29 +488,57 @@ describe("broker execution archiver queue", () => {
 });
 
 describe("broker execution archiver env", () => {
-	test("createBrokerExecutionArchiverFromEnv uses ClickHouse forwarder by default without OTel logs", async () => {
+	test("resolveArchiveForwarderUrlFromEnv derives the ClickHouse forwarder URL with defaults", () => {
 		const originalForwarderUrl = process.env.CEX_BROKER_ARCHIVE_FORWARDER_URL;
+		const originalForwarderHost = process.env.CEX_BROKER_ARCHIVE_FORWARDER_HOST;
+		const originalForwarderPort = process.env.CEX_BROKER_ARCHIVE_FORWARDER_PORT;
 		const originalClickhouseHost = process.env.CEX_BROKER_CLICKHOUSE_HOST;
-		const originalClickhousePort = process.env.CEX_BROKER_CLICKHOUSE_PORT;
 		const originalOtelLogsEnabled =
 			process.env.CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED;
-		const originalFetch = globalThis.fetch;
 
 		delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_URL;
+		delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_HOST;
+		delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_PORT;
 		process.env.CEX_BROKER_CLICKHOUSE_HOST = "clickhouse.local";
-		delete process.env.CEX_BROKER_CLICKHOUSE_PORT;
 		delete process.env.CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED;
-
-		const posts: unknown[] = [];
-		globalThis.fetch = (async (_url, init) => {
-			posts.push(JSON.parse(String(init?.body)));
-			return new Response(null, { status: 200 });
-		}) as typeof fetch;
 
 		try {
 			expect(resolveArchiveForwarderUrlFromEnv()).toBe(
 				"http://clickhouse.local:8090/archive",
 			);
+			expect(isArchiveOtelLogsEnabled()).toBe(false);
+		} finally {
+			restoreEnv("CEX_BROKER_ARCHIVE_FORWARDER_URL", originalForwarderUrl);
+			restoreEnv("CEX_BROKER_ARCHIVE_FORWARDER_HOST", originalForwarderHost);
+			restoreEnv("CEX_BROKER_ARCHIVE_FORWARDER_PORT", originalForwarderPort);
+			restoreEnv("CEX_BROKER_CLICKHOUSE_HOST", originalClickhouseHost);
+			restoreEnv(
+				"CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED",
+				originalOtelLogsEnabled,
+			);
+		}
+	});
+
+	test("createBrokerExecutionArchiverFromEnv posts to the derived forwarder without OTel logs", async () => {
+		const server = await startForwarderServer();
+		const port = new URL(server.url).port;
+		const originalForwarderUrl = process.env.CEX_BROKER_ARCHIVE_FORWARDER_URL;
+		const originalForwarderHost = process.env.CEX_BROKER_ARCHIVE_FORWARDER_HOST;
+		const originalForwarderPort = process.env.CEX_BROKER_ARCHIVE_FORWARDER_PORT;
+		const originalClickhouseHost = process.env.CEX_BROKER_CLICKHOUSE_HOST;
+		const originalOtelLogsEnabled =
+			process.env.CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED;
+
+		// Point the ClickHouse-host resolution path at the local forwarder so the
+		// row actually travels the production node:http transport.
+		delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_URL;
+		delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_HOST;
+		process.env.CEX_BROKER_CLICKHOUSE_HOST = "127.0.0.1";
+		process.env.CEX_BROKER_ARCHIVE_FORWARDER_PORT = port;
+		delete process.env.CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED;
+
+		try {
+			expect(resolveArchiveForwarderUrlFromEnv()).toBe(server.url);
 			expect(isArchiveOtelLogsEnabled()).toBe(false);
 
 			const otelLogs = new MockOtelLogs();
@@ -475,31 +550,18 @@ describe("broker execution archiver env", () => {
 			await archiver.flush();
 			// No OTel mirror (flag off), but the row still lands at the forwarder.
 			expect(otelLogs.emits).toHaveLength(0);
-			expect(posts).toHaveLength(1);
+			expect(server.requests).toHaveLength(1);
 			await archiver.close();
 		} finally {
-			globalThis.fetch = originalFetch;
-			if (originalForwarderUrl === undefined) {
-				delete process.env.CEX_BROKER_ARCHIVE_FORWARDER_URL;
-			} else {
-				process.env.CEX_BROKER_ARCHIVE_FORWARDER_URL = originalForwarderUrl;
-			}
-			if (originalClickhouseHost === undefined) {
-				delete process.env.CEX_BROKER_CLICKHOUSE_HOST;
-			} else {
-				process.env.CEX_BROKER_CLICKHOUSE_HOST = originalClickhouseHost;
-			}
-			if (originalClickhousePort === undefined) {
-				delete process.env.CEX_BROKER_CLICKHOUSE_PORT;
-			} else {
-				process.env.CEX_BROKER_CLICKHOUSE_PORT = originalClickhousePort;
-			}
-			if (originalOtelLogsEnabled === undefined) {
-				delete process.env.CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED;
-			} else {
-				process.env.CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED =
-					originalOtelLogsEnabled;
-			}
+			await server.close();
+			restoreEnv("CEX_BROKER_ARCHIVE_FORWARDER_URL", originalForwarderUrl);
+			restoreEnv("CEX_BROKER_ARCHIVE_FORWARDER_HOST", originalForwarderHost);
+			restoreEnv("CEX_BROKER_ARCHIVE_FORWARDER_PORT", originalForwarderPort);
+			restoreEnv("CEX_BROKER_CLICKHOUSE_HOST", originalClickhouseHost);
+			restoreEnv(
+				"CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED",
+				originalOtelLogsEnabled,
+			);
 		}
 	});
 

--- a/test/subscribe-handler.test.ts
+++ b/test/subscribe-handler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
@@ -13,6 +13,7 @@ import {
 	SubscriptionType,
 	type SubscriptionType as SubscriptionTypeValue,
 } from "../src/helpers/constants";
+import { startForwarderServer } from "./archive-forwarder-server";
 
 type MockCallState = {
 	writes: SubscribeResponse[];
@@ -317,15 +318,11 @@ describe("subscribe handler", () => {
 	});
 
 	test("archives orderbook snapshot rows to the forwarder", async () => {
-		const originalFetch = globalThis.fetch;
+		const server = await startForwarderServer();
+		const posts = server.requests;
 		const originalInterval = process.env.CEX_BROKER_ORDERBOOK_INTERVAL_MS;
 		const originalArchiveEnabled =
 			process.env.CEX_BROKER_MARKET_ARCHIVE_ENABLED;
-		const posts: unknown[] = [];
-		globalThis.fetch = (async (_url, init) => {
-			posts.push(JSON.parse(String(init?.body)));
-			return new Response(null, { status: 200 });
-		}) as typeof fetch;
 		process.env.CEX_BROKER_ORDERBOOK_INTERVAL_MS = "1";
 		process.env.CEX_BROKER_MARKET_ARCHIVE_ENABLED = "true";
 
@@ -335,7 +332,7 @@ describe("subscribe handler", () => {
 				watchOrderBook: controlledWatch.watch,
 			} as unknown as Exchange;
 			const archiver = BrokerExecutionArchiver.create({
-				forwarderUrl: "http://127.0.0.1:9/archive",
+				forwarderUrl: server.url,
 				deploymentId: "test-deploy",
 				batchSize: 1,
 				flushIntervalMs: 60_000,
@@ -359,7 +356,9 @@ describe("subscribe handler", () => {
 				timestamp: 1_700_000_000_000,
 			});
 			await waitFor(() => archiver.getStats().enqueued >= 1);
-			await archiver.flush();
+			// batchSize 1 auto-flushes on enqueue; wait for that post to reach the
+			// forwarder over the real transport rather than racing the round trip.
+			await waitFor(() => archiver.getStats().flushed >= 1);
 			await waitFor(() => controlledWatch.calls.length >= 2);
 			call.emit("close");
 			controlledWatch.resolvers[1]?.({
@@ -370,17 +369,16 @@ describe("subscribe handler", () => {
 			await handlerPromise;
 
 			expect(posts.length).toBeGreaterThanOrEqual(1);
-			expect(posts[0]).toMatchObject({
+			expect(posts[0]?.body).toMatchObject({
 				source: "broker_write",
 				deployment_id: "test-deploy",
 			});
 			const rows = posts.flatMap(
 				(post) =>
-					(
-						post as {
-							rows: Array<{ table: string; row: Record<string, unknown> }>;
-						}
-					).rows,
+					(post.body.rows ?? []) as Array<{
+						table: string;
+						row: Record<string, unknown>;
+					}>,
 			);
 			expect(
 				rows.some((entry) => entry.table === "market_data.orderbook_snapshots"),
@@ -399,7 +397,7 @@ describe("subscribe handler", () => {
 
 			await archiver.close();
 		} finally {
-			globalThis.fetch = originalFetch;
+			await server.close();
 			if (originalInterval === undefined) {
 				delete process.env.CEX_BROKER_ORDERBOOK_INTERVAL_MS;
 			} else {
@@ -414,14 +412,10 @@ describe("subscribe handler", () => {
 	});
 
 	test("archives OHLCV candle rows to the forwarder", async () => {
-		const originalFetch = globalThis.fetch;
+		const server = await startForwarderServer();
+		const posts = server.requests;
 		const originalArchiveEnabled =
 			process.env.CEX_BROKER_MARKET_ARCHIVE_ENABLED;
-		const posts: unknown[] = [];
-		globalThis.fetch = (async (_url, init) => {
-			posts.push(JSON.parse(String(init?.body)));
-			return new Response(null, { status: 200 });
-		}) as typeof fetch;
 		process.env.CEX_BROKER_MARKET_ARCHIVE_ENABLED = "true";
 
 		try {
@@ -430,7 +424,7 @@ describe("subscribe handler", () => {
 				fetchOHLCVWs: controlledWatch.watch,
 			} as unknown as Exchange;
 			const archiver = BrokerExecutionArchiver.create({
-				forwarderUrl: "http://127.0.0.1:9/archive",
+				forwarderUrl: server.url,
 				deploymentId: "test-deploy",
 				batchSize: 1,
 				flushIntervalMs: 60_000,
@@ -451,18 +445,19 @@ describe("subscribe handler", () => {
 			await waitFor(() => controlledWatch.calls.length === 1);
 			controlledWatch.resolvers[0]?.([[1_700_000_000_000, 1, 2, 0.5, 1.5, 10]]);
 			await waitFor(() => archiver.getStats().enqueued >= 1);
-			await archiver.flush();
+			// batchSize 1 auto-flushes on enqueue; wait for that post to reach the
+			// forwarder over the real transport rather than racing the round trip.
+			await waitFor(() => archiver.getStats().flushed >= 1);
 			await waitFor(() => controlledWatch.calls.length >= 2);
 			call.emit("close");
 			controlledWatch.resolvers[1]?.([[1_700_000_000_000, 1, 2, 0.5, 1.5, 10]]);
 			await handlerPromise;
 
 			expect(posts.length).toBeGreaterThanOrEqual(1);
-			const rows = (
-				posts[0] as {
-					rows: Array<{ table: string; row: Record<string, unknown> }>;
-				}
-			).rows;
+			const rows = (posts[0]?.body.rows ?? []) as Array<{
+				table: string;
+				row: Record<string, unknown>;
+			}>;
 			expect(rows.some((entry) => entry.table === "market_data.candles")).toBe(
 				true,
 			);
@@ -474,7 +469,7 @@ describe("subscribe handler", () => {
 
 			await archiver.close();
 		} finally {
-			globalThis.fetch = originalFetch;
+			await server.close();
 			if (originalArchiveEnabled === undefined) {
 				delete process.env.CEX_BROKER_MARKET_ARCHIVE_ENABLED;
 			} else {


### PR DESCRIPTION
## Problem

In production, inside the Gramine SGX enclave, the broker execution archive forwarder is dead: **every** archive batch fails and rows are dropped, even though the trading path is unaffected (the archive plane is fail-open).

The forwarder (`postToForwarder` in `src/helpers/broker-execution-archive/writer.ts`) used the global `fetch`, which is backed by undici. undici lazily instantiates its `llhttp` WASM parser on first use, and the enclave's constrained memory rejects it:

```
TypeError: fetch failed
  → RangeError: WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance
    at lazyllhttp
```

The TCP connect succeeds; only the undici client library is broken in the enclave. Result: all archive batches fail (warn-once spam, rows dropped) and the archive plane never delivers.

## Fix

Post batches over `node:http` / `node:https` `request` (chosen by URL protocol) instead of the global `fetch`. This mirrors the existing enclave-safe precedent in `src/helpers/travel-rule-deposit-reconciler.ts` (`resolveOnChainSender`), which documents the same failure class and already runs the ccxt/node HTTP transport that works inside the enclave.

Semantics are preserved:
- POST with `content-type: application/json` (+ `content-length`)
- optional `authorization: Bearer <token>`
- request timeout bound via the node request `timeout` option (destroy + reject on timeout), still using `forwarderTimeoutMs`
- non-2xx throws the same `Archive forwarder returned <status> <statusText-or-empty>` error so caller/log wording is stable
- response body is drained so the socket can be released
- the now-unused `AbortController` is removed

Only `postToForwarder` used the global `fetch` in the archive path (grep of `src/helpers` confirms no other call site).

## Tests

The archive-writer and subscribe-handler tests previously stubbed `globalThis.fetch`. Those stubs are now dead, so the affected tests were rewritten to run a **real local HTTP server** (`test/archive-forwarder-server.ts`, a `node:http` capture server on a random port) that captures method/headers/body and scripts responses per test (success, 503 non-2xx, and a socket-destroy network failure). This exercises the real `node:http` transport end to end rather than a production test seam.

- `bun test`: 389 pass, 0 fail
- `bun run build`: passes (publish gate)
- `biome lint`: clean on changed files

## Rollout

This blocks the FIET-924 prod archive rollout — with the current build the archive plane cannot deliver inside the enclave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of archive forwarding, including better handling of request timeouts, failed responses, and network interruptions.
  * Archive requests now consistently include the expected headers and payload format.
* **Chores**
  * Bumped the package version to `0.2.20`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->