### PR TITLE
Remove expiry from venue cash-flow audit tables

### DIFF
--- a/schema/clickhouse/broker_execution.sql
+++ b/schema/clickhouse/broker_execution.sql
@@ -68,13 +68,15 @@ ORDER BY (exchange, symbol, broker_observed_timestamp);
 -- CEX value movements: withdrawals, deposits, and sub<->master internal transfers.
 --
 -- Column names/types/ORDER BY match the fiet-maker consumer contract
--- (docs/CEX_EXECUTION_ARCHIVE_CONTRACT.md + scripts/sql/clickhouse-schema.sql):
--- MergeTree with a 90-day TTL, DateTime64(3,'UTC') timestamps, string quantities,
--- result_index UInt32, error_summary. Two ADDITIVE columns not in the consumer
--- contract: fee_amount / fee_currency (the ccxt withdrawal object exposes the fee,
--- the dominant small-commit cost). broker_observed_timestamp is emitted as an
--- ISO-8601 UTC string and parsed on insert via the forwarder's
--- date_time_input_format=best_effort (see services/archive-forwarder/index.ts).
+-- (docs/CEX_EXECUTION_ARCHIVE_CONTRACT.md): MergeTree, DateTime64(3,'UTC')
+-- timestamps, string quantities, result_index UInt32, error_summary. The contract
+-- does not constrain retention; like every table in this file these are execution
+-- audit facts (the venue cash-flow ledger) and must not expire, so no TTL. Two
+-- ADDITIVE columns not in the consumer contract: fee_amount / fee_currency (the
+-- ccxt withdrawal object exposes the fee, the dominant small-commit cost).
+-- broker_observed_timestamp is emitted as an ISO-8601 UTC string and parsed on
+-- insert via the forwarder's date_time_input_format=best_effort (see
+-- services/archive-forwarder/index.ts).
 --
 -- Engine is plain MergeTree (contract), so re-observed rows are NOT collapsed;
 -- dedup, when needed, is at read time (GROUP BY / argMax over exchange,
@@ -106,9 +108,7 @@ CREATE TABLE IF NOT EXISTS broker_execution.transfer_events
 )
 ENGINE = MergeTree
 PARTITION BY toDate(broker_observed_timestamp)
-ORDER BY (account_selector, broker_observed_timestamp, exchange, symbol, event_kind, lifecycle_action)
-TTL toDateTime(broker_observed_timestamp) + toIntervalDay(90)
-SETTINGS ttl_only_drop_parts = 1;
+ORDER BY (account_selector, broker_observed_timestamp, exchange, symbol, event_kind, lifecycle_action);
 
 -- Per-fill execution facts from the venue trade-history endpoint (fetchMyTrades),
 -- captured by the broker-internal fill poller. GetOrderDetails/createOrder payloads
@@ -116,8 +116,9 @@ SETTINGS ttl_only_drop_parts = 1;
 -- (incl. fee) requires this endpoint; hence event_kind is stamped
 -- "trade_history_fill" rather than the contract fixture's "create_order_fill".
 --
--- Column names/types/ORDER BY match the fiet-maker consumer contract: MergeTree +
--- 90-day TTL, DateTime64 timestamps, string quantities, fill_index UInt32. Plain
+-- Column names/types/ORDER BY match the fiet-maker consumer contract: MergeTree,
+-- DateTime64 timestamps, string quantities, fill_index UInt32. The contract does
+-- not constrain retention; fills are execution audit facts and carry no TTL. Plain
 -- MergeTree (contract): the poller re-scans a lookback window after a restart, so
 -- the same trade can be re-inserted; dedup is at read time (GROUP BY / argMax over
 -- exchange, account_selector, symbol, order_id, fill_id).
@@ -148,9 +149,7 @@ CREATE TABLE IF NOT EXISTS broker_execution.fill_events
 )
 ENGINE = MergeTree
 PARTITION BY toDate(broker_observed_timestamp)
-ORDER BY (symbol, account_selector, broker_observed_timestamp, exchange, order_id, fill_index)
-TTL toDateTime(broker_observed_timestamp) + toIntervalDay(90)
-SETTINGS ttl_only_drop_parts = 1;
+ORDER BY (symbol, account_selector, broker_observed_timestamp, exchange, order_id, fill_index);
 
 -- Pre-order top-of-book snapshots captured immediately before an order action,
 -- joinable to order_events via market_metadata_hash and the order identifiers.


### PR DESCRIPTION
## Why

`fill_events` and `transfer_events` carried a 90-day TTL inherited from an old fiet-maker schema draft. The consumer contract (`CEX_EXECUTION_ARCHIVE_CONTRACT.md`) does not constrain retention, and this schema file's own header policy — *execution audit facts must not expire* — is already followed by `order_events` and `market_metadata_snapshots`. Fills and value movements are the venue cash-flow ledger; expiring them destroys accounting history on a rolling basis, which blocks NAV/PnL reconstruction on the maker side.

Both tables are currently empty in production (the archive pipeline is not deployed yet), so this changes policy, not data.

## Changes

- Drop `TTL ... + toIntervalDay(90)` from `broker_execution.fill_events` and `broker_execution.transfer_events` in `schema/clickhouse/broker_execution.sql`.
- Correct the table comments that claimed the 90-day TTL was part of the fiet-maker consumer contract.
- `market_data.*` streams keep their 90-day TTL — they are the high-volume tables; these two are low-volume.

## Deploy note

The archive-forwarder self-init is `CREATE TABLE IF NOT EXISTS` and will not alter existing tables. Deployments that already created these tables need:

```sql
ALTER TABLE broker_execution.transfer_events REMOVE TTL;
ALTER TABLE broker_execution.fill_events REMOVE TTL;
```

## Cross-repo pairing

usherlabs/fiet-maker#673 aligns the maker-side sandbox fixture with this retention policy; the two should merge in the same wave.
