### PR TITLE
Archive durable fill and transfer execution facts

### DIFF
--- a/schema/clickhouse/broker_execution.sql
+++ b/schema/clickhouse/broker_execution.sql
@@ -65,6 +65,93 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(parseDateTimeBestEffortOrZero(broker_observed_timestamp))
 ORDER BY (exchange, symbol, broker_observed_timestamp);
 
+-- CEX value movements: withdrawals, deposits, and sub<->master internal transfers.
+--
+-- Column names/types/ORDER BY match the fiet-maker consumer contract
+-- (docs/CEX_EXECUTION_ARCHIVE_CONTRACT.md + scripts/sql/clickhouse-schema.sql):
+-- MergeTree with a 90-day TTL, DateTime64(3,'UTC') timestamps, string quantities,
+-- result_index UInt32, error_summary. Two ADDITIVE columns not in the consumer
+-- contract: fee_amount / fee_currency (the ccxt withdrawal object exposes the fee,
+-- the dominant small-commit cost). broker_observed_timestamp is emitted as an
+-- ISO-8601 UTC string and parsed on insert via the forwarder's
+-- date_time_input_format=best_effort (see services/archive-forwarder/index.ts).
+--
+-- Engine is plain MergeTree (contract), so re-observed rows are NOT collapsed;
+-- dedup, when needed, is at read time (GROUP BY / argMax over exchange,
+-- account_selector, symbol, external_id, lifecycle_action).
+CREATE TABLE IF NOT EXISTS broker_execution.transfer_events
+(
+    broker_observed_timestamp DateTime64(3, 'UTC'),
+    source LowCardinality(String),
+    deployment_id LowCardinality(String),
+    schema_version LowCardinality(String),
+    account_selector LowCardinality(String),
+    exchange LowCardinality(String),
+    symbol LowCardinality(String),
+    event_kind LowCardinality(String),
+    lifecycle_action LowCardinality(String),
+    status LowCardinality(String) DEFAULT '',
+    asset_symbol LowCardinality(String) DEFAULT '',
+    amount String DEFAULT '',
+    address String DEFAULT '',
+    network LowCardinality(String) DEFAULT '',
+    external_id String DEFAULT '',
+    txid String DEFAULT '',
+    result_index UInt32 DEFAULT 0,
+    fee_amount String DEFAULT '',
+    fee_currency LowCardinality(String) DEFAULT '',
+    exchange_timestamp Nullable(DateTime64(3, 'UTC')),
+    error_summary String DEFAULT '',
+    payload_json String DEFAULT ''
+)
+ENGINE = MergeTree
+PARTITION BY toDate(broker_observed_timestamp)
+ORDER BY (account_selector, broker_observed_timestamp, exchange, symbol, event_kind, lifecycle_action)
+TTL toDateTime(broker_observed_timestamp) + toIntervalDay(90)
+SETTINGS ttl_only_drop_parts = 1;
+
+-- Per-fill execution facts from the venue trade-history endpoint (fetchMyTrades),
+-- captured by the broker-internal fill poller. GetOrderDetails/createOrder payloads
+-- carry no per-trade breakdown and no fee on most venues, so per-fill truth
+-- (incl. fee) requires this endpoint; hence event_kind is stamped
+-- "trade_history_fill" rather than the contract fixture's "create_order_fill".
+--
+-- Column names/types/ORDER BY match the fiet-maker consumer contract: MergeTree +
+-- 90-day TTL, DateTime64 timestamps, string quantities, fill_index UInt32. Plain
+-- MergeTree (contract): the poller re-scans a lookback window after a restart, so
+-- the same trade can be re-inserted; dedup is at read time (GROUP BY / argMax over
+-- exchange, account_selector, symbol, order_id, fill_id).
+CREATE TABLE IF NOT EXISTS broker_execution.fill_events
+(
+    broker_observed_timestamp DateTime64(3, 'UTC'),
+    source LowCardinality(String),
+    deployment_id LowCardinality(String),
+    schema_version LowCardinality(String),
+    account_selector LowCardinality(String),
+    exchange LowCardinality(String),
+    symbol LowCardinality(String),
+    event_kind LowCardinality(String),
+    order_id String,
+    client_order_id String DEFAULT '',
+    fill_id String DEFAULT '',
+    fill_index UInt32 DEFAULT 0,
+    side LowCardinality(String) DEFAULT '',
+    order_type LowCardinality(String) DEFAULT '',
+    price String DEFAULT '',
+    base_quantity String DEFAULT '',
+    quote_quantity String DEFAULT '',
+    fee_amount String DEFAULT '',
+    fee_currency LowCardinality(String) DEFAULT '',
+    fee_rate String DEFAULT '',
+    exchange_timestamp Nullable(DateTime64(3, 'UTC')),
+    payload_json String DEFAULT ''
+)
+ENGINE = MergeTree
+PARTITION BY toDate(broker_observed_timestamp)
+ORDER BY (symbol, account_selector, broker_observed_timestamp, exchange, order_id, fill_index)
+TTL toDateTime(broker_observed_timestamp) + toIntervalDay(90)
+SETTINGS ttl_only_drop_parts = 1;
+
 -- Pre-order top-of-book snapshots captured immediately before an order action,
 -- joinable to order_events via market_metadata_hash and the order identifiers.
 CREATE TABLE IF NOT EXISTS broker_execution.market_metadata_snapshots

--- a/services/archive-forwarder/index.ts
+++ b/services/archive-forwarder/index.ts
@@ -17,6 +17,12 @@ const clickhouse = createClient({
 	username: config.clickhouse.username,
 	password: config.clickhouse.password,
 	database: config.clickhouse.database,
+	// broker_execution.transfer_events/fill_events use DateTime64 columns; producers
+	// emit broker_observed_timestamp/exchange_timestamp as ISO-8601 UTC strings, so
+	// the inserter must best-effort-parse them (basic mode rejects the 'T'/'Z' form).
+	// Strictly more lenient than basic, so it never breaks the existing String/Int64
+	// timestamp columns on the other archive tables.
+	clickhouse_settings: { date_time_input_format: "best_effort" },
 });
 const inserter = createClickHouseInserter(clickhouse);
 
@@ -82,11 +88,18 @@ const server = Bun.serve({
 			}
 
 			if (parsed.rejectedRowCount > 0) {
+				// Name the offending tables: an unknown table (e.g. a forgotten
+				// SUPPORTED_TABLES entry for a new archive table) would otherwise reject
+				// the whole batch with only a count, hiding which table is at fault.
+				console.warn(
+					`Rejected ${parsed.rejectedRowCount}/${parsed.inputRowCount} archive row(s) from ${parsed.batch.source}; tables: ${parsed.rejectedTables.join(", ")}`,
+				);
 				return Response.json(
 					{
 						error: "Malformed archive rows in batch",
 						rejected: parsed.rejectedRowCount,
 						inputRows: parsed.inputRowCount,
+						rejectedTables: parsed.rejectedTables,
 					},
 					{ status: 400 },
 				);

--- a/services/archive-forwarder/router.ts
+++ b/services/archive-forwarder/router.ts
@@ -8,6 +8,10 @@ export type ParsedArchiveBatch =
 			batch: ArchiveBatchRequest;
 			inputRowCount: number;
 			rejectedRowCount: number;
+			// Distinct table names among rejected rows (unknown/unsupported tables),
+			// so the caller can name them in a WARN instead of dropping silently.
+			// A rejected row with no string `table` contributes "(malformed)".
+			rejectedTables: string[];
 	  }
 	| { ok: false };
 
@@ -45,6 +49,7 @@ export function parseArchiveBatchRequest(body: unknown): ParsedArchiveBatch {
 	}
 	const inputRowCount = record.rows.length;
 	const rows = record.rows.filter(isValidArchiveRow);
+	const rejectedTables = collectRejectedTables(record.rows);
 	return {
 		ok: true,
 		batch: {
@@ -54,7 +59,20 @@ export function parseArchiveBatchRequest(body: unknown): ParsedArchiveBatch {
 		},
 		inputRowCount,
 		rejectedRowCount: inputRowCount - rows.length,
+		rejectedTables,
 	};
+}
+
+function collectRejectedTables(rows: unknown[]): string[] {
+	const tables = new Set<string>();
+	for (const entry of rows) {
+		if (isValidArchiveRow(entry)) {
+			continue;
+		}
+		const table = (entry as { table?: unknown } | null)?.table;
+		tables.add(typeof table === "string" ? table : "(malformed)");
+	}
+	return [...tables];
 }
 
 /** @deprecated Use parseArchiveBatchRequest returning ParsedArchiveBatch */

--- a/services/archive-forwarder/types.ts
+++ b/services/archive-forwarder/types.ts
@@ -25,6 +25,8 @@ export const SUPPORTED_TABLES = [
 	"market_data.cex_trades",
 	"broker_execution.order_events",
 	"broker_execution.market_metadata_snapshots",
+	"broker_execution.transfer_events",
+	"broker_execution.fill_events",
 	"strategy_data.policy_evaluation_events",
 	"strategy_data.strategy_policy_snapshots",
 	"strategy_data.inventory_settlement_events",

--- a/src/handlers/execute-action/context.ts
+++ b/src/handlers/execute-action/context.ts
@@ -13,6 +13,7 @@ import {
 	resolveGrpcError,
 	stableGrpcErrorCode,
 } from "../../helpers/grpc/status";
+import type { OrderActivityTracker } from "../../helpers/order-activity-tracker";
 import type { OtelMetrics } from "../../helpers/otel";
 import { getErrorMessage } from "../../helpers/shared/errors";
 import type { PolicyConfig } from "../../types";
@@ -38,6 +39,7 @@ export type ExecuteActionContext = {
 	verityProverUrl: string;
 	otelMetrics?: OtelMetrics;
 	brokerArchiver?: BrokerExecutionArchiver;
+	orderActivityTracker?: OrderActivityTracker;
 };
 
 export function requireSymbol(

--- a/src/handlers/execute-action/deposit.ts
+++ b/src/handlers/execute-action/deposit.ts
@@ -1,5 +1,6 @@
 import * as grpc from "@grpc/grpc-js";
 import ccxt from "@usherlabs/ccxt";
+import { archiveTransferEventInBackground } from "../../helpers/broker-execution-archive";
 import {
 	depositField,
 	depositMatchesTransaction,
@@ -19,7 +20,13 @@ import type { ExecuteActionContext } from "./context";
 import { parsePayloadForAction, rejectWithGrpcError } from "./context";
 
 export async function handleDeposit(ctx: ExecuteActionContext): Promise<void> {
-	const { normalizedCex, symbol, selectedBrokerAccount, broker } = ctx;
+	const {
+		normalizedCex,
+		symbol,
+		selectedBrokerAccount,
+		broker,
+		brokerArchiver,
+	} = ctx;
 
 	if (!symbol) {
 		return ctx.wrappedCallback(
@@ -117,6 +124,40 @@ export async function handleDeposit(ctx: ExecuteActionContext): Promise<void> {
 			const status = normalizeDepositStatus(
 				depositField(deposit, ["status", "state"]),
 			);
+			const depositTxid = String(
+				depositField(deposit, ["txid", "txId", "tx_hash", "txHash"]) ??
+					value.transactionHash,
+			);
+			const creditedAt = depositField(deposit, [
+				"creditedAt",
+				"credited_at",
+				"updated",
+				"updatedAt",
+				"timestamp",
+				"datetime",
+			]);
+			// Observed deposit lifecycle fact (contract lifecycle_action
+			// "observe_deposit"). MergeTree keeps all observations; dedup, if needed,
+			// is at read time over (exchange, account, symbol, external_id, status).
+			archiveTransferEventInBackground(brokerArchiver, {
+				exchange: normalizedCex,
+				accountSelector: selectedBrokerAccount?.label,
+				assetSymbol: symbol,
+				transfer: {
+					eventKind: "deposit",
+					lifecycleAction: "observe_deposit",
+					status,
+					amount:
+						observedAmount !== undefined ? String(observedAmount) : undefined,
+					address: String(observedAddress ?? value.recipientAddress),
+					network: depositNetwork?.exchangeNetworkId,
+					externalId: depositTxid,
+					txid: depositTxid,
+					exchangeTimestamp:
+						typeof creditedAt === "string" ? creditedAt : undefined,
+					payload: deposit,
+				},
+			});
 			log.info(
 				`Amount ${value.amount} at ${value.transactionHash} . Paid to ${value.recipientAddress}`,
 			);

--- a/src/handlers/execute-action/handler.ts
+++ b/src/handlers/execute-action/handler.ts
@@ -7,6 +7,7 @@ import type { BrokerExecutionArchiver } from "../../helpers/broker-execution-arc
 import { Action, getActionName, resolveAction } from "../../helpers/constants";
 import { selectBrokerAccountForCex } from "../../helpers/grpc/broker";
 import { log } from "../../helpers/logger";
+import type { OrderActivityTracker } from "../../helpers/order-activity-tracker";
 import type { OtelMetrics } from "../../helpers/otel";
 import { safeLogError } from "../../helpers/shared/errors";
 import {
@@ -27,6 +28,7 @@ export type ExecuteActionDeps = {
 	verityProverUrl: string;
 	otelMetrics?: OtelMetrics;
 	brokerArchiver?: BrokerExecutionArchiver;
+	orderActivityTracker?: OrderActivityTracker;
 };
 
 export function createExecuteActionHandler(deps: ExecuteActionDeps) {
@@ -38,6 +40,7 @@ export function createExecuteActionHandler(deps: ExecuteActionDeps) {
 		verityProverUrl,
 		otelMetrics,
 		brokerArchiver,
+		orderActivityTracker,
 	} = deps;
 
 	return async (
@@ -151,6 +154,7 @@ export function createExecuteActionHandler(deps: ExecuteActionDeps) {
 				verityProverUrl,
 				otelMetrics,
 				brokerArchiver,
+				orderActivityTracker,
 			};
 
 			if (action === Action.Call) {

--- a/src/handlers/execute-action/internal-transfer.ts
+++ b/src/handlers/execute-action/internal-transfer.ts
@@ -7,6 +7,10 @@ import {
 	transferBinanceInternal,
 	verityHttpClientOverridePredicate,
 } from "../../helpers";
+import {
+	archiveTransferEventInBackground,
+	normalizeCcxtTransactionForArchive,
+} from "../../helpers/broker-execution-archive";
 import { mapCcxtErrorToGrpcStatus } from "../../helpers/grpc/status";
 import { log } from "../../helpers/logger";
 import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
@@ -25,6 +29,7 @@ export async function handleInternalTransfer(
 		verity,
 		useVerity,
 		verityProverUrl,
+		brokerArchiver,
 	} = ctx;
 
 	if (!symbol) {
@@ -103,6 +108,22 @@ export async function handleInternalTransfer(
 			symbol,
 			transferPayload.amount,
 		);
+		// account_selector is the source; the destination is kept in payload_json.
+		const normalized = normalizeCcxtTransactionForArchive(result);
+		archiveTransferEventInBackground(brokerArchiver, {
+			exchange: normalizedCex,
+			accountSelector: fromSelector,
+			assetSymbol: symbol,
+			transfer: {
+				eventKind: "internal_transfer",
+				lifecycleAction: "submit_internal_transfer",
+				status: normalized.status ?? "ok",
+				amount: normalized.amount ?? String(transferPayload.amount),
+				network: "internal",
+				externalId: normalized.externalId,
+				payload: { from: fromSelector, to: toSelector, result },
+			},
+		});
 		ctx.wrappedCallback(null, {
 			proof: verity.proof,
 			result: JSON.stringify(result),

--- a/src/handlers/execute-action/orders.ts
+++ b/src/handlers/execute-action/orders.ts
@@ -36,6 +36,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 		verityProverUrl,
 		otelMetrics,
 		brokerArchiver,
+		orderActivityTracker,
 	} = ctx;
 	const verityProof = verity.proof;
 
@@ -82,6 +83,14 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 			side: resolution.side,
 			requestedQuantity: resolution.amountBase ?? orderValue.amount,
 		};
+		// Mark this (account, symbol) so the fill poller scans it for trade history.
+		if (selectedBrokerAccount?.label) {
+			orderActivityTracker?.record(
+				cex,
+				selectedBrokerAccount.label,
+				resolution.symbol,
+			);
+		}
 		const telemetryIds = extractOrderTelemetryIds(orderValue.params);
 		const submissionTimestamp = new Date().toISOString();
 		const marketMetadataHash = await captureMarketMetadataSnapshot(
@@ -183,6 +192,7 @@ async function handleGetOrderDetails(ctx: ExecuteActionContext): Promise<void> {
 		verityProverUrl,
 		otelMetrics,
 		brokerArchiver,
+		orderActivityTracker,
 	} = ctx;
 	const verityProof = verity.proof;
 
@@ -207,6 +217,9 @@ async function handleGetOrderDetails(ctx: ExecuteActionContext): Promise<void> {
 			symbol,
 			{ ...getOrderValue.params },
 		);
+		if (selectedBrokerAccount?.label && symbol) {
+			orderActivityTracker?.record(cex, selectedBrokerAccount.label, symbol);
+		}
 		const getOrderContext = {
 			action: "GetOrderDetails" as const,
 			cex,
@@ -285,6 +298,7 @@ async function handleCancelOrder(ctx: ExecuteActionContext): Promise<void> {
 		verityProverUrl,
 		otelMetrics,
 		brokerArchiver,
+		orderActivityTracker,
 	} = ctx;
 	const verityProof = verity.proof;
 
@@ -312,6 +326,9 @@ async function handleCancelOrder(ctx: ExecuteActionContext): Promise<void> {
 			symbol,
 			cancelOrderValue.params ?? {},
 		);
+		if (selectedBrokerAccount?.label && symbol) {
+			orderActivityTracker?.record(cex, selectedBrokerAccount.label, symbol);
+		}
 		emitOrderExecutionTelemetryInBackground(
 			otelMetrics,
 			cancelOrderContext,

--- a/src/handlers/execute-action/withdraw.ts
+++ b/src/handlers/execute-action/withdraw.ts
@@ -5,6 +5,10 @@ import {
 	withdrawViaLocalEntity,
 } from "../../helpers";
 import {
+	archiveTransferEventInBackground,
+	normalizeCcxtTransactionForArchive,
+} from "../../helpers/broker-execution-archive";
+import {
 	mapCcxtErrorToGrpcStatus,
 	stableGrpcErrorCode,
 } from "../../helpers/grpc/status";
@@ -35,6 +39,7 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 		useVerity,
 		verityProverUrl,
 		otelMetrics,
+		brokerArchiver,
 	} = ctx;
 	const verityProof = verity.proof;
 
@@ -121,6 +126,28 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 						},
 					);
 		log.info(`Withdraw Result: ${JSON.stringify(transaction)}`);
+		// The ccxt transaction carries the venue-normalized withdrawal fee (the
+		// dominant cost at small commits) which the gRPC response drops; archive it.
+		const normalized = normalizeCcxtTransactionForArchive(transaction);
+		archiveTransferEventInBackground(brokerArchiver, {
+			exchange: cex,
+			accountSelector: selectedBrokerAccount?.label,
+			assetSymbol: normalized.assetSymbol ?? symbol,
+			transfer: {
+				eventKind: "withdrawal",
+				lifecycleAction: "submit_withdrawal",
+				status: normalized.status,
+				amount: normalized.amount ?? String(transferValue.amount),
+				address: normalized.address ?? transferValue.recipientAddress,
+				network: normalized.network ?? withdrawNetwork.exchangeNetworkId,
+				externalId: normalized.externalId,
+				txid: normalized.txid,
+				feeAmount: normalized.feeAmount,
+				feeCurrency: normalized.feeCurrency,
+				exchangeTimestamp: normalized.exchangeTimestamp,
+				payload: transaction,
+			},
+		});
 		ctx.wrappedCallback(null, {
 			proof: ctx.verity.proof,
 			result: JSON.stringify({
@@ -132,6 +159,23 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 		});
 	} catch (error) {
 		safeLogError("Withdraw failed", error);
+		// Record the failed submission as a movement-lifecycle fact (error_summary
+		// set). error_summary is the redacted grpc message, not the raw error.
+		archiveTransferEventInBackground(brokerArchiver, {
+			exchange: cex,
+			accountSelector: selectedBrokerAccount?.label,
+			assetSymbol: symbol,
+			transfer: {
+				eventKind: "withdrawal",
+				lifecycleAction: "submit_withdrawal",
+				status: "failed",
+				amount: String(transferValue.amount),
+				address: transferValue.recipientAddress,
+				network: withdrawNetwork.exchangeNetworkId,
+				errorSummary: getErrorMessage(error),
+				payload: { recipientAddress: transferValue.recipientAddress },
+			},
+		});
 		const code = mapCcxtErrorToGrpcStatus(error) ?? grpc.status.INTERNAL;
 		ctx.wrappedCallback(
 			{

--- a/src/helpers/broker-execution-archive/capture.ts
+++ b/src/helpers/broker-execution-archive/capture.ts
@@ -11,6 +11,8 @@ import {
 	buildMarketMetadataSnapshotRow,
 	buildOrderEventArchiveRow,
 	buildSubscribeStreamArchiveRow,
+	buildTransferEventArchiveRow,
+	type TransferArchiveFields,
 } from "./rows";
 import type { SubscribeArchiveType } from "./types";
 import type { BrokerExecutionArchiver } from "./writer";
@@ -85,6 +87,37 @@ export function archiveSubscribeStreamInBackground(
 			log.warn("Failed to archive subscribe stream event", {
 				error: archiveError,
 			});
+		}
+	});
+}
+
+export function archiveTransferEventInBackground(
+	archiver: BrokerExecutionArchiver | undefined,
+	input: {
+		exchange: string;
+		accountSelector?: string;
+		assetSymbol?: string;
+		brokerObservedTimestamp?: string;
+		transfer: TransferArchiveFields;
+	},
+): void {
+	if (!archiver?.isEnabled()) {
+		return;
+	}
+	queueMicrotask(() => {
+		try {
+			const tags = buildCommonArchiveTags({
+				deploymentId: archiver.getDeploymentId(),
+				accountSelector: input.accountSelector,
+				exchange: input.exchange,
+				symbol: input.assetSymbol,
+				brokerObservedTimestamp: input.brokerObservedTimestamp,
+			});
+			archiver.enqueue(
+				buildTransferEventArchiveRow({ tags, transfer: input.transfer }),
+			);
+		} catch (archiveError) {
+			log.warn("Failed to archive transfer event", { error: archiveError });
 		}
 	});
 }

--- a/src/helpers/broker-execution-archive/index.ts
+++ b/src/helpers/broker-execution-archive/index.ts
@@ -1,6 +1,7 @@
 export {
 	archiveOrderExecutionInBackground,
 	archiveSubscribeStreamInBackground,
+	archiveTransferEventInBackground,
 	captureMarketMetadataSnapshot,
 	captureMarketMetadataSnapshotInBackground,
 } from "./capture";
@@ -12,17 +13,27 @@ export {
 } from "./redact";
 export {
 	buildCommonArchiveTags,
+	buildFillEventArchiveRow,
 	buildMarketMetadataSnapshotRow,
 	buildOrderEventArchiveRow,
 	buildSubscribeStreamArchiveRow,
+	buildTransferEventArchiveRow,
+	type FillArchiveFields,
+	normalizeCcxtTradeForArchive,
+	normalizeCcxtTransactionForArchive,
+	type NormalizedCcxtTransfer,
+	type TransferArchiveFields,
 } from "./rows";
 export {
+	ARCHIVE_SCHEMA_VERSION,
 	BROKER_WRITE_SOURCE,
 	type BrokerArchiveCommonTags,
 	type BrokerArchiveRow,
 	type BrokerArchiveTable,
 	type OrderArchiveAction,
 	type SubscribeArchiveType,
+	type TransferEventKind,
+	type TransferLifecycleAction,
 } from "./types";
 export {
 	BrokerExecutionArchiver,

--- a/src/helpers/broker-execution-archive/rows.ts
+++ b/src/helpers/broker-execution-archive/rows.ts
@@ -2,11 +2,15 @@ import type { OrderExecutionTelemetry } from "../order-telemetry";
 import { asRecord } from "../shared/guards";
 import { hashMarketMetadata, redactStreamPayload } from "./redact";
 import {
+	ARCHIVE_SCHEMA_VERSION,
 	BROKER_WRITE_SOURCE,
 	type BrokerArchiveCommonTags,
 	type BrokerArchiveRow,
+	FILL_EVENT_KIND,
 	type OrderArchiveAction,
 	type SubscribeArchiveType,
+	type TransferEventKind,
+	type TransferLifecycleAction,
 } from "./types";
 
 function firstString(...values: unknown[]): string | undefined {
@@ -19,6 +23,33 @@ function firstString(...values: unknown[]): string | undefined {
 		}
 	}
 	return undefined;
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+	for (const value of values) {
+		const numeric =
+			typeof value === "number"
+				? value
+				: typeof value === "string" && value.trim()
+					? Number(value)
+					: Number.NaN;
+		if (Number.isFinite(numeric)) {
+			return numeric;
+		}
+	}
+	return undefined;
+}
+
+function normalizeTimestamp(value: unknown): string | undefined {
+	if (typeof value === "string" && value.trim()) {
+		return value.trim();
+	}
+	const ms = firstNumber(value);
+	if (ms === undefined) {
+		return undefined;
+	}
+	const date = new Date(ms);
+	return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }
 
 function compactUndefined(
@@ -129,6 +160,195 @@ export function buildSubscribeStreamArchiveRow(input: {
 			)?.toLowerCase(),
 			payload_json: JSON.stringify(redactedPayload),
 		}),
+	};
+}
+
+// Column shapes below follow the fiet-maker CEX_EXECUTION_ARCHIVE_CONTRACT: shared
+// tags + contract columns, all quantities/prices as strings (venue precision
+// varies by asset), fill_index/result_index as numbers (UInt32 columns). Two
+// deliberate ADDITIVE divergences the consumer contract doesn't yet list:
+// transfer_events carries fee_amount/fee_currency (the ccxt withdrawal object
+// exposes the fee, which is the dominant small-commit cost), and fill_events.event_kind
+// is stamped with the true trade-history-poller source rather than "create_order_fill".
+
+// Preserve venue precision: prefer the raw string the venue returned (usually in
+// `info`) over ccxt's parsed number, stringifying a number only as a fallback.
+function quantityString(...values: unknown[]): string | undefined {
+	return firstString(...values);
+}
+
+export type TransferArchiveFields = {
+	eventKind: TransferEventKind;
+	lifecycleAction: TransferLifecycleAction;
+	status?: string;
+	amount?: string;
+	address?: string;
+	network?: string;
+	externalId?: string;
+	txid?: string;
+	resultIndex?: number;
+	feeAmount?: string;
+	feeCurrency?: string;
+	exchangeTimestamp?: string;
+	errorSummary?: string;
+	payload: unknown;
+};
+
+// asset_symbol mirrors the shared `symbol` tag for transfers (the moved asset,
+// e.g. "USDC"), per the contract. event_kind/lifecycle_action/external_id are the
+// primary read keys; they are always emitted (external_id/status default to "").
+export function buildTransferEventArchiveRow(input: {
+	tags: BrokerArchiveCommonTags;
+	transfer: TransferArchiveFields;
+}): BrokerArchiveRow {
+	const { tags, transfer } = input;
+	return {
+		table: "broker_execution.transfer_events",
+		row: compactUndefined({
+			...tags,
+			schema_version: ARCHIVE_SCHEMA_VERSION,
+			event_kind: transfer.eventKind,
+			lifecycle_action: transfer.lifecycleAction,
+			status: transfer.status ?? "",
+			asset_symbol: tags.symbol,
+			amount: transfer.amount,
+			address: transfer.address,
+			network: transfer.network,
+			external_id: transfer.externalId ?? "",
+			txid: transfer.txid,
+			result_index: transfer.resultIndex ?? 0,
+			// Additive (not in the consumer contract's transfer_events column set).
+			fee_amount: transfer.feeAmount,
+			fee_currency: transfer.feeCurrency,
+			exchange_timestamp: transfer.exchangeTimestamp,
+			error_summary: transfer.errorSummary,
+			payload_json: JSON.stringify(transfer.payload),
+		}),
+	};
+}
+
+// Normalized fields pulled from a ccxt unified transaction (withdraw/deposit) so
+// the withdraw/deposit handlers stay declarative. The full raw object is kept in
+// payload_json regardless, so this only needs the columns we index/filter on.
+export type NormalizedCcxtTransfer = {
+	externalId?: string;
+	txid?: string;
+	address?: string;
+	network?: string;
+	amount?: string;
+	assetSymbol?: string;
+	status?: string;
+	feeAmount?: string;
+	feeCurrency?: string;
+	exchangeTimestamp?: string;
+};
+
+export function normalizeCcxtTransactionForArchive(
+	transaction: unknown,
+): NormalizedCcxtTransfer {
+	const record = asRecord(transaction);
+	const info = asRecord(record?.info);
+	const fee = asRecord(record?.fee);
+	return compactUndefined({
+		externalId: firstString(record?.id, info?.id, record?.txid, info?.txId),
+		txid: firstString(record?.txid, info?.txId, info?.txid, info?.tx_hash),
+		address: firstString(record?.address, record?.addressTo, info?.address),
+		network: firstString(record?.network, info?.network),
+		amount: quantityString(info?.amount, record?.amount),
+		assetSymbol: firstString(record?.currency, info?.coin, info?.asset),
+		status: firstString(record?.status, info?.status)?.toLowerCase(),
+		feeAmount: quantityString(fee?.cost, record?.feeCost),
+		feeCurrency: firstString(fee?.currency, record?.feeCurrency),
+		exchangeTimestamp: normalizeTimestamp(
+			firstValueForTransfer(
+				record?.timestamp,
+				record?.datetime,
+				info?.applyTime,
+			),
+		),
+	}) as NormalizedCcxtTransfer;
+}
+
+function firstValueForTransfer(...values: unknown[]): unknown {
+	return values.find((value) => value !== undefined && value !== null);
+}
+
+export type FillArchiveFields = {
+	orderId?: string;
+	clientOrderId?: string;
+	fillId?: string;
+	fillIndex?: number;
+	side?: string;
+	orderType?: string;
+	price?: string;
+	baseQuantity?: string;
+	quoteQuantity?: string;
+	feeAmount?: string;
+	feeCurrency?: string;
+	feeRate?: string;
+	exchangeTimestamp?: string;
+	payload: unknown;
+};
+
+// Contract read keys are (symbol, account_selector, broker_observed_timestamp,
+// exchange, order_id, fill_index). order_id/fill_index are always present.
+export function buildFillEventArchiveRow(input: {
+	tags: BrokerArchiveCommonTags;
+	fill: FillArchiveFields;
+}): BrokerArchiveRow {
+	const { tags, fill } = input;
+	return {
+		table: "broker_execution.fill_events",
+		row: compactUndefined({
+			...tags,
+			schema_version: ARCHIVE_SCHEMA_VERSION,
+			event_kind: FILL_EVENT_KIND,
+			order_id: fill.orderId ?? "",
+			client_order_id: fill.clientOrderId,
+			fill_id: fill.fillId,
+			fill_index: fill.fillIndex ?? 0,
+			side: fill.side,
+			order_type: fill.orderType,
+			price: fill.price,
+			base_quantity: fill.baseQuantity,
+			quote_quantity: fill.quoteQuantity,
+			fee_amount: fill.feeAmount,
+			fee_currency: fill.feeCurrency,
+			fee_rate: fill.feeRate,
+			exchange_timestamp: fill.exchangeTimestamp,
+			payload_json: JSON.stringify(fill.payload),
+		}),
+	};
+}
+
+// Maps one ccxt unified trade (fetchMyTrades element) to fill archive fields.
+// fillIndex is assigned by the poller (batch position); left undefined here.
+export function normalizeCcxtTradeForArchive(
+	trade: unknown,
+): FillArchiveFields {
+	const record = asRecord(trade);
+	const info = asRecord(record?.info);
+	const fee = asRecord(record?.fee);
+	return {
+		orderId: firstString(record?.order, info?.orderId, info?.orderID),
+		clientOrderId: firstString(
+			record?.clientOrderId,
+			info?.clientOrderId,
+			info?.origClientOrderId,
+		),
+		fillId: firstString(record?.id, info?.id, info?.tradeId),
+		side: firstString(record?.side, info?.side)?.toLowerCase(),
+		orderType: firstString(record?.type, info?.type)?.toLowerCase(),
+		price: quantityString(info?.price, record?.price),
+		baseQuantity: quantityString(info?.qty, record?.amount),
+		quoteQuantity: quantityString(info?.quoteQty, record?.cost),
+		feeAmount: quantityString(fee?.cost, info?.commission),
+		feeCurrency: firstString(fee?.currency, info?.commissionAsset),
+		feeRate: quantityString(fee?.rate),
+		exchangeTimestamp: normalizeTimestamp(
+			firstValueForTransfer(record?.timestamp, record?.datetime, info?.time),
+		),
+		payload: trade,
 	};
 }
 

--- a/src/helpers/broker-execution-archive/types.ts
+++ b/src/helpers/broker-execution-archive/types.ts
@@ -1,8 +1,16 @@
 export const BROKER_WRITE_SOURCE = "broker_write" as const;
 
+// Bumped only on a breaking column-shape change to a broker_execution table.
+// Stamped onto every transfer_events / fill_events row so a reader can tell which
+// row layout produced it (the forwarder's CREATE TABLE IF NOT EXISTS never
+// migrates an existing table — see D7 in the observability proposal).
+export const ARCHIVE_SCHEMA_VERSION = "1" as const;
+
 export type BrokerArchiveTable =
 	| "broker_execution.order_events"
 	| "broker_execution.market_metadata_snapshots"
+	| "broker_execution.transfer_events"
+	| "broker_execution.fill_events"
 	| "market_data.orderbook_snapshots"
 	| "market_data.candles"
 	| "market_data.cex_stream_events"
@@ -29,3 +37,19 @@ export type OrderArchiveAction =
 	| "GetOrderDetails";
 
 export type SubscribeArchiveType = "ORDERS" | "BALANCE";
+
+// A CEX value movement between accounts/wallets (as opposed to an order fill).
+// Values match the fiet-maker CEX_EXECUTION_ARCHIVE_CONTRACT transfer_events grain.
+export type TransferEventKind = "withdrawal" | "deposit" | "internal_transfer";
+
+// Which movement lifecycle step produced the row (contract `lifecycle_action`).
+export type TransferLifecycleAction =
+	| "submit_withdrawal"
+	| "observe_deposit"
+	| "submit_internal_transfer";
+
+// fill_events.event_kind. The contract fixture uses "create_order_fill" for fills
+// exploded from a createOrder result; our producer is the trade-history poller
+// (createOrder results carry no trades[] on the venues in use — see WS2.2), so we
+// stamp the true source here. Same column, honest provenance value.
+export const FILL_EVENT_KIND = "trade_history_fill" as const;

--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -294,15 +294,50 @@ export class BrokerExecutionArchiver {
 		}
 
 		this.stats.flushed += batch.length;
+		this.recordFlushHealth(batch);
 		return true;
+	}
+
+	// Self-health emitted only on a successful forwarder post (or OTel-only flush):
+	// a per-table rows-flushed counter to compare against enqueued, and a
+	// last-flush-success gauge (unix seconds) whose staleness is the "archive plane
+	// stuck" signal. Fire-and-forget so metrics never gate flushing.
+	private recordFlushHealth(batch: BrokerArchiveRow[]): void {
+		const countByTable = new Map<string, number>();
+		for (const entry of batch) {
+			countByTable.set(entry.table, (countByTable.get(entry.table) ?? 0) + 1);
+		}
+		for (const [table, count] of countByTable) {
+			void this.recordArchiveMetric(
+				"cex_archive_rows_flushed_total",
+				{ table },
+				count,
+			);
+		}
+		void this.recordArchiveGauge(
+			"cex_archive_last_flush_success",
+			Math.floor(Date.now() / 1000),
+		);
 	}
 
 	private async recordArchiveMetric(
 		metricName: string,
 		labels: Record<string, string | number>,
+		value = 1,
 	): Promise<void> {
 		try {
-			await this.otelMetrics?.recordCounter(metricName, 1, labels);
+			await this.otelMetrics?.recordCounter(metricName, value, labels);
+		} catch {
+			// Archive metrics must not affect flushing.
+		}
+	}
+
+	private async recordArchiveGauge(
+		metricName: string,
+		value: number,
+	): Promise<void> {
+		try {
+			await this.otelMetrics?.recordGauge(metricName, value, {});
 		} catch {
 			// Archive metrics must not affect flushing.
 		}

--- a/src/helpers/fill-archive-poller.ts
+++ b/src/helpers/fill-archive-poller.ts
@@ -1,0 +1,217 @@
+import type { BrokerPoolEntry } from "./broker";
+import { resolveBrokerAccount } from "./broker";
+import {
+	type BrokerExecutionArchiver,
+	buildCommonArchiveTags,
+	buildFillEventArchiveRow,
+	normalizeCcxtTradeForArchive,
+} from "./broker-execution-archive";
+import { log } from "./logger";
+import type { OrderActivityTracker } from "./order-activity-tracker";
+import type { OtelMetrics } from "./otel";
+import { asRecord } from "./shared/guards";
+
+// ccxt method surface used by the poller (typed defensively — not every exchange
+// build exposes fetchMyTrades).
+type ExchangeWithTrades = {
+	fetchMyTrades?: (
+		symbol: string,
+		since?: number,
+		limit?: number,
+		params?: Record<string, unknown>,
+	) => Promise<unknown[]>;
+	has?: Record<string, unknown>;
+};
+
+export type FillArchivePollerConfig = {
+	// Constant defaults (no env vars): every broker env var must be allowlisted in a
+	// Gramine manifest in another repo, so the poller intentionally introduces none.
+	pollIntervalMs: number;
+	// How far back the first poll of a (account, symbol) reaches. A restart loses the
+	// in-memory cursor and re-scans this window; the resulting duplicate rows are
+	// resolved by read-time dedup (fill_events is plain MergeTree, per contract).
+	lookbackMs: number;
+	tradesLimit: number;
+};
+
+const DEFAULT_CONFIG: FillArchivePollerConfig = {
+	pollIntervalMs: 60_000,
+	lookbackMs: 24 * 60 * 60 * 1000,
+	tradesLimit: 500,
+};
+
+/**
+ * Advances a since-cursor past the newest trade in a batch. The next poll asks for
+ * trades strictly after the last one seen (+1ms) so the same trade is not refetched
+ * every tick, while still tolerating out-of-order timestamps within a batch.
+ */
+export function nextFillCursor(
+	trades: unknown[],
+	currentSince: number,
+): number {
+	let next = currentSince;
+	for (const trade of trades) {
+		const ts = asRecord(trade)?.timestamp;
+		if (typeof ts === "number" && Number.isFinite(ts) && ts + 1 > next) {
+			next = ts + 1;
+		}
+	}
+	return next;
+}
+
+/**
+ * Broker-internal periodic capture of per-fill facts. For each (account, symbol)
+ * that saw recent order activity it calls the venue trade-history endpoint
+ * (fetchMyTrades) with a since-cursor and archives each trade to
+ * broker_execution.fill_events. Started at bootstrap only when archiving is
+ * enabled; symbols are staggered by sequential awaits so one tick never bursts the
+ * venue rate limit. Mirrors the TravelRuleDepositReconciler lifecycle.
+ */
+export class FillArchivePoller {
+	#timer: ReturnType<typeof setTimeout> | null = null;
+	#stopped = false;
+	#running = false;
+	// Per (exchange|account|symbol) last since-cursor (epoch ms). In-memory only.
+	readonly #cursors = new Map<string, number>();
+	readonly #config: FillArchivePollerConfig;
+
+	constructor(
+		private readonly params: {
+			brokers: Record<string, BrokerPoolEntry>;
+			archiver: BrokerExecutionArchiver;
+			tracker: OrderActivityTracker;
+			metrics?: OtelMetrics;
+			config?: Partial<FillArchivePollerConfig>;
+		},
+	) {
+		this.#config = { ...DEFAULT_CONFIG, ...params.config };
+	}
+
+	start(): void {
+		if (this.#timer || this.#stopped) {
+			return;
+		}
+		if (!this.params.archiver.isEnabled()) {
+			return;
+		}
+		log.info("🧾 Fill archive poller started");
+		this.#timer = setTimeout(() => void this.#tick(), 0);
+		this.#timer.unref?.();
+	}
+
+	stop(): void {
+		this.#stopped = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = null;
+		}
+	}
+
+	async #tick(): Promise<void> {
+		if (this.#stopped || this.#running) {
+			return;
+		}
+		this.#running = true;
+		try {
+			await this.pollTrackedOnce();
+		} catch (error) {
+			log.error("Fill archive poller tick failed", error);
+		} finally {
+			this.#running = false;
+			if (!this.#stopped) {
+				this.#timer = setTimeout(
+					() => void this.#tick(),
+					this.#config.pollIntervalMs,
+				);
+				this.#timer.unref?.();
+			}
+		}
+	}
+
+	/**
+	 * Runs one poll pass over every tracked (account, symbol), sequentially so the
+	 * per-symbol awaits stagger venue calls. Exposed for tests (the timer loop calls
+	 * it every tick).
+	 */
+	async pollTrackedOnce(): Promise<void> {
+		for (const entry of this.params.tracker.list()) {
+			if (this.#stopped) {
+				break;
+			}
+			await this.#pollOne(entry.exchangeId, entry.accountLabel, entry.symbol);
+		}
+	}
+
+	async #pollOne(
+		exchangeId: string,
+		accountLabel: string,
+		symbol: string,
+	): Promise<void> {
+		const account = resolveBrokerAccount(
+			this.params.brokers[exchangeId],
+			accountLabel,
+		);
+		if (!account) {
+			return;
+		}
+		const exchange = account.exchange as unknown as ExchangeWithTrades;
+		if (
+			typeof exchange.fetchMyTrades !== "function" ||
+			exchange.has?.fetchMyTrades === false
+		) {
+			return;
+		}
+
+		const key = `${exchangeId}|${accountLabel}|${symbol}`;
+		const since =
+			this.#cursors.get(key) ?? Date.now() - this.#config.lookbackMs;
+
+		let trades: unknown[];
+		try {
+			trades = await exchange.fetchMyTrades(
+				symbol,
+				since,
+				this.#config.tradesLimit,
+			);
+		} catch (error) {
+			void this.params.metrics?.recordCounter(
+				"cex_fill_poller_errors_total",
+				1,
+				{
+					exchange: exchangeId,
+				},
+			);
+			log.warn("Fill archive poll failed", {
+				exchange: exchangeId,
+				account: accountLabel,
+				symbol,
+				error,
+			});
+			return;
+		}
+		if (!Array.isArray(trades) || trades.length === 0) {
+			return;
+		}
+
+		trades.forEach((trade, fillIndex) => {
+			const tags = buildCommonArchiveTags({
+				deploymentId: this.params.archiver.getDeploymentId(),
+				accountSelector: accountLabel,
+				exchange: exchangeId,
+				symbol,
+			});
+			this.params.archiver.enqueue(
+				buildFillEventArchiveRow({
+					tags,
+					fill: { ...normalizeCcxtTradeForArchive(trade), fillIndex },
+				}),
+			);
+		});
+		void this.params.metrics?.recordCounter(
+			"cex_fill_poller_trades_archived_total",
+			trades.length,
+			{ exchange: exchangeId },
+		);
+		this.#cursors.set(key, nextFillCursor(trades, since));
+	}
+}

--- a/src/helpers/order-activity-tracker.ts
+++ b/src/helpers/order-activity-tracker.ts
@@ -1,0 +1,59 @@
+export type OrderActivityEntry = {
+	exchangeId: string;
+	accountLabel: string;
+	symbol: string;
+	lastActivityAt: number;
+};
+
+// Entries not touched within this window are dropped from the poll set: their
+// trades have long since been archived and re-polling them wastes venue rate limit.
+const DEFAULT_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Records the (exchange, account, symbol) tuples that saw order activity through
+ * the execute-action path, so the fill poller scans only those markets instead of
+ * the whole exchange. Process-lifetime, in-memory only (no persistence needed: on
+ * restart the poller re-derives the set from fresh order activity and read-time
+ * dedup absorbs the lookback re-scan).
+ */
+export class OrderActivityTracker {
+	readonly #entries = new Map<string, OrderActivityEntry>();
+	readonly #maxAgeMs: number;
+
+	constructor(options?: { maxAgeMs?: number }) {
+		this.#maxAgeMs = options?.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+	}
+
+	record(
+		exchangeId: string,
+		accountLabel: string,
+		symbol: string,
+		now: number = Date.now(),
+	): void {
+		const exchange = exchangeId.trim().toLowerCase();
+		const trimmedSymbol = symbol.trim();
+		if (!exchange || !accountLabel.trim() || !trimmedSymbol) {
+			return;
+		}
+		const key = `${exchange}|${accountLabel}|${trimmedSymbol}`;
+		this.#entries.set(key, {
+			exchangeId: exchange,
+			accountLabel,
+			symbol: trimmedSymbol,
+			lastActivityAt: now,
+		});
+	}
+
+	/** Active entries (seen within maxAge). Prunes stale entries as a side effect. */
+	list(now: number = Date.now()): OrderActivityEntry[] {
+		const active: OrderActivityEntry[] = [];
+		for (const [key, entry] of this.#entries) {
+			if (now - entry.lastActivityAt > this.#maxAgeMs) {
+				this.#entries.delete(key);
+				continue;
+			}
+			active.push(entry);
+		}
+		return active;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ import {
 	type BrokerExecutionArchiver,
 	createBrokerExecutionArchiverFromEnv,
 } from "./helpers/broker-execution-archive";
+import { FillArchivePoller } from "./helpers/fill-archive-poller";
 import { log } from "./helpers/logger";
+import { OrderActivityTracker } from "./helpers/order-activity-tracker";
 import {
 	createOtelLogsFromEnv,
 	createOtelMetricsFromEnv,
@@ -52,6 +54,10 @@ export default class CEXBroker {
 	private otelLogs?: OtelLogs;
 	private brokerArchiver?: BrokerExecutionArchiver;
 	private depositReconciler?: TravelRuleDepositReconciler;
+	// Order activity feeds the fill poller its per-market poll set; shared with the
+	// execute-action handler so orders record the (account, symbol) they touch.
+	private readonly orderActivityTracker = new OrderActivityTracker();
+	private fillArchivePoller?: FillArchivePoller;
 
 	/**
 	 * Loads environment variables prefixed with CEX_BROKER_
@@ -273,6 +279,10 @@ export default class CEXBroker {
 			this.depositReconciler.stop();
 			this.depositReconciler = undefined;
 		}
+		if (this.fillArchivePoller) {
+			this.fillArchivePoller.stop();
+			this.fillArchivePoller = undefined;
+		}
 		if (this.server) {
 			await this.server.forceShutdown();
 		}
@@ -294,11 +304,15 @@ export default class CEXBroker {
 		if (this.server) {
 			await this.server.forceShutdown();
 		}
-		// run() is re-invoked on policy hot-reload; tear down the prior reconciler so
-		// it is rebuilt against the updated policy rather than duplicated.
+		// run() is re-invoked on policy hot-reload; tear down the prior reconciler and
+		// poller so they are rebuilt rather than duplicated.
 		if (this.depositReconciler) {
 			this.depositReconciler.stop();
 			this.depositReconciler = undefined;
+		}
+		if (this.fillArchivePoller) {
+			this.fillArchivePoller.stop();
+			this.fillArchivePoller = undefined;
 		}
 		log.info(`Running CEXBroker at ${new Date().toISOString()}`);
 
@@ -315,6 +329,7 @@ export default class CEXBroker {
 			this.#verityProverUrl,
 			this.otelMetrics,
 			this.brokerArchiver,
+			this.orderActivityTracker,
 		);
 
 		this.server.bindAsync(
@@ -339,6 +354,19 @@ export default class CEXBroker {
 			metrics: this.otelMetrics,
 		});
 		this.depositReconciler.start();
+
+		// Per-fill capture from the venue trade-history endpoint. Only runs when the
+		// archive plane is enabled (a forwarder/OTel sink is configured); otherwise
+		// there is nowhere to write fills, so it stays inert.
+		if (this.brokerArchiver?.isEnabled()) {
+			this.fillArchivePoller = new FillArchivePoller({
+				brokers: this.brokers,
+				archiver: this.brokerArchiver,
+				tracker: this.orderActivityTracker,
+				metrics: this.otelMetrics,
+			});
+			this.fillArchivePoller.start();
+		}
 		return this;
 	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { createExecuteActionHandler } from "./handlers/execute-action";
 import { createSubscribeHandler } from "./handlers/subscribe";
 import type { BrokerPoolEntry } from "./helpers";
 import type { BrokerExecutionArchiver } from "./helpers/broker-execution-archive";
+import type { OrderActivityTracker } from "./helpers/order-activity-tracker";
 import type { OtelMetrics } from "./helpers/otel";
 import { CEX_BROKER_PACKAGE_DEFINITION } from "./proto-package-definition";
 import type { PolicyConfig } from "./types";
@@ -26,6 +27,7 @@ export function getServer(
 	verityProverUrl: string,
 	otelMetrics?: OtelMetrics,
 	brokerArchiver?: BrokerExecutionArchiver,
+	orderActivityTracker?: OrderActivityTracker,
 ) {
 	const server = new grpc.Server();
 
@@ -38,6 +40,7 @@ export function getServer(
 			verityProverUrl,
 			otelMetrics,
 			brokerArchiver,
+			orderActivityTracker,
 		}),
 		Subscribe: createSubscribeHandler({
 			brokers,

--- a/test/archive-forwarder.test.ts
+++ b/test/archive-forwarder.test.ts
@@ -66,6 +66,53 @@ describe("archive forwarder batch parsing", () => {
 		expect(parsed.batch.rows).toHaveLength(1);
 	});
 
+	test("accepts the new broker_execution transfer_events and fill_events tables", () => {
+		expect(isSupportedTable("broker_execution.transfer_events")).toBe(true);
+		expect(isSupportedTable("broker_execution.fill_events")).toBe(true);
+
+		const parsed = parseArchiveBatchRequest({
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			rows: [
+				{
+					table: "broker_execution.transfer_events",
+					row: { external_id: "wd-1", event_kind: "withdrawal" },
+				},
+				{
+					table: "broker_execution.fill_events",
+					row: { order_id: "o-1", trade_id: "t-1" },
+				},
+			],
+		});
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) {
+			return;
+		}
+		expect(parsed.rejectedRowCount).toBe(0);
+		expect(parsed.batch.rows).toHaveLength(2);
+	});
+
+	test("names the offending tables in rejectedTables so a bad rollout is visible", () => {
+		const parsed = parseArchiveBatchRequest({
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			rows: [
+				{ table: "broker_execution.order_events", row: { order_id: "1" } },
+				{ table: "broker_execution.mystery_table", row: { x: 1 } },
+				{ table: 123, row: {} },
+			],
+		});
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) {
+			return;
+		}
+		expect(parsed.rejectedRowCount).toBe(2);
+		expect(parsed.batch.rows).toHaveLength(1);
+		expect(parsed.rejectedTables).toEqual(
+			expect.arrayContaining(["broker_execution.mystery_table", "(malformed)"]),
+		);
+	});
+
 	test("parseArchiveBatchRequest accepts broker_execution and strategy_data, rejects unknown tables", () => {
 		const parsed = parseArchiveBatchRequest({
 			source: "hb_runtime",
@@ -260,6 +307,8 @@ describe("archive forwarder schema init", () => {
 			expect.arrayContaining([
 				"broker_execution.order_events",
 				"broker_execution.market_metadata_snapshots",
+				"broker_execution.transfer_events",
+				"broker_execution.fill_events",
 				"strategy_data.policy_evaluation_events",
 				"strategy_data.strategy_policy_snapshots",
 				"strategy_data.inventory_settlement_events",

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -7,9 +7,13 @@ import {
 } from "../src/helpers/broker-execution-archive/redact";
 import {
 	buildCommonArchiveTags,
+	buildFillEventArchiveRow,
 	buildMarketMetadataSnapshotRow,
 	buildOrderEventArchiveRow,
 	buildSubscribeStreamArchiveRow,
+	buildTransferEventArchiveRow,
+	normalizeCcxtTradeForArchive,
+	normalizeCcxtTransactionForArchive,
 } from "../src/helpers/broker-execution-archive/rows";
 import {
 	BrokerExecutionArchiver,
@@ -181,6 +185,266 @@ describe("broker execution archive rows", () => {
 		}
 		// A snapshot always computes its content hash, so it is always present.
 		expect(snapshotRow.row).toHaveProperty("market_metadata_hash");
+	});
+
+	test("builds transfer event rows in the contract column shape", () => {
+		const row = buildTransferEventArchiveRow({
+			tags: buildCommonArchiveTags({
+				deploymentId: "deploy-a",
+				accountSelector: "primary",
+				exchange: "binance",
+				symbol: "USDC",
+			}),
+			transfer: {
+				eventKind: "withdrawal",
+				lifecycleAction: "submit_withdrawal",
+				status: "ok",
+				amount: "100",
+				address: "0xdead",
+				network: "ARBITRUM",
+				externalId: "wd-1",
+				txid: "0xabc",
+				feeAmount: "4.89",
+				feeCurrency: "USDC",
+				payload: { id: "wd-1" },
+			},
+		});
+
+		expect(row.table).toBe("broker_execution.transfer_events");
+		expect(row.row).toMatchObject({
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			account_selector: "primary",
+			exchange: "binance",
+			symbol: "USDC",
+			// asset_symbol mirrors the shared symbol tag for transfers, per contract.
+			asset_symbol: "USDC",
+			schema_version: "1",
+			event_kind: "withdrawal",
+			lifecycle_action: "submit_withdrawal",
+			status: "ok",
+			amount: "100",
+			external_id: "wd-1",
+			result_index: 0,
+			// Additive columns (ccxt exposes the withdrawal fee).
+			fee_amount: "4.89",
+			fee_currency: "USDC",
+		});
+	});
+
+	test("transfer rows keep the read-key columns present when ids are absent", () => {
+		const row = buildTransferEventArchiveRow({
+			tags: buildCommonArchiveTags({
+				deploymentId: "deploy-a",
+				exchange: "binance",
+				symbol: "USDC",
+			}),
+			transfer: {
+				eventKind: "deposit",
+				lifecycleAction: "observe_deposit",
+				payload: {},
+			},
+		});
+		expect(row.row.external_id).toBe("");
+		expect(row.row.status).toBe("");
+		expect(row.row.result_index).toBe(0);
+		expect(row.row.event_kind).toBe("deposit");
+	});
+
+	test("normalizeCcxtTransactionForArchive captures the withdrawal fee as a string", () => {
+		const normalized = normalizeCcxtTransactionForArchive({
+			id: "wd-1",
+			txid: "0xabc",
+			address: "0xdead",
+			currency: "USDC",
+			amount: 100,
+			status: "ok",
+			network: "ARBITRUM",
+			fee: { cost: 4.89, currency: "USDC" },
+			datetime: "2026-07-04T00:00:00.000Z",
+		});
+		expect(normalized).toMatchObject({
+			externalId: "wd-1",
+			txid: "0xabc",
+			address: "0xdead",
+			network: "ARBITRUM",
+			amount: "100",
+			assetSymbol: "USDC",
+			status: "ok",
+			feeAmount: "4.89",
+			feeCurrency: "USDC",
+			exchangeTimestamp: "2026-07-04T00:00:00.000Z",
+		});
+	});
+
+	test("normalizeCcxtTransactionForArchive prefers the venue raw string amount", () => {
+		const normalized = normalizeCcxtTransactionForArchive({
+			amount: 7.5,
+			info: { amount: "7.50000000" },
+			fee: { cost: 0.1 },
+		});
+		// Venue precision preserved over ccxt's parsed number.
+		expect(normalized.amount).toBe("7.50000000");
+	});
+
+	test("builds fill event rows in the contract column shape", () => {
+		const row = buildFillEventArchiveRow({
+			tags: buildCommonArchiveTags({
+				deploymentId: "deploy-a",
+				accountSelector: "primary",
+				exchange: "binance",
+				symbol: "USDC/USDT",
+			}),
+			fill: {
+				...normalizeCcxtTradeForArchive({
+					id: "t-1",
+					order: "o-1",
+					clientOrderId: "c-1",
+					side: "BUY",
+					type: "limit",
+					price: 1.0,
+					amount: 50,
+					cost: 50,
+					fee: { cost: 0.05, currency: "USDC", rate: 0.001 },
+					timestamp: 1_700_000_000_000,
+				}),
+				fillIndex: 2,
+			},
+		});
+
+		expect(row.table).toBe("broker_execution.fill_events");
+		expect(row.row).toMatchObject({
+			symbol: "USDC/USDT",
+			schema_version: "1",
+			// Honest provenance: trade-history poller, not createOrder trades[].
+			event_kind: "trade_history_fill",
+			order_id: "o-1",
+			client_order_id: "c-1",
+			fill_id: "t-1",
+			fill_index: 2,
+			side: "buy",
+			order_type: "limit",
+			price: "1",
+			base_quantity: "50",
+			quote_quantity: "50",
+			fee_amount: "0.05",
+			fee_currency: "USDC",
+			fee_rate: "0.001",
+		});
+	});
+
+	test("fill rows default order_id/fill_index (contract read keys) when the venue omits them", () => {
+		const row = buildFillEventArchiveRow({
+			tags: buildCommonArchiveTags({
+				deploymentId: "deploy-a",
+				exchange: "binance",
+				symbol: "USDC/USDT",
+			}),
+			fill: normalizeCcxtTradeForArchive({ price: 1 }),
+		});
+		expect(row.row.order_id).toBe("");
+		expect(row.row.fill_index).toBe(0);
+	});
+
+	// Guards the fiet-maker CEX_EXECUTION_ARCHIVE_CONTRACT: a fully-populated row must
+	// carry every consumer-required column so the sandbox proof harness queries hold.
+	test("transfer/fill rows cover every consumer-contract column", () => {
+		const CONTRACT_TRANSFER_COLUMNS = [
+			"broker_observed_timestamp",
+			"source",
+			"deployment_id",
+			"schema_version",
+			"account_selector",
+			"exchange",
+			"symbol",
+			"event_kind",
+			"lifecycle_action",
+			"status",
+			"asset_symbol",
+			"amount",
+			"address",
+			"network",
+			"external_id",
+			"txid",
+			"result_index",
+			"exchange_timestamp",
+			"error_summary",
+			"payload_json",
+		];
+		const CONTRACT_FILL_COLUMNS = [
+			"broker_observed_timestamp",
+			"source",
+			"deployment_id",
+			"schema_version",
+			"account_selector",
+			"exchange",
+			"symbol",
+			"event_kind",
+			"order_id",
+			"client_order_id",
+			"fill_id",
+			"fill_index",
+			"side",
+			"order_type",
+			"price",
+			"base_quantity",
+			"quote_quantity",
+			"fee_amount",
+			"fee_currency",
+			"fee_rate",
+			"exchange_timestamp",
+			"payload_json",
+		];
+		const tags = buildCommonArchiveTags({
+			deploymentId: "deploy-a",
+			accountSelector: "secondary:1",
+			exchange: "binance",
+			symbol: "USDC",
+		});
+		const transferRow = buildTransferEventArchiveRow({
+			tags,
+			transfer: {
+				eventKind: "withdrawal",
+				lifecycleAction: "submit_withdrawal",
+				status: "ok",
+				amount: "7.5",
+				address: "0xwallet",
+				network: "ARBITRUM",
+				externalId: "wd-1",
+				txid: "0xabc",
+				resultIndex: 0,
+				feeAmount: "0.1",
+				feeCurrency: "USDC",
+				exchangeTimestamp: "2026-07-04T00:00:00.000Z",
+				errorSummary: "",
+				payload: {},
+			},
+		}).row;
+		for (const column of CONTRACT_TRANSFER_COLUMNS) {
+			expect(transferRow).toHaveProperty(column);
+		}
+		const fillRow = buildFillEventArchiveRow({
+			tags,
+			fill: {
+				orderId: "o-1",
+				clientOrderId: "c-1",
+				fillId: "t-1",
+				fillIndex: 0,
+				side: "buy",
+				orderType: "limit",
+				price: "1",
+				baseQuantity: "5",
+				quoteQuantity: "5",
+				feeAmount: "0.01",
+				feeCurrency: "USDC",
+				feeRate: "0.001",
+				exchangeTimestamp: "2026-07-04T00:00:00.000Z",
+				payload: {},
+			},
+		}).row;
+		for (const column of CONTRACT_FILL_COLUMNS) {
+			expect(fillRow).toHaveProperty(column);
+		}
 	});
 });
 

--- a/test/fill-archive-poller.test.ts
+++ b/test/fill-archive-poller.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import type { BrokerAccount, BrokerPoolEntry } from "../src/helpers/broker";
+import type { BrokerArchiveRow } from "../src/helpers/broker-execution-archive";
+import type { BrokerExecutionArchiver } from "../src/helpers/broker-execution-archive";
+import {
+	FillArchivePoller,
+	nextFillCursor,
+} from "../src/helpers/fill-archive-poller";
+import { OrderActivityTracker } from "../src/helpers/order-activity-tracker";
+
+function fakeArchiver(sink: BrokerArchiveRow[]): BrokerExecutionArchiver {
+	return {
+		isEnabled: () => true,
+		getDeploymentId: () => "deploy-a",
+		enqueue: (row: BrokerArchiveRow) => sink.push(row),
+	} as unknown as BrokerExecutionArchiver;
+}
+
+function poolWith(exchange: unknown): Record<string, BrokerPoolEntry> {
+	const account = { exchange, label: "primary" } as unknown as BrokerAccount;
+	return { binance: { primary: account, secondaryBrokers: [] } };
+}
+
+describe("OrderActivityTracker", () => {
+	test("records distinct (exchange, account, symbol) and normalizes the exchange", () => {
+		const tracker = new OrderActivityTracker();
+		tracker.record("Binance", "primary", "USDC/USDT", 1_000);
+		tracker.record("binance", "primary", "USDC/USDT", 2_000);
+		tracker.record("binance", "secondary:1", "ARB/USDT", 2_000);
+
+		const entries = tracker.list(2_000);
+		expect(entries).toHaveLength(2);
+		expect(entries).toContainEqual({
+			exchangeId: "binance",
+			accountLabel: "primary",
+			symbol: "USDC/USDT",
+			lastActivityAt: 2_000,
+		});
+	});
+
+	test("ignores empty inputs and prunes entries past maxAge", () => {
+		const tracker = new OrderActivityTracker({ maxAgeMs: 1_000 });
+		tracker.record("binance", "", "USDC/USDT", 0);
+		tracker.record("binance", "primary", "USDC/USDT", 0);
+
+		expect(tracker.list(500)).toHaveLength(1);
+		expect(tracker.list(2_000)).toHaveLength(0);
+	});
+});
+
+describe("nextFillCursor", () => {
+	test("advances past the newest trade timestamp, tolerating out-of-order batches", () => {
+		expect(
+			nextFillCursor(
+				[{ timestamp: 100 }, { timestamp: 250 }, { timestamp: 200 }],
+				0,
+			),
+		).toBe(251);
+	});
+
+	test("keeps the current cursor when the batch has no usable timestamps", () => {
+		expect(nextFillCursor([], 42)).toBe(42);
+		expect(nextFillCursor([{ id: "no-ts" }], 42)).toBe(42);
+	});
+});
+
+describe("FillArchivePoller.pollTrackedOnce", () => {
+	test("archives fetched trades and advances the cursor so the next poll is incremental", async () => {
+		// Newer than the poller's lookback floor (now - 24h) so the cursor actually
+		// advances past it on the first pass.
+		const tradeTs = Date.now() + 10_000;
+		const trades = [
+			{
+				id: "t-1",
+				order: "o-1",
+				side: "buy",
+				price: 1,
+				amount: 50,
+				cost: 50,
+				timestamp: tradeTs,
+				fee: { cost: 0.05, currency: "USDC" },
+			},
+		];
+		let calls = 0;
+		let lastSince: number | undefined;
+		const exchange = {
+			has: { fetchMyTrades: true },
+			fetchMyTrades: async (_symbol: string, since?: number) => {
+				calls += 1;
+				lastSince = since;
+				return calls === 1 ? trades : [];
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const tracker = new OrderActivityTracker();
+		tracker.record("binance", "primary", "USDC/USDT");
+		const poller = new FillArchivePoller({
+			brokers: poolWith(exchange),
+			archiver: fakeArchiver(sink),
+			tracker,
+		});
+
+		await poller.pollTrackedOnce();
+		expect(sink).toHaveLength(1);
+		expect(sink[0]?.table).toBe("broker_execution.fill_events");
+		expect(sink[0]?.row).toMatchObject({
+			order_id: "o-1",
+			fill_id: "t-1",
+			fill_index: 0,
+			event_kind: "trade_history_fill",
+			symbol: "USDC/USDT",
+			account_selector: "primary",
+		});
+
+		// Second pass asks strictly after the last seen trade and archives nothing new.
+		await poller.pollTrackedOnce();
+		expect(calls).toBe(2);
+		expect(lastSince).toBe(tradeTs + 1);
+		expect(sink).toHaveLength(1);
+	});
+
+	test("skips accounts whose exchange has no fetchMyTrades", async () => {
+		const sink: BrokerArchiveRow[] = [];
+		const tracker = new OrderActivityTracker();
+		tracker.record("binance", "primary", "USDC/USDT");
+		const poller = new FillArchivePoller({
+			brokers: poolWith({ has: { fetchMyTrades: false } }),
+			archiver: fakeArchiver(sink),
+			tracker,
+		});
+
+		await poller.pollTrackedOnce();
+		expect(sink).toHaveLength(0);
+	});
+
+	test("a failing venue call does not stall the other tracked symbols", async () => {
+		const good = {
+			has: { fetchMyTrades: true },
+			fetchMyTrades: async () => [
+				{ id: "t-9", order: "o-9", timestamp: 5, price: 2, amount: 1, cost: 2 },
+			],
+		};
+		const bad = {
+			has: { fetchMyTrades: true },
+			fetchMyTrades: async () => {
+				throw new Error("rate limited");
+			},
+		};
+		const account = (exchange: unknown, label: string, index?: number) =>
+			({ exchange, label, index }) as unknown as BrokerAccount;
+		const brokers: Record<string, BrokerPoolEntry> = {
+			binance: {
+				primary: account(bad, "primary"),
+				secondaryBrokers: [account(good, "secondary:1", 1)],
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const tracker = new OrderActivityTracker();
+		tracker.record("binance", "primary", "USDC/USDT");
+		tracker.record("binance", "secondary:1", "ARB/USDT");
+		const poller = new FillArchivePoller({
+			brokers,
+			archiver: fakeArchiver(sink),
+			tracker,
+		});
+
+		await poller.pollTrackedOnce();
+		// The good account still produced its fill despite the bad account throwing.
+		expect(sink).toHaveLength(1);
+		expect(sink[0]?.row).toMatchObject({ fill_id: "t-9", symbol: "ARB/USDT" });
+	});
+});


### PR DESCRIPTION
## Summary

Adds durable CEX execution facts for the two grains that today require repeated, truncation-prone venue-history scans: `broker_execution.transfer_events` and `broker_execution.fill_events`, end to end (row builders, emit sites, forwarder support, schema).

### transfer_events

- Withdrawals emit at the execute-action site, **including the venue fee the ccxt transaction already carries** (previously discarded) and failed attempts (`status="failed"` with `error_summary`).
- Observed deposits emit from the deposit polling path; sub↔master internal transfers emit as `event_kind="internal_transfer"`.
- Withdrawal fees dominate measurable cost at small commits, and deposit-account attribution enables cheap wrong-account-credit detection — both currently reconstructed via paginated venue APIs.

### fill_events

- Production `createOrder`/`GetOrderDetails` responses carry **no per-trade data and no fees** (verified against live archive rows: 0 of ~520k detail rows have `trades[]` or fee fields), so per-fill truth requires the trade-history endpoint.
- A `FillArchivePoller` (constructed only when archiving is enabled; mirrors the deposit-reconciler lifecycle) polls ccxt trade history per (account, symbol) seen through order activity, with an in-memory since-cursor. Restart re-scans a bounded lookback; duplicates resolve at read time (plain MergeTree, per the consumer contract). Symbols poll sequentially to stagger venue calls; per-symbol failures are isolated. Enclave-safe (node http/https only).

### Contract alignment

Column shapes follow fiet-maker's `docs/CEX_EXECUTION_ARCHIVE_CONTRACT.md` (and its sandbox proof harness); a test asserts a fully-populated row covers every contract column for both tables. Deliberate divergences are **additive only**:

- `transfer_events` gains `fee_amount`/`fee_currency` (contract lacks them; ccxt provides them).
- `fill_events.event_kind` = `trade_history_fill` (the contract's `create_order_fill` grain would yield zero rows in production, per the finding above); `fill_index` is the trade's position within the poll batch.
- `internal_transfer` / `submit_internal_transfer` values in existing enum-style columns; withdrawal failures use the contract's `error_summary`.

These should be reflected back into the contract doc/fixture on the fiet-maker side.

### Archive self-health

- Writer now emits `cex_archive_rows_flushed_total` and a `cex_archive_last_flush_success` gauge (the enqueued/shed/failure counters existed but flushed/last-success did not).
- The forwarder names rejected tables in its warning log and response body.

## Verification

`bun test`: 405 pass / 0 fail; `tsc --noEmit` clean; biome clean. New tests cover builder shapes against the consumer contract, fee-as-string precision preference, forwarder acceptance of the new tables + rejected-table naming, order-activity tracking, cursor advancement, and poller failure isolation.

## Rollout

- **Broker and forwarder must release together**: the forwarder 400-rejects any batch containing an unknown table and the writer requeues rejected batches indefinitely, so a broker emitting the new tables against an old forwarder poison-pills its archive queue.
- **No new environment variables** — poller tuning is constants — so the SGX/Gramine manifest allowlist is unchanged; the usual enclave redeploy applies.
