### PR TITLE
feat(archive): accept control-plane snapshot tables and policy source_cursor

### DIFF
--- a/schema/clickhouse/strategy_data.sql
+++ b/schema/clickhouse/strategy_data.sql
@@ -33,12 +33,17 @@ CREATE TABLE IF NOT EXISTS strategy_data.policy_evaluation_events
     fidelity LowCardinality(String),
     lag_ms Int64,
     fallback_reason String,
+    -- Durable replay provenance cursor ("block:<n>:log:<i>"), empty when not derived from a chain cursor.
+    source_cursor String,
     decision_kind LowCardinality(String),
     payload_json String
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
 ORDER BY (controller_id, trading_pair, event_time_ms);
+
+ALTER TABLE strategy_data.policy_evaluation_events
+ADD COLUMN IF NOT EXISTS source_cursor String AFTER fallback_reason;
 
 -- Append-only versioned snapshots of the effective controller/ladder config
 -- on start and on config/policy change, hash-gated (FIET-905).
@@ -66,6 +71,58 @@ CREATE TABLE IF NOT EXISTS strategy_data.strategy_policy_snapshots
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
 ORDER BY (controller_id, trading_pair, event_time_ms);
+
+-- Append-only market identity snapshots keyed by canonical core pool id; the
+-- latest row with event_time_ms <= t is the identity active at t (FIET-905).
+CREATE TABLE IF NOT EXISTS strategy_data.market_identity
+(
+    event_time_ms Int64,
+    emitted_at_ms Int64,
+    source LowCardinality(String),
+    deployment_id LowCardinality(String),
+    schema_version LowCardinality(String),
+    controller_id String,
+    controller_type LowCardinality(String),
+    connector_name LowCardinality(String),
+    exchange LowCardinality(String),
+    trading_pair LowCardinality(String),
+    market_id String,
+    run_id String,
+
+    snapshot_reason LowCardinality(String),
+    source_hash String,
+    core_pool_id String,
+    canonical_core_pool_id String,
+    payload_json String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
+ORDER BY (canonical_core_pool_id, event_time_ms);
+
+-- Append-only CEX routeability snapshots keyed by exchange + trading_pair
+-- (FIET-905).
+CREATE TABLE IF NOT EXISTS strategy_data.symbol_mapping
+(
+    event_time_ms Int64,
+    emitted_at_ms Int64,
+    source LowCardinality(String),
+    deployment_id LowCardinality(String),
+    schema_version LowCardinality(String),
+    controller_id String,
+    controller_type LowCardinality(String),
+    connector_name LowCardinality(String),
+    exchange LowCardinality(String),
+    trading_pair LowCardinality(String),
+    market_id String,
+    run_id String,
+
+    snapshot_reason LowCardinality(String),
+    source_hash String,
+    payload_json String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
+ORDER BY (exchange, trading_pair, event_time_ms);
 
 -- Inventory snapshots (and, later, reservation/funding facts) on change with a
 -- periodic heartbeat, hash-gated (FIET-906).

--- a/services/archive-forwarder/types.ts
+++ b/services/archive-forwarder/types.ts
@@ -29,6 +29,8 @@ export const SUPPORTED_TABLES = [
 	"broker_execution.fill_events",
 	"strategy_data.policy_evaluation_events",
 	"strategy_data.strategy_policy_snapshots",
+	"strategy_data.market_identity",
+	"strategy_data.symbol_mapping",
 	"strategy_data.inventory_settlement_events",
 ] as const;
 

--- a/test/archive-forwarder.test.ts
+++ b/test/archive-forwarder.test.ts
@@ -158,7 +158,11 @@ describe("archive forwarder batch parsing", () => {
 				},
 				{
 					table: "strategy_data.symbol_mapping",
-					row: { event_time_ms: 3, exchange: "binance", trading_pair: "BTC-USDT" },
+					row: {
+						event_time_ms: 3,
+						exchange: "binance",
+						trading_pair: "BTC-USDT",
+					},
 				},
 			],
 		});

--- a/test/archive-forwarder.test.ts
+++ b/test/archive-forwarder.test.ts
@@ -139,6 +139,37 @@ describe("archive forwarder batch parsing", () => {
 			"strategy_data.policy_evaluation_events",
 		]);
 	});
+
+	test("accepts control-plane snapshots and policy replay cursors", () => {
+		const parsed = parseArchiveBatchRequest({
+			source: "hb_runtime",
+			deployment_id: "deploy-a",
+			rows: [
+				{
+					table: "strategy_data.policy_evaluation_events",
+					row: {
+						event_time_ms: 1,
+						source_cursor: "block:12345680:log:3",
+					},
+				},
+				{
+					table: "strategy_data.market_identity",
+					row: { event_time_ms: 2, canonical_core_pool_id: "pool-1" },
+				},
+				{
+					table: "strategy_data.symbol_mapping",
+					row: { event_time_ms: 3, exchange: "binance", trading_pair: "BTC-USDT" },
+				},
+			],
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok) {
+			return;
+		}
+		expect(parsed.rejectedRowCount).toBe(0);
+		expect(parsed.batch.rows).toHaveLength(3);
+	});
 });
 
 describe("archive forwarder routing", () => {
@@ -157,6 +188,14 @@ describe("archive forwarder routing", () => {
 				row: { event_time_ms: 1 },
 			},
 			{
+				table: "strategy_data.market_identity",
+				row: { event_time_ms: 2 },
+			},
+			{
+				table: "strategy_data.symbol_mapping",
+				row: { event_time_ms: 3 },
+			},
+			{
 				table: "market_data.unknown_table",
 				row: { symbol: "ETH/USDT" },
 			},
@@ -168,12 +207,16 @@ describe("archive forwarder routing", () => {
 		expect(
 			grouped.get("strategy_data.inventory_settlement_events"),
 		).toHaveLength(1);
+		expect(grouped.get("strategy_data.market_identity")).toHaveLength(1);
+		expect(grouped.get("strategy_data.symbol_mapping")).toHaveLength(1);
 		expect(countSkippedRows(rows)).toBe(1);
 		expect(isSupportedTable("market_data.candles")).toBe(true);
 		expect(isSupportedTable("broker_execution.order_events")).toBe(true);
 		expect(isSupportedTable("strategy_data.policy_evaluation_events")).toBe(
 			true,
 		);
+		expect(isSupportedTable("strategy_data.market_identity")).toBe(true);
+		expect(isSupportedTable("strategy_data.symbol_mapping")).toBe(true);
 		expect(isSupportedTable("market_data.unknown_table")).toBe(false);
 	});
 
@@ -311,6 +354,8 @@ describe("archive forwarder schema init", () => {
 				"broker_execution.fill_events",
 				"strategy_data.policy_evaluation_events",
 				"strategy_data.strategy_policy_snapshots",
+				"strategy_data.market_identity",
+				"strategy_data.symbol_mapping",
 				"strategy_data.inventory_settlement_events",
 			]),
 		);

--- a/test/clickhouse-schema.integration.test.ts
+++ b/test/clickhouse-schema.integration.test.ts
@@ -68,6 +68,22 @@ async function cleanupTestRows(): Promise<void> {
 	await client!.command({
 		query: "OPTIMIZE TABLE candles FINAL",
 	});
+	for (const table of [
+		"policy_evaluation_events",
+		"market_identity",
+		"symbol_mapping",
+	]) {
+		await client!.command({
+			query: `
+				ALTER TABLE strategy_data.${table}
+				DELETE WHERE deployment_id = {deployment_id:String}
+			`,
+			query_params: { deployment_id: TEST_DEPLOYMENT },
+		});
+		await client!.command({
+			query: `OPTIMIZE TABLE strategy_data.${table} FINAL`,
+		});
+	}
 }
 
 describe("ClickHouse market_data schema integration", () => {
@@ -343,5 +359,148 @@ describe("ClickHouse market_data schema integration", () => {
 		const viewRow = (await viaView.json())[0] as Record<string, unknown>;
 		expect(Number(viewRow.best_bid)).toBe(50);
 		expect(Number(viewRow.best_ask)).toBe(51);
+	});
+
+	test("schema migration adds source_cursor to the existing policy table", async () => {
+		if (!clickhouseAvailable || !client) {
+			return;
+		}
+
+		await client.command({
+			query: `
+				ALTER TABLE strategy_data.policy_evaluation_events
+				DROP COLUMN IF EXISTS source_cursor
+			`,
+		});
+		try {
+			await ensureArchiveSchema(client);
+
+			const result = await client.query({
+				query: `
+					SELECT name
+					FROM system.columns
+					WHERE database = 'strategy_data'
+						AND table = 'policy_evaluation_events'
+						AND name = 'source_cursor'
+				`,
+				format: "JSONEachRow",
+			});
+			expect(await result.json()).toEqual([{ name: "source_cursor" }]);
+		} finally {
+			await ensureArchiveSchema(client);
+		}
+	});
+
+	test("archive forwarder stores policy cursors and control-plane snapshots", async () => {
+		if (!clickhouseAvailable || !client) {
+			return;
+		}
+
+		const eventMs = TEST_EVENT_MS + 180_000;
+		const sourceCursor = "block:12345680:log:3";
+		const result = await handleArchiveBatch(createClickHouseInserter(client), {
+			source: "hb_runtime",
+			deployment_id: TEST_DEPLOYMENT,
+			rows: [
+				{
+					table: "strategy_data.policy_evaluation_events",
+					row: {
+						event_time_ms: eventMs,
+						emitted_at_ms: eventMs,
+						source: "hb_runtime",
+						deployment_id: TEST_DEPLOYMENT,
+						schema_version: "1",
+						controller_id: "controller-1",
+						controller_type: "layer12",
+						connector_name: "binance",
+						exchange: "binance",
+						trading_pair: "BTC-USDT",
+						market_id: "market-1",
+						run_id: "run-1",
+						policy_epoch: "epoch-1",
+						fidelity: "live",
+						lag_ms: 0,
+						fallback_reason: "",
+						source_cursor: sourceCursor,
+						decision_kind: "quote",
+						payload_json: "{}",
+					},
+				},
+				{
+					table: "strategy_data.market_identity",
+					row: {
+						event_time_ms: eventMs + 1,
+						emitted_at_ms: eventMs + 1,
+						source: "hb_runtime",
+						deployment_id: TEST_DEPLOYMENT,
+						schema_version: "1",
+						controller_id: "controller-1",
+						controller_type: "layer12",
+						connector_name: "binance",
+						exchange: "binance",
+						trading_pair: "BTC-USDT",
+						market_id: "market-1",
+						run_id: "run-1",
+						snapshot_reason: "startup",
+						source_hash: "identity-hash",
+						canonical_core_pool_id: "pool-1",
+						payload_json: "{}",
+					},
+				},
+				{
+					table: "strategy_data.symbol_mapping",
+					row: {
+						event_time_ms: eventMs + 2,
+						emitted_at_ms: eventMs + 2,
+						source: "hb_runtime",
+						deployment_id: TEST_DEPLOYMENT,
+						schema_version: "1",
+						controller_id: "controller-1",
+						controller_type: "layer12",
+						connector_name: "binance",
+						exchange: "binance",
+						trading_pair: "BTC-USDT",
+						market_id: "market-1",
+						run_id: "run-1",
+						snapshot_reason: "startup",
+						source_hash: "symbol-hash",
+						payload_json: "{}",
+					},
+				},
+			],
+		});
+
+		expect(result).toMatchObject({ inserted: 3, failed: 0, skipped: 0 });
+
+		const policy = await client.query({
+			query: `
+				SELECT source_cursor
+				FROM strategy_data.policy_evaluation_events
+				WHERE deployment_id = {deployment_id:String}
+					AND event_time_ms = {event_time_ms:Int64}
+			`,
+			query_params: {
+				deployment_id: TEST_DEPLOYMENT,
+				event_time_ms: eventMs,
+			},
+			format: "JSONEachRow",
+		});
+		expect(await policy.json()).toEqual([{ source_cursor: sourceCursor }]);
+
+		for (const [table, sourceHash] of [
+			["market_identity", "identity-hash"],
+			["symbol_mapping", "symbol-hash"],
+		] as const) {
+			const snapshot = await client.query({
+				query: `
+					SELECT source_hash
+					FROM strategy_data.${table}
+					WHERE deployment_id = {deployment_id:String}
+				`,
+				query_params: { deployment_id: TEST_DEPLOYMENT },
+				format: "JSONEachRow",
+			});
+			expect(await snapshot.json()).toEqual([{ source_hash: sourceHash }]);
+		}
 	});
 });

--- a/test/clickhouse-schema.integration.test.ts
+++ b/test/clickhouse-schema.integration.test.ts
@@ -14,6 +14,13 @@ const TEST_EVENT_MS = 1_900_000_000_000;
 let client: ClickHouseClient | undefined;
 let clickhouseAvailable = false;
 
+function requireClient(): ClickHouseClient {
+	if (!client) {
+		throw new Error("ClickHouse client is not initialized");
+	}
+	return client;
+}
+
 async function probeClickHouse(): Promise<boolean> {
 	const probe = createClient({
 		url: CLICKHOUSE_URL,
@@ -34,7 +41,8 @@ async function probeClickHouse(): Promise<boolean> {
 }
 
 async function tableEngine(name: string): Promise<string | null> {
-	const result = await client!.query({
+	const activeClient = requireClient();
+	const result = await activeClient.query({
 		query: `
 			SELECT engine
 			FROM system.tables
@@ -48,24 +56,25 @@ async function tableEngine(name: string): Promise<string | null> {
 }
 
 async function cleanupTestRows(): Promise<void> {
-	await client!.command({
+	const activeClient = requireClient();
+	await activeClient.command({
 		query: `
 			ALTER TABLE orderbook_snapshots
 			DELETE WHERE deployment_id = {deployment_id:String}
 		`,
 		query_params: { deployment_id: TEST_DEPLOYMENT },
 	});
-	await client!.command({
+	await activeClient.command({
 		query: `
 			ALTER TABLE candles
 			DELETE WHERE deployment_id = {deployment_id:String}
 		`,
 		query_params: { deployment_id: TEST_DEPLOYMENT },
 	});
-	await client!.command({
+	await activeClient.command({
 		query: "OPTIMIZE TABLE orderbook_snapshots FINAL",
 	});
-	await client!.command({
+	await activeClient.command({
 		query: "OPTIMIZE TABLE candles FINAL",
 	});
 	for (const table of [
@@ -73,14 +82,14 @@ async function cleanupTestRows(): Promise<void> {
 		"market_identity",
 		"symbol_mapping",
 	]) {
-		await client!.command({
+		await activeClient.command({
 			query: `
 				ALTER TABLE strategy_data.${table}
 				DELETE WHERE deployment_id = {deployment_id:String}
 			`,
 			query_params: { deployment_id: TEST_DEPLOYMENT },
 		});
-		await client!.command({
+		await activeClient.command({
 			query: `OPTIMIZE TABLE strategy_data.${table} FINAL`,
 		});
 	}

--- a/test/fixtures/archive_forwarder_envelope.json
+++ b/test/fixtures/archive_forwarder_envelope.json
@@ -13,6 +13,7 @@
         "exchange": "binance",
         "fidelity": "hb_runtime_policy_clock",
         "lag_ms": 12,
+        "source_cursor": "block:12345680:log:3",
         "market_id": "arb-usdc-015",
         "payload_json": "{\"execution_role\":\"dex_lead\",\"mid_price\":\"1.0234\"}",
         "policy_epoch": "42",


### PR DESCRIPTION
Companion to usherlabs/fiet-maker#678 — must merge and deploy before (or together with) it.

fiet-maker#678 starts emitting three row shapes the forwarder cannot accept today:

- `strategy_data.policy_evaluation_events` rows stamped with a new `source_cursor` column (`block:<n>:log:<i>` replay provenance). Without the column, the JSONEachRow insert fails the whole per-table group for any batch containing a cursor-stamped row — taking down the existing policy-clock stream, not just the new data.
- `strategy_data.market_identity` and `strategy_data.symbol_mapping` (FIET-905 control-plane snapshots), currently rejected as unsupported tables.

## Changes

- **`schema/clickhouse/strategy_data.sql`**: `source_cursor` column on `policy_evaluation_events` plus an idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` — `ensureArchiveSchema` applies it at startup, so existing deployments migrate on the next forwarder restart with no manual DDL. New `CREATE TABLE`s for `market_identity` (`ORDER BY (canonical_core_pool_id, event_time_ms)`) and `symbol_mapping` (`ORDER BY (exchange, trading_pair, event_time_ms)`), following the sibling tables' provenance block and partitioning.
- **`services/archive-forwarder/types.ts`**: the two new tables added to `SUPPORTED_TABLES`.
- **Contract fixture** synced byte-for-byte with fiet-maker#678's copy (policy row now carries `source_cursor`).
- **Tests**: unit coverage for parsing/grouping the new shapes; ClickHouse integration coverage for the old-shape migration path (drop column → `ensureArchiveSchema` → column present) and for inserting + querying all three row shapes end to end.

## Verification

Full `bun test` with the compose ClickHouse up: **416 pass / 0 fail** (integration suite executed against a live ClickHouse, not skipped; focused run 6 pass / 0 fail). `biome check` clean on changed files.

## Rollout

1. Merge + deploy this forwarder — schema self-applies at startup; old emitters are unaffected (column defaulted, tables additive).
2. Then merge fiet-maker#678.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance cursor support to policy evaluation event records.
  * Added market identity and symbol mapping history tables.
  * Archive processing now accepts and stores these new record types and associated metadata.

* **Bug Fixes**
  * Improved schema migration handling for the new provenance and history fields.

* **Tests**
  * Expanded coverage for archiving, routing, schema migrations, and data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->