### PR TITLE
chore(release): bump cex-broker to 0.2.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- bump the package version to 0.2.24
- release the withdrawal observation support merged in #65

## Verification

- bun test: 423 passed, 0 failed
- bunx @biomejs/biome lint .: passed with existing warnings
- bun run build
- npm pack --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version to 0.2.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->