### PR TITLE
Surface sanitized underlying error detail in typed ExecuteAction failures

### DIFF
--- a/src/handlers/execute-action/context.ts
+++ b/src/handlers/execute-action/context.ts
@@ -15,7 +15,7 @@ import {
 } from "../../helpers/grpc/status";
 import type { OrderActivityTracker } from "../../helpers/order-activity-tracker";
 import type { OtelMetrics } from "../../helpers/otel";
-import { getErrorMessage } from "../../helpers/shared/errors";
+import { errorClassName, getErrorMessage } from "../../helpers/shared/errors";
 import type { PolicyConfig } from "../../types";
 import type { ActionRequest, ActionResponse } from "../types";
 
@@ -71,6 +71,11 @@ export function rejectWithGrpcError(
 		message?: string;
 		prefix?: string;
 		preferStableMessageOnly?: boolean;
+		/** Append the caught error's class name (e.g. InsufficientFunds) as a
+		 * suffix. It goes last, not in front, because the gRPC status code is
+		 * derived from the raw message via stableGrpcErrorCode; prepending the
+		 * class name would break that prefix match. */
+		appendClassName?: boolean;
 	},
 ): void {
 	const resolvedMessage = options?.message ?? getErrorMessage(error);
@@ -85,6 +90,12 @@ export function rejectWithGrpcError(
 		finalMessage = `${options.prefix}${message}`;
 	} else {
 		finalMessage = message;
+	}
+	if (options?.appendClassName) {
+		const className = errorClassName(error);
+		if (className && !finalMessage.includes(className)) {
+			finalMessage = `${finalMessage} (${className})`;
+		}
 	}
 	ctx.wrappedCallback({ code, message: finalMessage }, null);
 }

--- a/src/handlers/execute-action/deposit.ts
+++ b/src/handlers/execute-action/deposit.ts
@@ -235,6 +235,7 @@ export async function handleDeposit(ctx: ExecuteActionContext): Promise<void> {
 		rejectWithGrpcError(ctx, error, {
 			message,
 			prefix: "deposit_observation_unavailable: ",
+			appendClassName: true,
 		});
 	}
 }

--- a/src/handlers/execute-action/internal-transfer.ts
+++ b/src/handlers/execute-action/internal-transfer.ts
@@ -13,7 +13,11 @@ import {
 } from "../../helpers/broker-execution-archive";
 import { mapCcxtErrorToGrpcStatus } from "../../helpers/grpc/status";
 import { log } from "../../helpers/logger";
-import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
+import {
+	getErrorMessage,
+	safeLogError,
+	sanitizeErrorDetail,
+} from "../../helpers/shared/errors";
 import { InternalTransferPayloadSchema } from "../../schemas/action-payloads";
 import type { ExecuteActionContext } from "./context";
 import { parsePayloadForAction } from "./context";
@@ -151,7 +155,7 @@ export async function handleInternalTransfer(
 		ctx.wrappedCallback(
 			{
 				code,
-				message: `InternalTransfer failed: ${msg}`,
+				message: `InternalTransfer failed: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);

--- a/src/handlers/execute-action/order-book-call.ts
+++ b/src/handlers/execute-action/order-book-call.ts
@@ -8,7 +8,7 @@ import {
 	ORDER_BOOK_CALL_METHODS,
 	parseOrderBookCallPayload,
 } from "../../helpers/order-book";
-import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
+import { safeLogError, sanitizeErrorDetail } from "../../helpers/shared/errors";
 import type { ExecuteActionContext } from "./context";
 
 /** Handles Action.Call order-book methods before generic broker dispatch. Returns true when fully handled. */
@@ -116,11 +116,10 @@ export async function handleOrderBookCall(
 		});
 	} catch (error: unknown) {
 		safeLogError("Order-book Call failed", error);
-		const message = getErrorMessage(error);
 		ctx.wrappedCallback(
 			{
 				code: mapCcxtErrorToGrpcStatus(error) ?? grpc.status.INTERNAL,
-				message: `Order-book Call failed: ${message}`,
+				message: `Order-book Call failed: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);

--- a/src/handlers/execute-action/orders.ts
+++ b/src/handlers/execute-action/orders.ts
@@ -1,15 +1,15 @@
 import * as grpc from "@grpc/grpc-js";
 import { resolveOrderExecution } from "../../helpers";
-import { Action } from "../../helpers/constants";
 import {
 	archiveOrderExecutionInBackground,
 	captureMarketMetadataSnapshot,
 } from "../../helpers/broker-execution-archive";
+import { Action } from "../../helpers/constants";
 import {
 	emitOrderExecutionTelemetryInBackground,
 	extractOrderTelemetryIds,
 } from "../../helpers/order-telemetry";
-import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
+import { safeLogError, sanitizeErrorDetail } from "../../helpers/shared/errors";
 import {
 	CancelOrderPayloadSchema,
 	CreateOrderPayloadSchema,
@@ -167,7 +167,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 		ctx.wrappedCallback(
 			{
 				code: grpc.status.INTERNAL,
-				message: "Order Creation failed",
+				message: `Order Creation failed: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);
@@ -273,7 +273,7 @@ async function handleGetOrderDetails(ctx: ExecuteActionContext): Promise<void> {
 		ctx.wrappedCallback(
 			{
 				code: grpc.status.INTERNAL,
-				message: `Failed to fetch order details from ${cex}`,
+				message: `Failed to fetch order details from ${cex}: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);
@@ -366,7 +366,7 @@ async function handleCancelOrder(ctx: ExecuteActionContext): Promise<void> {
 		ctx.wrappedCallback(
 			{
 				code: grpc.status.INTERNAL,
-				message: `Failed to cancel order from ${cex}`,
+				message: `Failed to cancel order from ${cex}: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);

--- a/src/handlers/execute-action/perp-config.ts
+++ b/src/handlers/execute-action/perp-config.ts
@@ -1,7 +1,7 @@
 import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
 import { Action } from "../../helpers/constants";
-import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
+import { safeLogError, sanitizeErrorDetail } from "../../helpers/shared/errors";
 import {
 	GetPerpConfigStatePayloadSchema,
 	SetPerpConfigStatePayloadSchema,
@@ -91,7 +91,7 @@ async function handleGetPerpConfigState(
 		ctx.wrappedCallback(
 			{
 				code: grpc.status.INTERNAL,
-				message: getErrorMessage(error),
+				message: `GetPerpConfigState failed: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);
@@ -151,7 +151,7 @@ async function handleSetPerpConfigState(
 		ctx.wrappedCallback(
 			{
 				code: grpc.status.INTERNAL,
-				message: getErrorMessage(error),
+				message: `SetPerpConfigState failed: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);

--- a/src/handlers/execute-action/treasury-call.ts
+++ b/src/handlers/execute-action/treasury-call.ts
@@ -71,6 +71,7 @@ export async function handleTreasuryCall(
 		rejectWithGrpcError(ctx, error, {
 			message: getErrorMessage(error),
 			preferStableMessageOnly: true,
+			appendClassName: true,
 		});
 	}
 }

--- a/src/handlers/execute-action/withdraw.ts
+++ b/src/handlers/execute-action/withdraw.ts
@@ -13,7 +13,11 @@ import {
 	stableGrpcErrorCode,
 } from "../../helpers/grpc/status";
 import { log } from "../../helpers/logger";
-import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
+import {
+	getErrorMessage,
+	safeLogError,
+	sanitizeErrorDetail,
+} from "../../helpers/shared/errors";
 import {
 	resolveTransferNetwork,
 	type TransferNetworkResolution,
@@ -180,7 +184,7 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 		ctx.wrappedCallback(
 			{
 				code,
-				message: `Withdraw failed: ${getErrorMessage(error)}`,
+				message: `Withdraw failed: ${sanitizeErrorDetail(error)}`,
 			},
 			null,
 		);

--- a/src/helpers/shared/errors.ts
+++ b/src/helpers/shared/errors.ts
@@ -1,11 +1,38 @@
 import { log } from "../logger";
 
+/** Upper bound for a surfaced error detail. Long enough for a full ccxt venue
+ * message, short enough to keep gRPC trailers small. */
+const MAX_ERROR_DETAIL_LENGTH = 512;
+
 export function getErrorMessage(error: unknown): string {
 	return error instanceof Error
 		? error.message
 		: typeof error === "string"
 			? error
 			: "Unknown error";
+}
+
+/** Constructor/class name of a caught error (ccxt classes like InsufficientFunds,
+ * BadSymbol, OrderNotFound carry the actionable signal). The generic `Error` name
+ * adds nothing, so it is dropped; returns undefined for non-Error values. */
+export function errorClassName(error: unknown): string | undefined {
+	if (!(error instanceof Error)) {
+		return undefined;
+	}
+	const name = error.constructor?.name || error.name;
+	return name && name !== "Error" ? name : undefined;
+}
+
+/** Sanitized, single-line, length-capped detail for a caught error: the venue
+ * error class name plus its message. Safe to return to gRPC callers — it carries
+ * only the exchange's own error text (class + message), never a stack or payload,
+ * so downstream consumers can distinguish e.g. InsufficientFunds from BadSymbol
+ * instead of an opaque "<action> failed". */
+export function sanitizeErrorDetail(error: unknown): string {
+	const className = errorClassName(error);
+	const message = getErrorMessage(error);
+	const detail = className ? `${className}: ${message}` : message;
+	return detail.replace(/\s+/g, " ").trim().slice(0, MAX_ERROR_DETAIL_LENGTH);
 }
 
 export function safeLogError(context: string, error: unknown): void {

--- a/test/order-error-detail.test.ts
+++ b/test/order-error-detail.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import * as grpc from "@grpc/grpc-js";
+import type { Exchange } from "@usherlabs/ccxt";
+import type { ExecuteActionContext } from "../src/handlers/execute-action/context";
+import { handleOrders } from "../src/handlers/execute-action/orders";
+import { Action } from "../src/helpers/constants";
+import type { PolicyConfig } from "../src/types";
+
+/** Stand-in for a ccxt venue error: a named subclass carrying the venue message,
+ * the exact shape the enclave logs today but the caller never sees. */
+class InsufficientFunds extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "InsufficientFunds";
+	}
+}
+
+function createCallbackCapture() {
+	let error: { code?: number; message?: string } | null = null;
+	const callback = (
+		callbackError: { code?: number; message?: string } | null,
+	) => {
+		error = callbackError;
+	};
+	return { callback, getError: () => error };
+}
+
+function createContext(
+	broker: Exchange,
+	action: (typeof Action)[keyof typeof Action],
+	payload: Record<string, string>,
+): {
+	ctx: ExecuteActionContext;
+	getError: () => { code?: number; message?: string } | null;
+} {
+	const { callback, getError } = createCallbackCapture();
+	const ctx = {
+		action,
+		call: { request: { payload } },
+		wrappedCallback: callback,
+		cex: "binance",
+		normalizedCex: "binance",
+		symbol: "USDC/USDT",
+		broker,
+		verity: { proof: "" },
+		// Allow-everything policy so resolveOrderExecution reaches broker.createOrder.
+		policy: {
+			order: { rule: { markets: ["*"], limits: [] } },
+		} as unknown as PolicyConfig,
+		brokers: {},
+	} as unknown as ExecuteActionContext;
+	return { ctx, getError };
+}
+
+describe("orders handler surfaces underlying error detail", () => {
+	test("CreateOrder appends class name + message after the stable prefix", async () => {
+		const venueError = new InsufficientFunds(
+			"binance Account has insufficient balance for requested action.",
+		);
+		const broker = {
+			loadMarkets: async () => {},
+			markets: {
+				"USDC/USDT": {
+					symbol: "USDC/USDT",
+					base: "USDC",
+					quote: "USDT",
+					spot: true,
+					type: "spot",
+				},
+			},
+			createOrder: async () => {
+				throw venueError;
+			},
+		} as unknown as Exchange;
+
+		const { ctx, getError } = createContext(broker, Action.CreateOrder, {
+			amount: "1",
+			fromToken: "USDC",
+			toToken: "USDT",
+			price: "1",
+			marketType: "spot",
+		});
+		await handleOrders(ctx);
+
+		const error = getError();
+		expect(error?.code).toBe(grpc.status.INTERNAL);
+		expect(error?.message).toStartWith("Order Creation failed: ");
+		expect(error?.message).toContain("InsufficientFunds");
+		expect(error?.message).toContain("insufficient balance");
+	});
+
+	test("GetOrderDetails surfaces detail, keeps INTERNAL, single-line and capped", async () => {
+		const venueError = new InsufficientFunds(
+			`binance order lookup failed\nwith a newline and padding ${"x".repeat(1000)}`,
+		);
+		const broker = {
+			fetchOrder: async () => {
+				throw venueError;
+			},
+		} as unknown as Exchange;
+
+		const { ctx, getError } = createContext(broker, Action.GetOrderDetails, {
+			orderId: "order-123",
+		});
+		await handleOrders(ctx);
+
+		const error = getError();
+		expect(error?.code).toBe(grpc.status.INTERNAL);
+		expect(error?.message).toStartWith(
+			"Failed to fetch order details from binance: ",
+		);
+		expect(error?.message).toContain("InsufficientFunds");
+		// newline collapsed to a single line
+		expect(error?.message).not.toContain("\n");
+		// only the detail portion is capped at 512; the fixed prefix is extra
+		const prefix = "Failed to fetch order details from binance: ";
+		const detail = error?.message?.slice(prefix.length) ?? "";
+		expect(detail.length).toBe(512);
+	});
+});

--- a/test/order-telemetry.test.ts
+++ b/test/order-telemetry.test.ts
@@ -381,7 +381,9 @@ describe("order execution telemetry RPC harness", () => {
 			}),
 		).rejects.toMatchObject({
 			code: grpc.status.INTERNAL,
-			details: "Order Creation failed",
+			// Prefix preserved (consumers still match on it) with the underlying
+			// venue message now appended for diagnosis.
+			details: "Order Creation failed: exchange rejected order",
 		});
 		expect(metrics.counters).toContainEqual(
 			expect.objectContaining({

--- a/test/shared-errors.test.ts
+++ b/test/shared-errors.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { getErrorMessage } from "../src/helpers/shared/errors";
+import {
+	errorClassName,
+	getErrorMessage,
+	sanitizeErrorDetail,
+} from "../src/helpers/shared/errors";
+
+class InsufficientFunds extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "InsufficientFunds";
+	}
+}
 
 describe("shared errors", () => {
 	test("getErrorMessage handles Error", () => {
@@ -12,5 +23,42 @@ describe("shared errors", () => {
 
 	test("getErrorMessage handles unknown", () => {
 		expect(getErrorMessage(42)).toBe("Unknown error");
+	});
+
+	test("errorClassName returns the subclass name", () => {
+		expect(errorClassName(new InsufficientFunds("x"))).toBe(
+			"InsufficientFunds",
+		);
+	});
+
+	test("errorClassName drops the generic Error name and non-Errors", () => {
+		expect(errorClassName(new Error("x"))).toBeUndefined();
+		expect(errorClassName("nope")).toBeUndefined();
+	});
+
+	test("sanitizeErrorDetail prefixes the class name to the message", () => {
+		expect(
+			sanitizeErrorDetail(
+				new InsufficientFunds("binance Account has insufficient balance."),
+			),
+		).toBe("InsufficientFunds: binance Account has insufficient balance.");
+	});
+
+	test("sanitizeErrorDetail collapses newlines into a single line", () => {
+		const detail = sanitizeErrorDetail(
+			new InsufficientFunds("line one\nline two\n\tindented"),
+		);
+		expect(detail).not.toContain("\n");
+		expect(detail).toBe("InsufficientFunds: line one line two indented");
+	});
+
+	test("sanitizeErrorDetail caps the detail at 512 characters", () => {
+		const detail = sanitizeErrorDetail(new InsufficientFunds("a".repeat(1000)));
+		expect(detail.length).toBe(512);
+	});
+
+	test("sanitizeErrorDetail falls back to the message for non-Errors", () => {
+		expect(sanitizeErrorDetail("plain string")).toBe("plain string");
+		expect(sanitizeErrorDetail(new Error("bare"))).toBe("bare");
 	});
 });


### PR DESCRIPTION
## Summary

Typed ExecuteAction handlers previously wrapped any thrown exception as an opaque generic status (e.g. `INTERNAL "Order Creation failed"`), with the underlying ccxt/venue error visible only in the in-enclave logs. In production this converted a transient `createOrder` rejection into a multi-day misdiagnosis ("pair unsupported") because callers had no error detail to go on — while the pass-through `Call` path already surfaces raw ccxt messages, so exposing them has established precedent.

- New `sanitizeErrorDetail` / `errorClassName` helpers in `src/helpers/shared/errors.ts`: `"<ClassName>: <message>"`, whitespace collapsed to single spaces, capped at 512 chars. The ccxt class name (`InsufficientFunds`, `OrderNotFound`, `InvalidOrder`, …) is the high-value signal.
- Every typed handler's catch block now appends the sanitized detail to its existing message prefix (`Order Creation failed: InsufficientFunds: binance Account has insufficient balance…`). All gRPC status codes and message prefixes are preserved, so existing consumer matching is unaffected.
- `deposit.ts`/`treasury-call.ts` route through `rejectWithGrpcError`, which derives the code from the raw message prefix — for those, the class name is appended as a suffix via a new opt-in `appendClassName` option so code derivation is undisturbed.
- Pass-through handlers and the top-level dispatcher catch-all are unchanged; in-enclave `safeLogError` logging unchanged.

## Testing

`bun test`: 405 → 413 passed, 0 failed (new: helper unit tests; handler tests asserting code preserved + prefix preserved + class/message appended + single-line + 512-char cap). One existing telemetry test that asserted the old opaque message was updated to the enriched contract. `bunx biome check`: no new issues (one pre-existing import-ordering error cleared). Husky pre-commit (format + full suite) passed.