### PR TITLE
feat(archive): record withdrawal history observations

### DIFF
--- a/src/handlers/execute-action/context.ts
+++ b/src/handlers/execute-action/context.ts
@@ -3,7 +3,10 @@ import type { Metadata } from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
 import type { z } from "zod";
 import type { BrokerAccount, BrokerPoolEntry } from "../../helpers";
-import type { BrokerExecutionArchiver } from "../../helpers/broker-execution-archive";
+import type {
+	BrokerExecutionArchiver,
+	WithdrawalObservationTracker,
+} from "../../helpers/broker-execution-archive";
 import type { Action as ActionType } from "../../helpers/constants";
 import {
 	invalidArgumentError,
@@ -40,6 +43,7 @@ export type ExecuteActionContext = {
 	otelMetrics?: OtelMetrics;
 	brokerArchiver?: BrokerExecutionArchiver;
 	orderActivityTracker?: OrderActivityTracker;
+	withdrawalObservationTracker: WithdrawalObservationTracker;
 };
 
 export function requireSymbol(

--- a/src/handlers/execute-action/handler.ts
+++ b/src/handlers/execute-action/handler.ts
@@ -3,7 +3,10 @@ import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
 import { authenticateRequest } from "../../helpers/auth";
 import { type BrokerPoolEntry, createBroker } from "../../helpers/broker";
-import type { BrokerExecutionArchiver } from "../../helpers/broker-execution-archive";
+import {
+	type BrokerExecutionArchiver,
+	WithdrawalObservationTracker,
+} from "../../helpers/broker-execution-archive";
 import { Action, getActionName, resolveAction } from "../../helpers/constants";
 import { selectBrokerAccountForCex } from "../../helpers/grpc/broker";
 import { log } from "../../helpers/logger";
@@ -29,6 +32,7 @@ export type ExecuteActionDeps = {
 	otelMetrics?: OtelMetrics;
 	brokerArchiver?: BrokerExecutionArchiver;
 	orderActivityTracker?: OrderActivityTracker;
+	withdrawalObservationTracker?: WithdrawalObservationTracker;
 };
 
 export function createExecuteActionHandler(deps: ExecuteActionDeps) {
@@ -42,6 +46,8 @@ export function createExecuteActionHandler(deps: ExecuteActionDeps) {
 		brokerArchiver,
 		orderActivityTracker,
 	} = deps;
+	const withdrawalObservationTracker =
+		deps.withdrawalObservationTracker ?? new WithdrawalObservationTracker();
 
 	return async (
 		call: grpc.ServerUnaryCall<ActionRequest, ActionResponse>,
@@ -155,6 +161,7 @@ export function createExecuteActionHandler(deps: ExecuteActionDeps) {
 				otelMetrics,
 				brokerArchiver,
 				orderActivityTracker,
+				withdrawalObservationTracker,
 			};
 
 			if (action === Action.Call) {

--- a/src/handlers/execute-action/treasury-call.ts
+++ b/src/handlers/execute-action/treasury-call.ts
@@ -1,4 +1,5 @@
 import * as grpc from "@grpc/grpc-js";
+import { archiveWithdrawalObservationsInBackground } from "../../helpers/broker-execution-archive";
 import { getErrorMessage, safeLogError } from "../../helpers/shared/errors";
 import {
 	callArgs,
@@ -62,6 +63,17 @@ export async function handleTreasuryCall(
 		// Invoke
 		// biome-ignore lint/suspicious/noExplicitAny: dynamic call required for generic broker methods
 		const result = await (fn as any).apply(broker, argsArray);
+		if (callValue.functionName === "fetchWithdrawals") {
+			archiveWithdrawalObservationsInBackground(
+				ctx.brokerArchiver,
+				ctx.withdrawalObservationTracker,
+				{
+					exchange: ctx.normalizedCex,
+					accountSelector: ctx.selectedBrokerAccount?.label,
+					transactions: result,
+				},
+			);
+		}
 		ctx.wrappedCallback(null, {
 			proof: ctx.verity.proof,
 			result: JSON.stringify(result),

--- a/src/helpers/broker-execution-archive/capture.ts
+++ b/src/helpers/broker-execution-archive/capture.ts
@@ -12,9 +12,11 @@ import {
 	buildOrderEventArchiveRow,
 	buildSubscribeStreamArchiveRow,
 	buildTransferEventArchiveRow,
+	normalizeCcxtTransactionForArchive,
 	type TransferArchiveFields,
 } from "./rows";
 import type { SubscribeArchiveType } from "./types";
+import type { WithdrawalObservationTracker } from "./withdrawal-observation-tracker";
 import type { BrokerExecutionArchiver } from "./writer";
 
 export function archiveOrderExecutionInBackground(
@@ -120,6 +122,63 @@ export function archiveTransferEventInBackground(
 			log.warn("Failed to archive transfer event", { error: archiveError });
 		}
 	});
+}
+
+export function archiveWithdrawalObservationsInBackground(
+	archiver: BrokerExecutionArchiver | undefined,
+	tracker: WithdrawalObservationTracker,
+	input: {
+		exchange: string;
+		accountSelector?: string;
+		transactions: unknown;
+	},
+): void {
+	try {
+		if (!archiver?.isEnabled() || !Array.isArray(input.transactions)) {
+			return;
+		}
+		const brokerObservedTimestamp = new Date().toISOString();
+		for (const [resultIndex, transaction] of input.transactions.entries()) {
+			const normalized = normalizeCcxtTransactionForArchive(transaction);
+			const assetSymbol = normalized.assetSymbol;
+			if (
+				!tracker.shouldArchive({
+					exchange: input.exchange,
+					accountSelector: input.accountSelector,
+					assetSymbol,
+					transaction,
+					normalized,
+				})
+			) {
+				continue;
+			}
+			archiveTransferEventInBackground(archiver, {
+				exchange: input.exchange,
+				accountSelector: input.accountSelector,
+				assetSymbol,
+				brokerObservedTimestamp,
+				transfer: {
+					eventKind: "withdrawal",
+					lifecycleAction: "observe_withdrawal",
+					status: normalized.status,
+					amount: normalized.amount,
+					address: normalized.address,
+					network: normalized.network,
+					externalId: normalized.externalId,
+					txid: normalized.txid,
+					resultIndex,
+					feeAmount: normalized.feeAmount,
+					feeCurrency: normalized.feeCurrency,
+					exchangeTimestamp: normalized.exchangeTimestamp,
+					payload: transaction,
+				},
+			});
+		}
+	} catch (archiveError) {
+		log.warn("Failed to archive withdrawal observations", {
+			error: archiveError,
+		});
+	}
 }
 
 export async function captureMarketMetadataSnapshot(

--- a/src/helpers/broker-execution-archive/index.ts
+++ b/src/helpers/broker-execution-archive/index.ts
@@ -2,6 +2,7 @@ export {
 	archiveOrderExecutionInBackground,
 	archiveSubscribeStreamInBackground,
 	archiveTransferEventInBackground,
+	archiveWithdrawalObservationsInBackground,
 	captureMarketMetadataSnapshot,
 	captureMarketMetadataSnapshotInBackground,
 } from "./capture";
@@ -19,9 +20,9 @@ export {
 	buildSubscribeStreamArchiveRow,
 	buildTransferEventArchiveRow,
 	type FillArchiveFields,
+	type NormalizedCcxtTransfer,
 	normalizeCcxtTradeForArchive,
 	normalizeCcxtTransactionForArchive,
-	type NormalizedCcxtTransfer,
 	type TransferArchiveFields,
 } from "./rows";
 export {
@@ -35,6 +36,10 @@ export {
 	type TransferEventKind,
 	type TransferLifecycleAction,
 } from "./types";
+export {
+	DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES,
+	WithdrawalObservationTracker,
+} from "./withdrawal-observation-tracker";
 export {
 	BrokerExecutionArchiver,
 	type BrokerExecutionArchiverOptions,

--- a/src/helpers/broker-execution-archive/types.ts
+++ b/src/helpers/broker-execution-archive/types.ts
@@ -45,6 +45,7 @@ export type TransferEventKind = "withdrawal" | "deposit" | "internal_transfer";
 // Which movement lifecycle step produced the row (contract `lifecycle_action`).
 export type TransferLifecycleAction =
 	| "submit_withdrawal"
+	| "observe_withdrawal"
 	| "observe_deposit"
 	| "submit_internal_transfer";
 

--- a/src/helpers/broker-execution-archive/withdrawal-observation-tracker.ts
+++ b/src/helpers/broker-execution-archive/withdrawal-observation-tracker.ts
@@ -1,0 +1,133 @@
+import { asRecord } from "../shared/guards";
+import type { NormalizedCcxtTransfer } from "./rows";
+
+export const DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES = 10_000;
+
+const VENUE_LIFECYCLE_EVIDENCE_FIELDS = [
+	"updated",
+	"updatedAt",
+	"updated_at",
+	"updateTime",
+	"update_time",
+	"updateTimestamp",
+	"lastUpdateTimestamp",
+	"completed",
+	"completedAt",
+	"completed_at",
+	"completeTime",
+	"complete_time",
+	"completionTime",
+	"successTime",
+] as const;
+
+type WithdrawalObservation = {
+	exchange: string;
+	accountSelector?: string;
+	assetSymbol?: string;
+	transaction: unknown;
+	normalized: NormalizedCcxtTransfer;
+};
+
+function fingerprintEvidenceValue(value: unknown): unknown {
+	if (value === undefined || value === null) {
+		return value;
+	}
+	if (
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	) {
+		return value;
+	}
+	if (typeof value === "bigint") {
+		return value.toString();
+	}
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function venueLifecycleEvidence(transaction: unknown): unknown[] {
+	const record = asRecord(transaction);
+	const info = asRecord(record?.info);
+	const evidence: unknown[] = [];
+	for (const [scope, source] of [
+		["transaction", record],
+		["info", info],
+	] as const) {
+		for (const field of VENUE_LIFECYCLE_EVIDENCE_FIELDS) {
+			const value = source?.[field];
+			if (value !== undefined && value !== null) {
+				evidence.push([scope, field, fingerprintEvidenceValue(value)]);
+			}
+		}
+	}
+	return evidence;
+}
+
+function observationFingerprint(observation: WithdrawalObservation): string {
+	const { normalized, transaction } = observation;
+	return JSON.stringify({
+		status: normalized.status ?? null,
+		txid: normalized.txid ?? null,
+		amount: normalized.amount ?? null,
+		feeAmount: normalized.feeAmount ?? null,
+		feeCurrency: normalized.feeCurrency ?? null,
+		exchangeTimestamp: normalized.exchangeTimestamp ?? null,
+		venueLifecycleEvidence: venueLifecycleEvidence(transaction),
+	});
+}
+
+/**
+ * Suppresses unchanged withdrawal-history observations within one broker process.
+ * The tracker intentionally persists no state: restart replay is absorbed by
+ * archive consumers, while the in-process bound prevents unbounded venue history.
+ */
+export class WithdrawalObservationTracker {
+	readonly #fingerprints = new Map<string, string>();
+	readonly #maxEntries: number;
+	#missingIdSequence = 0n;
+
+	constructor(options?: { maxEntries?: number }) {
+		this.#maxEntries = Math.max(
+			1,
+			Math.floor(
+				options?.maxEntries ??
+					DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES,
+			),
+		);
+	}
+
+	shouldArchive(observation: WithdrawalObservation): boolean {
+		const externalId = observation.normalized.externalId?.trim();
+		// Without a venue identity, a one-use process sequence is safer than
+		// suppressing two distinct withdrawals that happen to share the same fields.
+		const identity = JSON.stringify([
+			observation.exchange.trim().toLowerCase() || "unknown",
+			observation.accountSelector?.trim() || "unknown",
+			observation.assetSymbol?.trim().toUpperCase() || "unknown",
+			externalId || `missing:${++this.#missingIdSequence}`,
+		]);
+		const fingerprint = observationFingerprint(observation);
+		if (this.#fingerprints.get(identity) === fingerprint) {
+			return false;
+		}
+
+		// Refresh changed entries so deterministic oldest-first eviction reflects the
+		// latest meaningful observation, not the first time an id was encountered.
+		this.#fingerprints.delete(identity);
+		this.#fingerprints.set(identity, fingerprint);
+		while (this.#fingerprints.size > this.#maxEntries) {
+			const oldest = this.#fingerprints.keys().next().value;
+			if (oldest === undefined) break;
+			this.#fingerprints.delete(oldest);
+		}
+		return true;
+	}
+
+	getSize(): number {
+		return this.#fingerprints.size;
+	}
+}

--- a/src/helpers/broker-execution-archive/withdrawal-observation-tracker.ts
+++ b/src/helpers/broker-execution-archive/withdrawal-observation-tracker.ts
@@ -75,6 +75,8 @@ function observationFingerprint(observation: WithdrawalObservation): string {
 		amount: normalized.amount ?? null,
 		feeAmount: normalized.feeAmount ?? null,
 		feeCurrency: normalized.feeCurrency ?? null,
+		address: normalized.address ?? null,
+		network: normalized.network ?? null,
 		exchangeTimestamp: normalized.exchangeTimestamp ?? null,
 		venueLifecycleEvidence: venueLifecycleEvidence(transaction),
 	});
@@ -91,13 +93,11 @@ export class WithdrawalObservationTracker {
 	#missingIdSequence = 0n;
 
 	constructor(options?: { maxEntries?: number }) {
-		this.#maxEntries = Math.max(
-			1,
-			Math.floor(
-				options?.maxEntries ??
-					DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES,
-			),
-		);
+		const maxEntries =
+			options?.maxEntries ?? DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES;
+		this.#maxEntries = Number.isFinite(maxEntries)
+			? Math.max(1, Math.floor(maxEntries))
+			: DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES;
 	}
 
 	shouldArchive(observation: WithdrawalObservation): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 import {
 	type BrokerExecutionArchiver,
 	createBrokerExecutionArchiverFromEnv,
+	WithdrawalObservationTracker,
 } from "./helpers/broker-execution-archive";
 import { FillArchivePoller } from "./helpers/fill-archive-poller";
 import { log } from "./helpers/logger";
@@ -57,6 +58,10 @@ export default class CEXBroker {
 	// Order activity feeds the fill poller its per-market poll set; shared with the
 	// execute-action handler so orders record the (account, symbol) they touch.
 	private readonly orderActivityTracker = new OrderActivityTracker();
+	// Persist across server rebuilds on policy reload so repeated venue polling is
+	// suppressed for the lifetime of this broker process.
+	private readonly withdrawalObservationTracker =
+		new WithdrawalObservationTracker();
 	private fillArchivePoller?: FillArchivePoller;
 
 	/**
@@ -330,6 +335,7 @@ export default class CEXBroker {
 			this.otelMetrics,
 			this.brokerArchiver,
 			this.orderActivityTracker,
+			this.withdrawalObservationTracker,
 		);
 
 		this.server.bindAsync(

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,10 @@ import * as grpc from "@grpc/grpc-js";
 import { createExecuteActionHandler } from "./handlers/execute-action";
 import { createSubscribeHandler } from "./handlers/subscribe";
 import type { BrokerPoolEntry } from "./helpers";
-import type { BrokerExecutionArchiver } from "./helpers/broker-execution-archive";
+import type {
+	BrokerExecutionArchiver,
+	WithdrawalObservationTracker,
+} from "./helpers/broker-execution-archive";
 import type { OrderActivityTracker } from "./helpers/order-activity-tracker";
 import type { OtelMetrics } from "./helpers/otel";
 import { CEX_BROKER_PACKAGE_DEFINITION } from "./proto-package-definition";
@@ -28,6 +31,7 @@ export function getServer(
 	otelMetrics?: OtelMetrics,
 	brokerArchiver?: BrokerExecutionArchiver,
 	orderActivityTracker?: OrderActivityTracker,
+	withdrawalObservationTracker?: WithdrawalObservationTracker,
 ) {
 	const server = new grpc.Server();
 
@@ -41,6 +45,7 @@ export function getServer(
 			otelMetrics,
 			brokerArchiver,
 			orderActivityTracker,
+			withdrawalObservationTracker,
 		}),
 		Subscribe: createSubscribeHandler({
 			brokers,

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -14,7 +14,10 @@ import {
 	normalizeCcxtTradeForArchive,
 	normalizeCcxtTransactionForArchive,
 } from "../src/helpers/broker-execution-archive/rows";
-import { WithdrawalObservationTracker } from "../src/helpers/broker-execution-archive/withdrawal-observation-tracker";
+import {
+	DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES,
+	WithdrawalObservationTracker,
+} from "../src/helpers/broker-execution-archive/withdrawal-observation-tracker";
 import {
 	BrokerExecutionArchiver,
 	createBrokerExecutionArchiverFromEnv,
@@ -488,6 +491,8 @@ describe("withdrawal observation tracker", () => {
 			{ ...baseline, amount: "11" },
 			{ ...baseline, fee: { cost: "1", currency: "USDC" } },
 			{ ...baseline, fee: { cost: "0", currency: "USDT" } },
+			{ ...baseline, address: "0xrecipient" },
+			{ ...baseline, network: "ARBITRUM" },
 			{ ...baseline, info: { completeTime: "2026-07-01T00:01:00Z" } },
 		];
 
@@ -527,6 +532,27 @@ describe("withdrawal observation tracker", () => {
 		expect(tracker.getSize()).toBe(2);
 		expect(shouldArchive(tracker, transaction("wd-1"))).toBe(true);
 		expect(tracker.getSize()).toBe(2);
+	});
+
+	test("falls back to the default bound for non-finite capacity overrides", () => {
+		for (const maxEntries of [Number.NaN, Number.POSITIVE_INFINITY]) {
+			const tracker = new WithdrawalObservationTracker({ maxEntries });
+			for (
+				let index = 0;
+				index <= DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES;
+				index += 1
+			) {
+				shouldArchive(tracker, {
+					id: `wd-${index}`,
+					currency: "USDC",
+					status: "pending",
+					amount: "10",
+				});
+			}
+			expect(tracker.getSize()).toBe(
+				DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES,
+			);
+		}
 	});
 });
 

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import type { LogRecord } from "@opentelemetry/api-logs";
-import { startForwarderServer } from "./archive-forwarder-server";
 import {
 	redactSecretLiterals,
 	redactStreamPayload,
@@ -15,6 +14,7 @@ import {
 	normalizeCcxtTradeForArchive,
 	normalizeCcxtTransactionForArchive,
 } from "../src/helpers/broker-execution-archive/rows";
+import { WithdrawalObservationTracker } from "../src/helpers/broker-execution-archive/withdrawal-observation-tracker";
 import {
 	BrokerExecutionArchiver,
 	createBrokerExecutionArchiverFromEnv,
@@ -23,6 +23,7 @@ import {
 } from "../src/helpers/broker-execution-archive/writer";
 import { buildOrderExecutionTelemetry } from "../src/helpers/order-telemetry";
 import type { OtelLogs } from "../src/helpers/otel";
+import { startForwarderServer } from "./archive-forwarder-server";
 
 function restoreEnv(key: string, original: string | undefined): void {
 	if (original === undefined) {
@@ -287,6 +288,14 @@ describe("broker execution archive rows", () => {
 		expect(normalized.amount).toBe("7.50000000");
 	});
 
+	test("normalizeCcxtTransactionForArchive preserves an explicit zero fee", () => {
+		const normalized = normalizeCcxtTransactionForArchive({
+			fee: { cost: 0, currency: "USDC" },
+		});
+		expect(normalized.feeAmount).toBe("0");
+		expect(normalized.feeCurrency).toBe("USDC");
+	});
+
 	test("builds fill event rows in the contract column shape", () => {
 		const row = buildFillEventArchiveRow({
 			tags: buildCommonArchiveTags({
@@ -445,6 +454,79 @@ describe("broker execution archive rows", () => {
 		for (const column of CONTRACT_FILL_COLUMNS) {
 			expect(fillRow).toHaveProperty(column);
 		}
+	});
+});
+
+describe("withdrawal observation tracker", () => {
+	function shouldArchive(
+		tracker: WithdrawalObservationTracker,
+		transaction: Record<string, unknown>,
+	): boolean {
+		return tracker.shouldArchive({
+			exchange: "binance",
+			accountSelector: "primary",
+			assetSymbol: "USDC",
+			transaction,
+			normalized: normalizeCcxtTransactionForArchive(transaction),
+		});
+	}
+
+	test("suppresses identical records and captures every fingerprint field change", () => {
+		const baseline = {
+			id: "wd-1",
+			txid: "tx-1",
+			currency: "USDC",
+			status: "pending",
+			amount: "10",
+			fee: { cost: "0", currency: "USDC" },
+			datetime: "2026-07-01T00:00:00.000Z",
+			info: { completeTime: "" },
+		};
+		const changedRecords = [
+			{ ...baseline, status: "ok" },
+			{ ...baseline, txid: "tx-2" },
+			{ ...baseline, amount: "11" },
+			{ ...baseline, fee: { cost: "1", currency: "USDC" } },
+			{ ...baseline, fee: { cost: "0", currency: "USDT" } },
+			{ ...baseline, info: { completeTime: "2026-07-01T00:01:00Z" } },
+		];
+
+		for (const changed of changedRecords) {
+			const tracker = new WithdrawalObservationTracker();
+			expect(shouldArchive(tracker, baseline)).toBe(true);
+			expect(shouldArchive(tracker, { ...baseline })).toBe(false);
+			expect(shouldArchive(tracker, changed)).toBe(true);
+		}
+	});
+
+	test("uses non-colliding identities when the venue omits ids", () => {
+		const tracker = new WithdrawalObservationTracker({ maxEntries: 2 });
+		const unidentified = {
+			currency: "USDC",
+			status: "pending",
+			amount: "10",
+		};
+
+		expect(shouldArchive(tracker, unidentified)).toBe(true);
+		expect(shouldArchive(tracker, { ...unidentified })).toBe(true);
+		expect(tracker.getSize()).toBe(2);
+	});
+
+	test("evicts the oldest identity at the configured bound and permits replay", () => {
+		const tracker = new WithdrawalObservationTracker({ maxEntries: 2 });
+		const transaction = (id: string) => ({
+			id,
+			currency: "USDC",
+			status: "pending",
+			amount: "10",
+		});
+
+		expect(shouldArchive(tracker, transaction("wd-1"))).toBe(true);
+		expect(shouldArchive(tracker, transaction("wd-2"))).toBe(true);
+		expect(shouldArchive(tracker, transaction("wd-3"))).toBe(true);
+		expect(tracker.getSize()).toBe(2);
+		expect(shouldArchive(tracker, transaction("wd-1"))).toBe(true);
+		expect(tracker.getSize()).toBe(2);
 	});
 });
 

--- a/test/treasury-discovery-rpc.test.ts
+++ b/test/treasury-discovery-rpc.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
+import {
+	BrokerExecutionArchiver,
+	WithdrawalObservationTracker,
+} from "../src/helpers/broker-execution-archive";
 import { Action } from "../src/helpers/constants";
 import type { BrokerPoolEntry } from "../src/helpers/index";
 import { getServer } from "../src/server";
 import type { PolicyConfig } from "../src/types";
+import { startForwarderServer } from "./archive-forwarder-server";
 import { bindServer, executeAction, grpcObj } from "./order-telemetry-fixtures";
 
 const testPolicy: PolicyConfig = {
@@ -18,6 +23,7 @@ type TreasuryExchangeOptions = {
 	markets?: Record<string, unknown>;
 	currencies?: Record<string, unknown>;
 	deposits?: Array<Record<string, unknown>>;
+	withdrawals?: Array<Record<string, unknown>>;
 	depositWithdrawFees?: Record<string, unknown>;
 	balances?: Record<string, number>;
 };
@@ -28,6 +34,7 @@ function createTreasuryExchange(options: TreasuryExchangeOptions = {}) {
 		loadMarkets: [],
 		fetchCurrencies: [],
 		fetchDeposits: [],
+		fetchWithdrawals: [],
 		fetchDepositWithdrawFees: [],
 		fetchDepositAddress: [],
 		fetchTotalBalance: [],
@@ -38,6 +45,7 @@ function createTreasuryExchange(options: TreasuryExchangeOptions = {}) {
 			fetchMarkets: true,
 			fetchCurrencies: true,
 			fetchDeposits: true,
+			fetchWithdrawals: true,
 			fetchDepositAddress: true,
 			...(options.has ?? {}),
 		},
@@ -81,6 +89,10 @@ function createTreasuryExchange(options: TreasuryExchangeOptions = {}) {
 			calls.fetchDeposits.push(args);
 			return options.deposits ?? [];
 		},
+		fetchWithdrawals: async (...args: unknown[]) => {
+			calls.fetchWithdrawals.push(args);
+			return options.withdrawals ?? [];
+		},
 		fetchDepositWithdrawFees: async (...args: unknown[]) => {
 			calls.fetchDepositWithdrawFees.push(args);
 			return options.depositWithdrawFees ?? {};
@@ -117,7 +129,7 @@ function createPool(exchange: Exchange): Record<string, BrokerPoolEntry> {
 	};
 }
 
-describe("Treasury discovery and deposit observation RPC", () => {
+describe("Treasury discovery and transfer observation RPC", () => {
 	let server: grpc.Server | undefined;
 	let client: InstanceType<typeof grpcObj.cex_broker.cex_service> | undefined;
 
@@ -128,8 +140,23 @@ describe("Treasury discovery and deposit observation RPC", () => {
 		}
 	});
 
-	async function start(exchange: Exchange, policy = testPolicy) {
-		server = getServer(policy, createPool(exchange), ["*"], false, "");
+	async function start(
+		exchange: Exchange,
+		policy = testPolicy,
+		brokerArchiver?: BrokerExecutionArchiver,
+		withdrawalObservationTracker?: WithdrawalObservationTracker,
+	) {
+		server = getServer(
+			policy,
+			createPool(exchange),
+			["*"],
+			false,
+			"",
+			undefined,
+			brokerArchiver,
+			undefined,
+			withdrawalObservationTracker,
+		);
 		const port = await bindServer(server);
 		client = new grpcObj.cex_broker.cex_service(
 			`127.0.0.1:${port}`,
@@ -137,6 +164,174 @@ describe("Treasury discovery and deposit observation RPC", () => {
 		);
 		return client;
 	}
+
+	test("archives evolving fetchWithdrawals venue observations without changing the RPC result", async () => {
+		const forwarder = await startForwarderServer();
+		const withdrawals = [
+			{
+				id: "wd-1",
+				txid: "tx-1",
+				currency: "USDC",
+				status: "pending",
+				amount: 12.5,
+				address: "0xrecipient",
+				network: "ARBITRUM",
+				fee: { cost: 0, currency: "USDC" },
+				datetime: "2026-07-01T00:00:00.000Z",
+				info: { amount: "12.50000000", completeTime: "" },
+			},
+			{
+				id: "wd-2",
+				txid: "tx-2",
+				currency: "ETH",
+				status: "ok",
+				amount: "1.25",
+				fee: { cost: "0.005", currency: "ETH" },
+			},
+		];
+		const options = { withdrawals };
+		const { exchange, calls } = createTreasuryExchange(options);
+		(
+			exchange as unknown as Record<
+				string,
+				(...args: unknown[]) => Promise<unknown>
+			>
+		).fetchWithdrawalsHistory = async () => [
+			{ id: "not-an-exact-fetch-withdrawals-call", currency: "USDC" },
+		];
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: forwarder.url,
+			deploymentId: "test-deploy",
+			batchSize: 100,
+			flushIntervalMs: 60_000,
+		});
+		const tracker = new WithdrawalObservationTracker();
+
+		try {
+			const rpc = await start(exchange, testPolicy, archiver, tracker);
+			const request = {
+				action: Action.Call,
+				cex: "binance",
+				payload: {
+					functionName: "fetchWithdrawals",
+					args: '["USDC", 1700000000000]',
+					params: '{"limit": 50}',
+				},
+			};
+
+			const initial = await executeAction(rpc, request);
+			expect(JSON.parse(initial.result)).toEqual(withdrawals);
+			expect(calls.fetchWithdrawals[0]).toEqual([
+				"USDC",
+				1700000000000,
+				{ limit: 50 },
+			]);
+			await Promise.resolve();
+			await archiver.flush();
+
+			const initialRows = forwarder.requests.flatMap(
+				(post) => post.body.rows ?? [],
+			) as Array<{ table: string; row: Record<string, unknown> }>;
+			expect(initialRows).toHaveLength(2);
+			expect(initialRows[0]).toMatchObject({
+				table: "broker_execution.transfer_events",
+				row: {
+					schema_version: "1",
+					event_kind: "withdrawal",
+					lifecycle_action: "observe_withdrawal",
+					exchange: "binance",
+					account_selector: "primary",
+					asset_symbol: "USDC",
+					external_id: "wd-1",
+					txid: "tx-1",
+					status: "pending",
+					amount: "12.50000000",
+					fee_amount: "0",
+					fee_currency: "USDC",
+					address: "0xrecipient",
+					network: "ARBITRUM",
+					exchange_timestamp: "2026-07-01T00:00:00.000Z",
+					result_index: 0,
+				},
+			});
+			expect(initialRows[0]?.row.payload_json).toBe(
+				JSON.stringify(withdrawals[0]),
+			);
+			expect(initialRows[1]?.row).toMatchObject({
+				asset_symbol: "ETH",
+				external_id: "wd-2",
+				txid: "tx-2",
+				fee_amount: "0.005",
+				fee_currency: "ETH",
+				result_index: 1,
+			});
+
+			const nonExact = await executeAction(rpc, {
+				...request,
+				payload: {
+					functionName: "fetchWithdrawalsHistory",
+					args: "[]",
+					params: "{}",
+				},
+			});
+			expect(JSON.parse(nonExact.result)).toEqual([
+				{ id: "not-an-exact-fetch-withdrawals-call", currency: "USDC" },
+			]);
+			expect(tracker.getSize()).toBe(2);
+
+			await executeAction(rpc, request);
+			await Promise.resolve();
+			expect(archiver.getQueueDepth()).toBe(0);
+
+			withdrawals[0] = {
+				...withdrawals[0],
+				status: "ok",
+				txid: "tx-1-final",
+				info: {
+					amount: "12.50000000",
+					completeTime: "2026-07-01T00:05:00.000Z",
+				},
+			};
+			await executeAction(rpc, request);
+			await Promise.resolve();
+			await archiver.flush();
+
+			const allRows = forwarder.requests.flatMap(
+				(post) => post.body.rows ?? [],
+			) as Array<{ row: Record<string, unknown> }>;
+			expect(allRows).toHaveLength(3);
+			expect(allRows[2]?.row).toMatchObject({
+				external_id: "wd-1",
+				txid: "tx-1-final",
+				status: "ok",
+				result_index: 0,
+			});
+		} finally {
+			await archiver.close();
+			await forwarder.close();
+		}
+	});
+
+	test("keeps fetchWithdrawals successful and the tracker empty when archiving is disabled", async () => {
+		const withdrawals = [{ id: "wd-1", currency: "USDC", status: "pending" }];
+		const { exchange } = createTreasuryExchange({ withdrawals });
+		const tracker = new WithdrawalObservationTracker();
+		const rpc = await start(
+			exchange,
+			testPolicy,
+			BrokerExecutionArchiver.disabled(),
+			tracker,
+		);
+
+		const response = await executeAction(rpc, {
+			action: Action.Call,
+			cex: "binance",
+			payload: { functionName: "fetchWithdrawals", args: "[]", params: "{}" },
+		});
+
+		expect(JSON.parse(response.result)).toEqual(withdrawals);
+		expect(tracker.getSize()).toBe(0);
+	});
 
 	test("serves fetchMarkets and fetchCurrencies through the Call action", async () => {
 		const { exchange, calls } = createTreasuryExchange();


### PR DESCRIPTION
## Summary

- archive normalized `fetchWithdrawals` results as `observe_withdrawal` lifecycle rows
- preserve venue status, withdrawal ID, transaction ID, amount, fee, currency, address, network, timestamp, and raw payload
- suppress unchanged observations in process while retaining meaningful state changes and safe restart replay

## Validation

- `bun test` — 422 tests passed
- `bun run build:ts`
- Biome check passed for all changed files



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background archival for withdrawal observations retrieved through treasury calls.
  * Suppresses duplicate unchanged withdrawal records while capturing meaningful updates.
  * Supports bounded tracking and re-archival after entries are evicted.
  * Preserves withdrawal results when archival is disabled or encounters errors.
* **Tests**
  * Added coverage for withdrawal archival, deduplication, identity handling, eviction, and fee normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->