### PR TITLE
feat(archive): record periodic account balance snapshots

### DIFF
--- a/schema/clickhouse/broker_account.sql
+++ b/schema/clickhouse/broker_account.sql
@@ -1,0 +1,38 @@
+-- Durable account-level CEX balance observations. Each row is one coherent
+-- fetchBalance({ type: 'spot' }) response for one configured broker account.
+-- Quantities are decimal strings produced from CCXT-normalized JavaScript numbers;
+-- they are not venue-raw or atomic-unit precision.
+-- NO TTL: these rows are replay evidence for later as-of diagnostics.
+
+CREATE DATABASE IF NOT EXISTS broker_account;
+
+CREATE TABLE IF NOT EXISTS broker_account.balance_snapshots
+(
+    broker_observed_timestamp DateTime64(3, 'UTC'),
+    exchange_timestamp Nullable(DateTime64(3, 'UTC')),
+    source LowCardinality(String),
+    deployment_id LowCardinality(String),
+    schema_version LowCardinality(String),
+    exchange LowCardinality(String),
+    account_selector LowCardinality(String),
+    balance_scope LowCardinality(String),
+    observation_id String,
+    -- Union of aggregate-map keys and CCXT per-asset entries, including assets
+    -- whose quantity is missing or non-numeric.
+    reported_assets Array(String),
+    asset_entry_assets Array(String),
+    -- Only explicit finite CCXT-normalized quantities are stored. A missing key
+    -- is unknown, while a present "0" is an explicit zero.
+    free_balances Map(String, String),
+    used_balances Map(String, String),
+    total_balances Map(String, String),
+    -- Whether CCXT supplied each aggregate map. Quantities can still be present
+    -- from the coherent response's per-asset entries.
+    aggregate_free_map_present UInt8,
+    aggregate_used_map_present UInt8,
+    aggregate_total_map_present UInt8,
+    precision_basis LowCardinality(String)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(broker_observed_timestamp)
+ORDER BY (exchange, account_selector, balance_scope, broker_observed_timestamp, observation_id);

--- a/schema/clickhouse/market_data.sql
+++ b/schema/clickhouse/market_data.sql
@@ -12,8 +12,9 @@
 --   }
 --
 -- The forwarder is the single durable sink for every archive table: market_data.*
--- here, plus broker_execution.* (broker_execution.sql) and strategy_data.*
--- (strategy_data.sql). Execution rows may ALSO be mirrored to OTel logs for
+-- here, plus broker_execution.* (broker_execution.sql), broker_account.*
+-- (broker_account.sql), and strategy_data.* (strategy_data.sql). Execution rows
+-- may ALSO be mirrored to OTel logs for
 -- observability when CEX_BROKER_ARCHIVE_OTEL_LOGS_ENABLED=true; that mirror is in
 -- addition to the forwarder, not a replacement, and market_data.* is never
 -- mirrored (no OTel schema exists for it).

--- a/services/archive-forwarder/index.ts
+++ b/services/archive-forwarder/index.ts
@@ -17,7 +17,7 @@ const clickhouse = createClient({
 	username: config.clickhouse.username,
 	password: config.clickhouse.password,
 	database: config.clickhouse.database,
-	// broker_execution.transfer_events/fill_events use DateTime64 columns; producers
+	// Broker execution and account snapshot tables use DateTime64 columns; producers
 	// emit broker_observed_timestamp/exchange_timestamp as ISO-8601 UTC strings, so
 	// the inserter must best-effort-parse them (basic mode rejects the 'T'/'Z' form).
 	// Strictly more lenient than basic, so it never breaks the existing String/Int64
@@ -29,7 +29,7 @@ const inserter = createClickHouseInserter(clickhouse);
 try {
 	await ensureArchiveSchema(clickhouse);
 	console.log(
-		"ClickHouse archive schema ensured (market_data, broker_execution, strategy_data)",
+		"ClickHouse archive schema ensured (market_data, broker_execution, broker_account, strategy_data)",
 	);
 } catch (error) {
 	console.error("Failed to ensure ClickHouse schema:", error);

--- a/services/archive-forwarder/schema.ts
+++ b/services/archive-forwarder/schema.ts
@@ -56,6 +56,7 @@ function isIdempotentSchemaError(error: unknown): boolean {
 const ARCHIVE_SCHEMA_FILES = [
 	"market_data.sql",
 	"broker_execution.sql",
+	"broker_account.sql",
 	"strategy_data.sql",
 ] as const;
 

--- a/services/archive-forwarder/types.ts
+++ b/services/archive-forwarder/types.ts
@@ -27,6 +27,7 @@ export const SUPPORTED_TABLES = [
 	"broker_execution.market_metadata_snapshots",
 	"broker_execution.transfer_events",
 	"broker_execution.fill_events",
+	"broker_account.balance_snapshots",
 	"strategy_data.policy_evaluation_events",
 	"strategy_data.strategy_policy_snapshots",
 	"strategy_data.market_identity",

--- a/src/helpers/account-balance-archive-poller.ts
+++ b/src/helpers/account-balance-archive-poller.ts
@@ -1,0 +1,205 @@
+import type { BrokerAccount, BrokerPoolEntry } from "./broker";
+import {
+	ACCOUNT_BALANCE_SCOPE,
+	type BrokerExecutionArchiver,
+	buildAccountBalanceSnapshotRow,
+	buildCommonArchiveTags,
+	normalizeCcxtBalanceForArchive,
+} from "./broker-execution-archive";
+import { log } from "./logger";
+import type { OtelMetrics } from "./otel";
+
+type ExchangeWithBalance = {
+	fetchBalance: (params: { type: "spot" }) => Promise<unknown>;
+};
+
+export type AccountBalanceArchivePollerConfig = {
+	pollIntervalMs: number;
+};
+
+const DEFAULT_CONFIG: AccountBalanceArchivePollerConfig = {
+	pollIntervalMs: 60_000,
+};
+
+type BalancePollTarget = {
+	exchangeId: string;
+	account: BrokerAccount;
+};
+
+const metricLabels = (target: BalancePollTarget) => ({
+	exchange: target.exchangeId,
+	account_selector: target.account.label,
+	balance_scope: ACCOUNT_BALANCE_SCOPE,
+});
+
+export class AccountBalanceArchivePoller {
+	#timer: ReturnType<typeof setTimeout> | null = null;
+	#stopped = false;
+	#running: Promise<boolean> | null = null;
+	readonly #lastSuccessMs = new Map<string, number>();
+	readonly #config: AccountBalanceArchivePollerConfig;
+
+	constructor(
+		private readonly params: {
+			brokers: Record<string, BrokerPoolEntry>;
+			archiver: BrokerExecutionArchiver;
+			metrics?: OtelMetrics;
+			config?: Partial<AccountBalanceArchivePollerConfig>;
+		},
+	) {
+		this.#config = { ...DEFAULT_CONFIG, ...params.config };
+	}
+
+	start(): void {
+		if (
+			this.#timer ||
+			this.#stopped ||
+			!this.params.archiver.canPersistAccountBalanceSnapshots()
+		) {
+			return;
+		}
+		log.info("💰 Account balance archive poller started", {
+			balanceScope: ACCOUNT_BALANCE_SCOPE,
+		});
+		this.#schedule(0);
+	}
+
+	async stop(): Promise<void> {
+		this.#stopped = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = null;
+		}
+		await this.#running;
+	}
+
+	async pollAllOnce(): Promise<boolean> {
+		if (
+			this.#stopped ||
+			this.#running ||
+			!this.params.archiver.canPersistAccountBalanceSnapshots()
+		) {
+			return false;
+		}
+		this.#running = this.#pollAllSequentially();
+		try {
+			return await this.#running;
+		} finally {
+			this.#running = null;
+		}
+	}
+
+	#targets(): BalancePollTarget[] {
+		const targets: BalancePollTarget[] = [];
+		for (const [exchangeId, pool] of Object.entries(this.params.brokers)) {
+			for (const account of [pool.primary, ...pool.secondaryBrokers]) {
+				targets.push({ exchangeId, account });
+			}
+		}
+		return targets;
+	}
+
+	async #pollAllSequentially(): Promise<boolean> {
+		for (const target of this.#targets()) {
+			if (this.#stopped) {
+				break;
+			}
+			await this.#pollOne(target);
+		}
+		return true;
+	}
+
+	async #pollOne(target: BalancePollTarget): Promise<void> {
+		const labels = metricLabels(target);
+		void this.params.metrics?.recordCounter(
+			"cex_account_balance_poll_attempts_total",
+			1,
+			labels,
+		);
+		try {
+			const exchange = target.account
+				.exchange as unknown as ExchangeWithBalance;
+			const balance = await exchange.fetchBalance({
+				type: ACCOUNT_BALANCE_SCOPE,
+			});
+			const observedAt = new Date();
+			const normalized = normalizeCcxtBalanceForArchive(balance);
+			this.params.archiver.enqueue(
+				buildAccountBalanceSnapshotRow({
+					tags: buildCommonArchiveTags({
+						deploymentId: this.params.archiver.getDeploymentId(),
+						accountSelector: target.account.label,
+						exchange: target.exchangeId,
+						brokerObservedTimestamp: observedAt.toISOString(),
+					}),
+					balance: normalized,
+				}),
+			);
+
+			const successMs = Date.now();
+			this.#lastSuccessMs.set(this.#targetKey(target), successMs);
+			void this.params.metrics?.recordCounter(
+				"cex_account_balance_poll_successes_total",
+				1,
+				labels,
+			);
+			void this.params.metrics?.recordGauge(
+				"cex_account_balance_poll_last_success_timestamp_seconds",
+				Math.floor(successMs / 1000),
+				labels,
+			);
+			this.#recordFreshness(labels, successMs, successMs);
+		} catch (error) {
+			void this.params.metrics?.recordCounter(
+				"cex_account_balance_poll_failures_total",
+				1,
+				labels,
+			);
+			const now = Date.now();
+			const lastSuccess = this.#lastSuccessMs.get(this.#targetKey(target));
+			if (lastSuccess !== undefined) {
+				this.#recordFreshness(labels, lastSuccess, now);
+			}
+			log.warn("Account balance archive poll failed", {
+				exchange: target.exchangeId,
+				account: target.account.label,
+				balanceScope: ACCOUNT_BALANCE_SCOPE,
+				errorType: error instanceof Error ? error.name : "unknown",
+			});
+		}
+	}
+
+	#recordFreshness(
+		labels: ReturnType<typeof metricLabels>,
+		lastSuccessMs: number,
+		nowMs: number,
+	): void {
+		void this.params.metrics?.recordGauge(
+			"cex_account_balance_poll_freshness_seconds",
+			Math.max(0, (nowMs - lastSuccessMs) / 1000),
+			labels,
+		);
+	}
+
+	#targetKey(target: BalancePollTarget): string {
+		return `${target.exchangeId}|${target.account.label}|${ACCOUNT_BALANCE_SCOPE}`;
+	}
+
+	#schedule(delayMs: number): void {
+		this.#timer = setTimeout(() => void this.#tick(), delayMs);
+		this.#timer.unref?.();
+	}
+
+	async #tick(): Promise<void> {
+		this.#timer = null;
+		try {
+			await this.pollAllOnce();
+		} catch (error) {
+			log.error("Account balance archive poller tick failed", error);
+		} finally {
+			if (!this.#stopped) {
+				this.#schedule(this.#config.pollIntervalMs);
+			}
+		}
+	}
+}

--- a/src/helpers/broker-execution-archive/index.ts
+++ b/src/helpers/broker-execution-archive/index.ts
@@ -13,6 +13,7 @@ export {
 	redactStreamPayload,
 } from "./redact";
 export {
+	buildAccountBalanceSnapshotRow,
 	buildCommonArchiveTags,
 	buildFillEventArchiveRow,
 	buildMarketMetadataSnapshotRow,
@@ -20,12 +21,16 @@ export {
 	buildSubscribeStreamArchiveRow,
 	buildTransferEventArchiveRow,
 	type FillArchiveFields,
+	type NormalizedCcxtBalance,
 	type NormalizedCcxtTransfer,
+	normalizeCcxtBalanceForArchive,
 	normalizeCcxtTradeForArchive,
 	normalizeCcxtTransactionForArchive,
 	type TransferArchiveFields,
 } from "./rows";
 export {
+	ACCOUNT_BALANCE_PRECISION_BASIS,
+	ACCOUNT_BALANCE_SCOPE,
 	ARCHIVE_SCHEMA_VERSION,
 	BROKER_WRITE_SOURCE,
 	type BrokerArchiveCommonTags,

--- a/src/helpers/broker-execution-archive/index.ts
+++ b/src/helpers/broker-execution-archive/index.ts
@@ -50,5 +50,6 @@ export {
 	type BrokerExecutionArchiverOptions,
 	createBrokerExecutionArchiverFromEnv,
 	isArchiveOtelLogsEnabled,
+	isBrokerExecutionArchiveTable,
 	resolveArchiveForwarderUrlFromEnv,
 } from "./writer";

--- a/src/helpers/broker-execution-archive/rows.ts
+++ b/src/helpers/broker-execution-archive/rows.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
 import type { OrderExecutionTelemetry } from "../order-telemetry";
 import { asRecord } from "../shared/guards";
 import { hashMarketMetadata, redactStreamPayload } from "./redact";
 import {
+	ACCOUNT_BALANCE_PRECISION_BASIS,
+	ACCOUNT_BALANCE_SCOPE,
 	ARCHIVE_SCHEMA_VERSION,
 	BROKER_WRITE_SOURCE,
 	type BrokerArchiveCommonTags,
@@ -12,6 +15,20 @@ import {
 	type TransferEventKind,
 	type TransferLifecycleAction,
 } from "./types";
+
+type BalanceQuantityMap = Record<string, string>;
+
+export type NormalizedCcxtBalance = {
+	exchangeTimestamp?: string;
+	reportedAssets: string[];
+	assetEntryAssets: string[];
+	freeBalances: BalanceQuantityMap;
+	usedBalances: BalanceQuantityMap;
+	totalBalances: BalanceQuantityMap;
+	freeMapPresent: boolean;
+	usedMapPresent: boolean;
+	totalMapPresent: boolean;
+};
 
 function firstString(...values: unknown[]): string | undefined {
 	for (const value of values) {
@@ -50,6 +67,180 @@ function normalizeTimestamp(value: unknown): string | undefined {
 	}
 	const date = new Date(ms);
 	return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+// CCXT has already normalized the venue value to a JavaScript number. Expanding
+// exponent notation makes storage stable but cannot recover venue-raw precision.
+function decimalString(value: unknown): string | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return undefined;
+	}
+	if (Object.is(value, -0)) {
+		return "0";
+	}
+	const rendered = String(value).toLowerCase();
+	if (!rendered.includes("e")) {
+		return rendered;
+	}
+	const [coefficient = "", rawExponent = "0"] = rendered.split("e");
+	const exponent = Number.parseInt(rawExponent, 10);
+	const negative = coefficient.startsWith("-");
+	const unsigned = negative ? coefficient.slice(1) : coefficient;
+	const [integer = "0", fraction = ""] = unsigned.split(".");
+	const digits = `${integer}${fraction}`;
+	const decimalIndex = integer.length + exponent;
+	let expanded: string;
+	if (decimalIndex <= 0) {
+		expanded = `0.${"0".repeat(-decimalIndex)}${digits}`;
+	} else if (decimalIndex >= digits.length) {
+		expanded = `${digits}${"0".repeat(decimalIndex - digits.length)}`;
+	} else {
+		expanded = `${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`;
+	}
+	return negative ? `-${expanded}` : expanded;
+}
+
+function normalizedBalanceMap(value: unknown): BalanceQuantityMap {
+	const record = asRecord(value);
+	if (!record) {
+		return {};
+	}
+	const entries: Array<[string, string]> = [];
+	for (const [rawAsset, quantity] of Object.entries(record)) {
+		const asset = rawAsset.trim();
+		const normalized = decimalString(quantity);
+		if (asset && normalized !== undefined) {
+			entries.push([asset, normalized]);
+		}
+	}
+	return Object.fromEntries(
+		entries.sort(([left], [right]) => left.localeCompare(right)),
+	);
+}
+
+function sortedBalanceMap(map: BalanceQuantityMap): BalanceQuantityMap {
+	return Object.fromEntries(
+		Object.entries(map).sort(([left], [right]) => left.localeCompare(right)),
+	);
+}
+
+const BALANCE_METADATA_KEYS = new Set([
+	"info",
+	"timestamp",
+	"datetime",
+	"free",
+	"used",
+	"total",
+	"debt",
+]);
+
+export function normalizeCcxtBalanceForArchive(
+	balance: unknown,
+): NormalizedCcxtBalance {
+	const record = asRecord(balance) ?? {};
+	const aggregateRecords = {
+		free: asRecord(record.free),
+		used: asRecord(record.used),
+		total: asRecord(record.total),
+	};
+	const maps = {
+		free: normalizedBalanceMap(record.free),
+		used: normalizedBalanceMap(record.used),
+		total: normalizedBalanceMap(record.total),
+	};
+	const assetEntryAssets = new Set<string>();
+
+	for (const [rawAsset, value] of Object.entries(record)) {
+		if (BALANCE_METADATA_KEYS.has(rawAsset)) {
+			continue;
+		}
+		const asset = rawAsset.trim();
+		const assetEntry = asRecord(value);
+		if (
+			!asset ||
+			!assetEntry ||
+			!("free" in assetEntry || "used" in assetEntry || "total" in assetEntry)
+		) {
+			continue;
+		}
+		assetEntryAssets.add(asset);
+		for (const field of ["free", "used", "total"] as const) {
+			const normalized = decimalString(assetEntry[field]);
+			if (normalized !== undefined && maps[field][asset] === undefined) {
+				maps[field][asset] = normalized;
+			}
+		}
+	}
+
+	const reportedAssets = new Set(assetEntryAssets);
+	for (const aggregateRecord of Object.values(aggregateRecords)) {
+		for (const rawAsset of Object.keys(aggregateRecord ?? {})) {
+			const asset = rawAsset.trim();
+			if (asset) {
+				reportedAssets.add(asset);
+			}
+		}
+	}
+	for (const map of Object.values(maps)) {
+		for (const asset of Object.keys(map)) {
+			reportedAssets.add(asset);
+		}
+	}
+
+	return {
+		exchangeTimestamp: normalizeTimestamp(record.timestamp ?? record.datetime),
+		reportedAssets: [...reportedAssets].sort(),
+		assetEntryAssets: [...assetEntryAssets].sort(),
+		freeBalances: sortedBalanceMap(maps.free),
+		usedBalances: sortedBalanceMap(maps.used),
+		totalBalances: sortedBalanceMap(maps.total),
+		freeMapPresent: aggregateRecords.free !== undefined,
+		usedMapPresent: aggregateRecords.used !== undefined,
+		totalMapPresent: aggregateRecords.total !== undefined,
+	};
+}
+
+export function buildAccountBalanceSnapshotRow(input: {
+	tags: BrokerArchiveCommonTags;
+	balance: NormalizedCcxtBalance;
+}): BrokerArchiveRow {
+	const { tags, balance } = input;
+	const observationId = createHash("sha256")
+		.update(
+			JSON.stringify({
+				deployment_id: tags.deployment_id,
+				exchange: tags.exchange,
+				account_selector: tags.account_selector,
+				balance_scope: ACCOUNT_BALANCE_SCOPE,
+				broker_observed_timestamp: tags.broker_observed_timestamp,
+				balance,
+			}),
+		)
+		.digest("hex");
+
+	return {
+		table: "broker_account.balance_snapshots",
+		row: compactUndefined({
+			broker_observed_timestamp: tags.broker_observed_timestamp,
+			exchange_timestamp: balance.exchangeTimestamp,
+			source: tags.source,
+			deployment_id: tags.deployment_id,
+			schema_version: ARCHIVE_SCHEMA_VERSION,
+			exchange: tags.exchange,
+			account_selector: tags.account_selector,
+			balance_scope: ACCOUNT_BALANCE_SCOPE,
+			observation_id: observationId,
+			reported_assets: balance.reportedAssets,
+			asset_entry_assets: balance.assetEntryAssets,
+			free_balances: balance.freeBalances,
+			used_balances: balance.usedBalances,
+			total_balances: balance.totalBalances,
+			aggregate_free_map_present: Number(balance.freeMapPresent),
+			aggregate_used_map_present: Number(balance.usedMapPresent),
+			aggregate_total_map_present: Number(balance.totalMapPresent),
+			precision_basis: ACCOUNT_BALANCE_PRECISION_BASIS,
+		}),
+	};
 }
 
 function compactUndefined(

--- a/src/helpers/broker-execution-archive/types.ts
+++ b/src/helpers/broker-execution-archive/types.ts
@@ -1,9 +1,7 @@
 export const BROKER_WRITE_SOURCE = "broker_write" as const;
 
-// Bumped only on a breaking column-shape change to a broker_execution table.
-// Stamped onto every transfer_events / fill_events row so a reader can tell which
-// row layout produced it (the forwarder's CREATE TABLE IF NOT EXISTS never
-// migrates an existing table — see D7 in the observability proposal).
+// Bumped only on a breaking broker archive column-shape change. Stamped onto
+// transfer, fill, and account-balance rows so a reader can identify their layout.
 export const ARCHIVE_SCHEMA_VERSION = "1" as const;
 
 export type BrokerArchiveTable =
@@ -11,6 +9,7 @@ export type BrokerArchiveTable =
 	| "broker_execution.market_metadata_snapshots"
 	| "broker_execution.transfer_events"
 	| "broker_execution.fill_events"
+	| "broker_account.balance_snapshots"
 	| "market_data.orderbook_snapshots"
 	| "market_data.candles"
 	| "market_data.cex_stream_events"
@@ -54,3 +53,7 @@ export type TransferLifecycleAction =
 // (createOrder results carry no trades[] on the venues in use — see WS2.2), so we
 // stamp the true source here. Same column, honest provenance value.
 export const FILL_EVENT_KIND = "trade_history_fill" as const;
+
+export const ACCOUNT_BALANCE_SCOPE = "spot" as const;
+export const ACCOUNT_BALANCE_PRECISION_BASIS =
+	"ccxt_normalized_number" as const;

--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -4,7 +4,20 @@ import { SeverityNumber } from "@opentelemetry/api-logs";
 import { log } from "../logger";
 import { isMarketArchiveTable } from "../market-data-archive/types";
 import type { OtelLogs, OtelMetrics } from "../otel";
-import type { BrokerArchiveRow } from "./types";
+import type { BrokerArchiveRow, BrokerArchiveTable } from "./types";
+
+const BROKER_EXECUTION_ARCHIVE_TABLES = new Set<BrokerArchiveTable>([
+	"broker_execution.order_events",
+	"broker_execution.market_metadata_snapshots",
+	"broker_execution.transfer_events",
+	"broker_execution.fill_events",
+]);
+
+export function isBrokerExecutionArchiveTable(
+	table: BrokerArchiveTable,
+): boolean {
+	return BROKER_EXECUTION_ARCHIVE_TABLES.has(table);
+}
 
 export type BrokerExecutionArchiverOptions = {
 	deploymentId?: string;
@@ -172,6 +185,12 @@ export class BrokerExecutionArchiver {
 			}
 			return;
 		}
+		if (
+			row.table === "broker_account.balance_snapshots" &&
+			!this.forwarderUrl
+		) {
+			return;
+		}
 		if (this.queue.length >= this.maxQueueSize) {
 			this.queue.shift();
 			this.stats.shed += 1;
@@ -271,14 +290,15 @@ export class BrokerExecutionArchiver {
 		// even while a forwarder is unreachable. A requeued batch re-emits here on
 		// the retry flush; OTel logs are observability, not the audit source.
 		for (const entry of batch) {
-			if (!isMarketArchiveTable(entry.table)) {
+			if (isBrokerExecutionArchiveTable(entry.table)) {
 				this.emitOtelLog(entry);
 			}
 		}
 
 		// The forwarder is the durable sink for every archive table it supports
-		// (market_data.*, broker_execution.*, strategy_data.*). Requeue the whole
-		// batch on failure so nothing is silently dropped while a forwarder is set.
+		// (market_data.*, broker_execution.*, broker_account.*, strategy_data.*).
+		// Requeue the whole batch on failure so nothing is silently dropped while a
+		// forwarder is set.
 		if (this.forwarderUrl) {
 			try {
 				await this.postToForwarder(batch);

--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -150,6 +150,10 @@ export class BrokerExecutionArchiver {
 		);
 	}
 
+	canPersistAccountBalanceSnapshots(): boolean {
+		return this.isEnabled() && Boolean(this.forwarderUrl);
+	}
+
 	enqueue(row: BrokerArchiveRow): void {
 		if (
 			!this.enabled ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 	normalizePolicyConfig,
 	TravelRuleDepositReconciler,
 } from "./helpers";
+import { AccountBalanceArchivePoller } from "./helpers/account-balance-archive-poller";
 import {
 	type BrokerExecutionArchiver,
 	createBrokerExecutionArchiverFromEnv,
@@ -63,6 +64,7 @@ export default class CEXBroker {
 	private readonly withdrawalObservationTracker =
 		new WithdrawalObservationTracker();
 	private fillArchivePoller?: FillArchivePoller;
+	private accountBalanceArchivePoller?: AccountBalanceArchivePoller;
 
 	/**
 	 * Loads environment variables prefixed with CEX_BROKER_
@@ -288,6 +290,10 @@ export default class CEXBroker {
 			this.fillArchivePoller.stop();
 			this.fillArchivePoller = undefined;
 		}
+		if (this.accountBalanceArchivePoller) {
+			await this.accountBalanceArchivePoller.stop();
+			this.accountBalanceArchivePoller = undefined;
+		}
 		if (this.server) {
 			await this.server.forceShutdown();
 		}
@@ -318,6 +324,10 @@ export default class CEXBroker {
 		if (this.fillArchivePoller) {
 			this.fillArchivePoller.stop();
 			this.fillArchivePoller = undefined;
+		}
+		if (this.accountBalanceArchivePoller) {
+			await this.accountBalanceArchivePoller.stop();
+			this.accountBalanceArchivePoller = undefined;
 		}
 		log.info(`Running CEXBroker at ${new Date().toISOString()}`);
 
@@ -372,6 +382,17 @@ export default class CEXBroker {
 				metrics: this.otelMetrics,
 			});
 			this.fillArchivePoller.start();
+		}
+
+		if (this.brokerArchiver?.canPersistAccountBalanceSnapshots()) {
+			// Balance coverage is advertised only with the HTTP forwarder: OTel logs
+			// are an observability mirror, not durable replay evidence.
+			this.accountBalanceArchivePoller = new AccountBalanceArchivePoller({
+				brokers: this.brokers,
+				archiver: this.brokerArchiver,
+				metrics: this.otelMetrics,
+			});
+			this.accountBalanceArchivePoller.start();
 		}
 		return this;
 	}

--- a/test/account-balance-archive-poller.test.ts
+++ b/test/account-balance-archive-poller.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test";
+import { AccountBalanceArchivePoller } from "../src/helpers/account-balance-archive-poller";
+import type { BrokerAccount, BrokerPoolEntry } from "../src/helpers/broker";
+import type {
+	BrokerArchiveRow,
+	BrokerExecutionArchiver,
+} from "../src/helpers/broker-execution-archive";
+import type { OtelMetrics } from "../src/helpers/otel";
+
+function account(
+	exchange: unknown,
+	label: BrokerAccount["label"],
+	index?: number,
+): BrokerAccount {
+	return { exchange, label, index } as unknown as BrokerAccount;
+}
+
+function fakeArchiver(
+	sink: BrokerArchiveRow[],
+	durable = true,
+): BrokerExecutionArchiver {
+	return {
+		canPersistAccountBalanceSnapshots: () => durable,
+		getDeploymentId: () => "deploy-a",
+		enqueue: (row: BrokerArchiveRow) => sink.push(row),
+	} as unknown as BrokerExecutionArchiver;
+}
+
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve = (_value: T) => {};
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+describe("AccountBalanceArchivePoller", () => {
+	test("polls every primary and secondary sequentially with explicit spot scope and isolates failures", async () => {
+		const calls: string[] = [];
+		const params: unknown[] = [];
+		let inFlight = 0;
+		let maxInFlight = 0;
+		const exchange = (name: string, shouldFail = false) => ({
+			fetchBalance: async (value: unknown) => {
+				calls.push(name);
+				params.push(value);
+				inFlight += 1;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				await Promise.resolve();
+				inFlight -= 1;
+				if (shouldFail) {
+					throw new Error("rate limited");
+				}
+				return {
+					free: { USDC: 80 },
+					used: { USDC: 20 },
+					total: { USDC: 100 },
+				};
+			},
+		});
+		const brokers: Record<string, BrokerPoolEntry> = {
+			binance: {
+				primary: account(exchange("primary"), "primary"),
+				secondaryBrokers: [
+					account(exchange("secondary:1", true), "secondary:1", 1),
+					account(exchange("secondary:2"), "secondary:2", 2),
+				],
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const counters: Array<{
+			name: string;
+			labels: Record<string, string | number>;
+		}> = [];
+		const gauges: Array<{
+			name: string;
+			labels: Record<string, string | number>;
+		}> = [];
+		const metrics = {
+			recordCounter: async (
+				name: string,
+				_value: number,
+				labels: Record<string, string | number>,
+			) => counters.push({ name, labels }),
+			recordGauge: async (
+				name: string,
+				_value: number,
+				labels: Record<string, string | number>,
+			) => gauges.push({ name, labels }),
+		} as unknown as OtelMetrics;
+		const poller = new AccountBalanceArchivePoller({
+			brokers,
+			archiver: fakeArchiver(sink),
+			metrics,
+		});
+
+		expect(await poller.pollAllOnce()).toBe(true);
+
+		expect(calls).toEqual(["primary", "secondary:1", "secondary:2"]);
+		expect(params).toEqual([
+			{ type: "spot" },
+			{ type: "spot" },
+			{ type: "spot" },
+		]);
+		expect(maxInFlight).toBe(1);
+		expect(sink).toHaveLength(2);
+		expect(sink.map((entry) => entry.row.account_selector)).toEqual([
+			"primary",
+			"secondary:2",
+		]);
+		expect(
+			counters.filter(({ name }) => name.endsWith("attempts_total")),
+		).toHaveLength(3);
+		expect(
+			counters.filter(({ name }) => name.endsWith("successes_total")),
+		).toHaveLength(2);
+		expect(
+			counters.filter(({ name }) => name.endsWith("failures_total")),
+		).toHaveLength(1);
+		expect(gauges.map(({ name }) => name).sort()).toEqual([
+			"cex_account_balance_poll_freshness_seconds",
+			"cex_account_balance_poll_freshness_seconds",
+			"cex_account_balance_poll_last_success_timestamp_seconds",
+			"cex_account_balance_poll_last_success_timestamp_seconds",
+		]);
+		for (const metric of [...counters, ...gauges]) {
+			expect(metric.labels).toMatchObject({
+				exchange: "binance",
+				balance_scope: "spot",
+			});
+			expect(["primary", "secondary:1", "secondary:2"]).toContain(
+				metric.labels.account_selector,
+			);
+		}
+	});
+
+	test("rejects overlapping passes", async () => {
+		const gate = deferred<unknown>();
+		let calls = 0;
+		const sink: BrokerArchiveRow[] = [];
+		const brokers: Record<string, BrokerPoolEntry> = {
+			binance: {
+				primary: account(
+					{
+						fetchBalance: () => {
+							calls += 1;
+							return gate.promise;
+						},
+					},
+					"primary",
+				),
+				secondaryBrokers: [],
+			},
+		};
+		const poller = new AccountBalanceArchivePoller({
+			brokers,
+			archiver: fakeArchiver(sink),
+		});
+
+		const first = poller.pollAllOnce();
+		expect(await poller.pollAllOnce()).toBe(false);
+		expect(calls).toBe(1);
+		gate.resolve({ free: {}, used: {}, total: {} });
+		expect(await first).toBe(true);
+		expect(sink).toHaveLength(1);
+	});
+
+	test("stop waits for the active account and prevents later accounts and ticks", async () => {
+		const gate = deferred<unknown>();
+		const calls: string[] = [];
+		const sink: BrokerArchiveRow[] = [];
+		const brokers: Record<string, BrokerPoolEntry> = {
+			binance: {
+				primary: account(
+					{
+						fetchBalance: () => {
+							calls.push("primary");
+							return gate.promise;
+						},
+					},
+					"primary",
+				),
+				secondaryBrokers: [
+					account(
+						{
+							fetchBalance: async () => {
+								calls.push("secondary:1");
+								return {};
+							},
+						},
+						"secondary:1",
+						1,
+					),
+				],
+			},
+		};
+		const poller = new AccountBalanceArchivePoller({
+			brokers,
+			archiver: fakeArchiver(sink),
+		});
+
+		const pass = poller.pollAllOnce();
+		const stopped = poller.stop();
+		gate.resolve({ total: { USDC: 1 } });
+		await stopped;
+		await pass;
+
+		expect(calls).toEqual(["primary"]);
+		expect(await poller.pollAllOnce()).toBe(false);
+	});
+
+	test("does not advertise or poll balance coverage without a durable forwarder", async () => {
+		let calls = 0;
+		const brokers: Record<string, BrokerPoolEntry> = {
+			binance: {
+				primary: account(
+					{
+						fetchBalance: async () => {
+							calls += 1;
+							return {};
+						},
+					},
+					"primary",
+				),
+				secondaryBrokers: [],
+			},
+		};
+		const poller = new AccountBalanceArchivePoller({
+			brokers,
+			archiver: fakeArchiver([], false),
+		});
+
+		poller.start();
+		expect(await poller.pollAllOnce()).toBe(false);
+		await Promise.resolve();
+		expect(calls).toBe(0);
+		await poller.stop();
+	});
+});

--- a/test/archive-forwarder.test.ts
+++ b/test/archive-forwarder.test.ts
@@ -66,9 +66,11 @@ describe("archive forwarder batch parsing", () => {
 		expect(parsed.batch.rows).toHaveLength(1);
 	});
 
-	test("accepts the new broker_execution transfer_events and fill_events tables", () => {
+	test("accepts the broker execution and account balance archive tables", () => {
 		expect(isSupportedTable("broker_execution.transfer_events")).toBe(true);
 		expect(isSupportedTable("broker_execution.fill_events")).toBe(true);
+		expect(isSupportedTable("broker_account.balance_snapshots")).toBe(true);
+		expect(isSupportedTable("broker_account.unknown")).toBe(false);
 
 		const parsed = parseArchiveBatchRequest({
 			source: "broker_write",
@@ -82,6 +84,10 @@ describe("archive forwarder batch parsing", () => {
 					table: "broker_execution.fill_events",
 					row: { order_id: "o-1", trade_id: "t-1" },
 				},
+				{
+					table: "broker_account.balance_snapshots",
+					row: { observation_id: "obs-1", balance_scope: "spot" },
+				},
 			],
 		});
 		expect(parsed.ok).toBe(true);
@@ -89,7 +95,7 @@ describe("archive forwarder batch parsing", () => {
 			return;
 		}
 		expect(parsed.rejectedRowCount).toBe(0);
-		expect(parsed.batch.rows).toHaveLength(2);
+		expect(parsed.batch.rows).toHaveLength(3);
 	});
 
 	test("names the offending tables in rejectedTables so a bad rollout is visible", () => {
@@ -188,6 +194,10 @@ describe("archive forwarder routing", () => {
 				row: { order_id: "1" },
 			},
 			{
+				table: "broker_account.balance_snapshots",
+				row: { observation_id: "obs-1" },
+			},
+			{
 				table: "strategy_data.inventory_settlement_events",
 				row: { event_time_ms: 1 },
 			},
@@ -208,6 +218,7 @@ describe("archive forwarder routing", () => {
 		const grouped = groupRowsByTable(rows);
 		expect(grouped.get("market_data.candles")).toHaveLength(1);
 		expect(grouped.get("broker_execution.order_events")).toHaveLength(1);
+		expect(grouped.get("broker_account.balance_snapshots")).toHaveLength(1);
 		expect(
 			grouped.get("strategy_data.inventory_settlement_events"),
 		).toHaveLength(1);
@@ -216,6 +227,7 @@ describe("archive forwarder routing", () => {
 		expect(countSkippedRows(rows)).toBe(1);
 		expect(isSupportedTable("market_data.candles")).toBe(true);
 		expect(isSupportedTable("broker_execution.order_events")).toBe(true);
+		expect(isSupportedTable("broker_account.balance_snapshots")).toBe(true);
 		expect(isSupportedTable("strategy_data.policy_evaluation_events")).toBe(
 			true,
 		);
@@ -341,6 +353,7 @@ describe("archive forwarder schema init", () => {
 			expect.arrayContaining([
 				"market_data",
 				"broker_execution",
+				"broker_account",
 				"strategy_data",
 			]),
 		);
@@ -356,6 +369,7 @@ describe("archive forwarder schema init", () => {
 				"broker_execution.market_metadata_snapshots",
 				"broker_execution.transfer_events",
 				"broker_execution.fill_events",
+				"broker_account.balance_snapshots",
 				"strategy_data.policy_evaluation_events",
 				"strategy_data.strategy_policy_snapshots",
 				"strategy_data.market_identity",
@@ -363,5 +377,24 @@ describe("archive forwarder schema init", () => {
 				"strategy_data.inventory_settlement_events",
 			]),
 		);
+
+		const balanceTable = statements.find((query) =>
+			/CREATE TABLE IF NOT EXISTS\s+broker_account\.balance_snapshots/i.test(
+				query,
+			),
+		);
+		expect(balanceTable).toContain(
+			"broker_observed_timestamp DateTime64(3, 'UTC')",
+		);
+		expect(balanceTable).toContain(
+			"exchange_timestamp Nullable(DateTime64(3, 'UTC'))",
+		);
+		expect(balanceTable).toContain("free_balances Map(String, String)");
+		expect(balanceTable).toContain("used_balances Map(String, String)");
+		expect(balanceTable).toContain("total_balances Map(String, String)");
+		expect(balanceTable).toContain(
+			"ORDER BY (exchange, account_selector, balance_scope, broker_observed_timestamp, observation_id)",
+		);
+		expect(balanceTable).not.toContain("TTL");
 	});
 });

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -5,12 +5,14 @@ import {
 	redactStreamPayload,
 } from "../src/helpers/broker-execution-archive/redact";
 import {
+	buildAccountBalanceSnapshotRow,
 	buildCommonArchiveTags,
 	buildFillEventArchiveRow,
 	buildMarketMetadataSnapshotRow,
 	buildOrderEventArchiveRow,
 	buildSubscribeStreamArchiveRow,
 	buildTransferEventArchiveRow,
+	normalizeCcxtBalanceForArchive,
 	normalizeCcxtTradeForArchive,
 	normalizeCcxtTransactionForArchive,
 } from "../src/helpers/broker-execution-archive/rows";
@@ -81,6 +83,114 @@ describe("broker execution archive redaction", () => {
 });
 
 describe("broker execution archive rows", () => {
+	test("builds one coherent spot balance row without reducing venue total for locked capital", () => {
+		const balance = normalizeCcxtBalanceForArchive({
+			timestamp: 1_784_000_000_123,
+			free: { USDC: 80, BTC: 0.00000001 },
+			used: { USDC: 20, BTC: 0 },
+			total: { USDC: 100, BTC: 0.00000001 },
+			USDC: { free: 80, used: 20, total: 100 },
+			BTC: { free: 0.00000001, used: 0, total: 0.00000001 },
+		});
+		const row = buildAccountBalanceSnapshotRow({
+			tags: buildCommonArchiveTags({
+				deploymentId: "deploy-a",
+				accountSelector: "secondary:2",
+				exchange: "binance",
+				brokerObservedTimestamp: "2026-07-14T12:00:00.000Z",
+			}),
+			balance,
+		});
+
+		expect(row.table).toBe("broker_account.balance_snapshots");
+		expect(row.row).toMatchObject({
+			broker_observed_timestamp: "2026-07-14T12:00:00.000Z",
+			exchange_timestamp: new Date(1_784_000_000_123).toISOString(),
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			schema_version: "1",
+			exchange: "binance",
+			account_selector: "secondary:2",
+			balance_scope: "spot",
+			reported_assets: ["BTC", "USDC"],
+			asset_entry_assets: ["BTC", "USDC"],
+			free_balances: { BTC: "0.00000001", USDC: "80" },
+			used_balances: { BTC: "0", USDC: "20" },
+			total_balances: { BTC: "0.00000001", USDC: "100" },
+			aggregate_free_map_present: 1,
+			aggregate_used_map_present: 1,
+			aggregate_total_map_present: 1,
+			precision_basis: "ccxt_normalized_number",
+		});
+		expect(row.row.observation_id).toMatch(/^[a-f0-9]{64}$/);
+		expect(row.row).not.toHaveProperty("payload_json");
+	});
+
+	test("preserves sparse map and reported-asset semantics without inventing zeros", () => {
+		const normalized = normalizeCcxtBalanceForArchive({
+			used: { USDC: 0, DOGE: null },
+			total: { BTC: 2, XRP: "1.2300" },
+			ETH: { free: 1, total: 1 },
+		});
+
+		expect(normalized).toEqual({
+			exchangeTimestamp: undefined,
+			reportedAssets: ["BTC", "DOGE", "ETH", "USDC", "XRP"],
+			assetEntryAssets: ["ETH"],
+			freeBalances: { ETH: "1" },
+			usedBalances: { USDC: "0" },
+			totalBalances: { BTC: "2", ETH: "1" },
+			freeMapPresent: false,
+			usedMapPresent: true,
+			totalMapPresent: true,
+		});
+		expect(normalized.freeBalances).not.toHaveProperty("BTC");
+		expect(normalized.totalBalances).not.toHaveProperty("USDC");
+		expect(normalized.totalBalances).not.toHaveProperty("XRP");
+		expect(normalized.usedBalances).not.toHaveProperty("DOGE");
+	});
+
+	test("excludes secrets and unfiltered info while keeping the row body bounded", () => {
+		const secret = "live-api-secret";
+		const normalized = normalizeCcxtBalanceForArchive({
+			free: { USDC: 1 },
+			used: {},
+			total: { USDC: 1 },
+			info: {
+				apiKey: secret,
+				raw: "x".repeat(6 * 1024 * 1024),
+			},
+		});
+		const row = buildAccountBalanceSnapshotRow({
+			tags: buildCommonArchiveTags({
+				deploymentId: "deploy-a",
+				accountSelector: "primary",
+				exchange: "binance",
+				brokerObservedTimestamp: "2026-07-14T12:00:00.000Z",
+			}),
+			balance: normalized,
+		});
+		const serialized = JSON.stringify(row);
+
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain('"info"');
+		expect(Buffer.byteLength(serialized)).toBeLessThan(2_000);
+	});
+
+	test("derives a stable observation id from the complete normalized observation", () => {
+		const balance = normalizeCcxtBalanceForArchive({ total: { USDC: 1 } });
+		const tags = buildCommonArchiveTags({
+			deploymentId: "deploy-a",
+			accountSelector: "primary",
+			exchange: "binance",
+			brokerObservedTimestamp: "2026-07-14T12:00:00.000Z",
+		});
+		const first = buildAccountBalanceSnapshotRow({ tags, balance });
+		const second = buildAccountBalanceSnapshotRow({ tags, balance });
+
+		expect(first.row.observation_id).toBe(second.row.observation_id);
+	});
+
 	test("builds order event rows tagged for broker_execution.order_events", () => {
 		const telemetry = buildOrderExecutionTelemetry(
 			{
@@ -856,6 +966,26 @@ describe("broker execution archiver queue", () => {
 
 		const disabled = BrokerExecutionArchiver.disabled();
 		expect(disabled.canPersistMarketMetadataSnapshot()).toBe(false);
+	});
+
+	test("advertises durable account balance snapshots only when an HTTP forwarder exists", async () => {
+		const forwarderOnly = BrokerExecutionArchiver.create({
+			forwarderUrl: "http://127.0.0.1:9/archive",
+			flushIntervalMs: 60_000,
+		});
+		const otelOnly = BrokerExecutionArchiver.create({
+			otelLogs: new MockOtelLogs(),
+			flushIntervalMs: 60_000,
+		});
+		const disabled = BrokerExecutionArchiver.disabled();
+
+		expect(forwarderOnly.canPersistAccountBalanceSnapshots()).toBe(true);
+		expect(otelOnly.isEnabled()).toBe(true);
+		expect(otelOnly.canPersistAccountBalanceSnapshots()).toBe(false);
+		expect(disabled.canPersistAccountBalanceSnapshots()).toBe(false);
+
+		await forwarderOnly.close();
+		await otelOnly.close();
 	});
 });
 

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { LogRecord } from "@opentelemetry/api-logs";
+import { MAX_ARCHIVE_BODY_BYTES } from "../services/archive-forwarder/limits";
 import {
 	redactSecretLiterals,
 	redactStreamPayload,
@@ -24,6 +25,7 @@ import {
 	BrokerExecutionArchiver,
 	createBrokerExecutionArchiverFromEnv,
 	isArchiveOtelLogsEnabled,
+	isBrokerExecutionArchiveTable,
 	resolveArchiveForwarderUrlFromEnv,
 } from "../src/helpers/broker-execution-archive/writer";
 import { buildOrderExecutionTelemetry } from "../src/helpers/order-telemetry";
@@ -175,6 +177,53 @@ describe("broker execution archive rows", () => {
 		expect(serialized).not.toContain(secret);
 		expect(serialized).not.toContain('"info"');
 		expect(Buffer.byteLength(serialized)).toBeLessThan(2_000);
+	});
+
+	test("keeps a default 10-row batch of 800-asset snapshots below the forwarder body limit", () => {
+		const assets = Array.from(
+			{ length: 800 },
+			(_, index) => `ASSET_${index.toString().padStart(4, "0")}`,
+		);
+		const free = Object.fromEntries(
+			assets.map((asset, index) => [asset, index + 0.125]),
+		);
+		const used = Object.fromEntries(
+			assets.map((asset, index) => [asset, index + 0.25]),
+		);
+		const total = Object.fromEntries(
+			assets.map((asset, index) => [asset, index * 2 + 0.375]),
+		);
+		const response: Record<string, unknown> = { free, used, total };
+		for (const asset of assets) {
+			response[asset] = {
+				free: free[asset],
+				used: used[asset],
+				total: total[asset],
+			};
+		}
+		const balance = normalizeCcxtBalanceForArchive(response);
+		const rows = Array.from({ length: 10 }, (_, index) =>
+			buildAccountBalanceSnapshotRow({
+				tags: buildCommonArchiveTags({
+					deploymentId: "deploy-a",
+					accountSelector: "primary",
+					exchange: "binance",
+					brokerObservedTimestamp: new Date(
+						Date.UTC(2026, 6, 14, 12, index),
+					).toISOString(),
+				}),
+				balance,
+			}),
+		);
+		const envelope = JSON.stringify({
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			rows,
+		});
+
+		expect(balance.reportedAssets).toHaveLength(800);
+		expect(rows).toHaveLength(10);
+		expect(Buffer.byteLength(envelope)).toBeLessThan(MAX_ARCHIVE_BODY_BYTES);
 	});
 
 	test("derives a stable observation id from the complete normalized observation", () => {
@@ -667,6 +716,21 @@ describe("withdrawal observation tracker", () => {
 });
 
 describe("broker execution archiver queue", () => {
+	test("classifies only broker_execution tables for the OTel mirror", () => {
+		for (const table of [
+			"broker_execution.order_events",
+			"broker_execution.market_metadata_snapshots",
+			"broker_execution.transfer_events",
+			"broker_execution.fill_events",
+		] as const) {
+			expect(isBrokerExecutionArchiveTable(table)).toBe(true);
+		}
+		expect(
+			isBrokerExecutionArchiveTable("broker_account.balance_snapshots"),
+		).toBe(false);
+		expect(isBrokerExecutionArchiveTable("market_data.candles")).toBe(false);
+	});
+
 	test("posts JSON with the bearer token over the real node:http transport", async () => {
 		const server = await startForwarderServer();
 		const originalToken = process.env.CEX_BROKER_ARCHIVE_FORWARDER_TOKEN;
@@ -748,7 +812,7 @@ describe("broker execution archiver queue", () => {
 		}
 	});
 
-	test("mirrors broker_execution rows to OTel logs and posts every table to the forwarder", async () => {
+	test("mirrors only broker_execution rows to OTel logs and forwards every archive table", async () => {
 		const server = await startForwarderServer();
 		try {
 			const otelLogs = new MockOtelLogs();
@@ -768,6 +832,10 @@ describe("broker execution archiver queue", () => {
 				table: "market_data.orderbook_snapshots",
 				row: { source: "broker_write", best_bid: 100 },
 			});
+			archiver.enqueue({
+				table: "broker_account.balance_snapshots",
+				row: { source: "broker_write", reported_assets: ["USDC"] },
+			});
 
 			await archiver.flush();
 
@@ -780,6 +848,9 @@ describe("broker execution archiver queue", () => {
 				rows: expect.arrayContaining([
 					expect.objectContaining({ table: "broker_execution.order_events" }),
 					expect.objectContaining({ table: "market_data.orderbook_snapshots" }),
+					expect.objectContaining({
+						table: "broker_account.balance_snapshots",
+					}),
 				]),
 			});
 
@@ -789,7 +860,7 @@ describe("broker execution archiver queue", () => {
 		}
 	});
 
-	test("drops market_data rows when forwarder URL is missing", async () => {
+	test("drops market-data and account-balance rows when the forwarder is missing", async () => {
 		const otelLogs = new MockOtelLogs();
 		const archiver = BrokerExecutionArchiver.create({
 			otelLogs,
@@ -801,6 +872,10 @@ describe("broker execution archiver queue", () => {
 		archiver.enqueue({
 			table: "market_data.candles",
 			row: { source: "broker_write", open_time_ms: 1_000 },
+		});
+		archiver.enqueue({
+			table: "broker_account.balance_snapshots",
+			row: { source: "broker_write", reported_assets: ["USDC"] },
 		});
 		archiver.enqueue({
 			table: "broker_execution.order_events",


### PR DESCRIPTION
## Summary

- poll every configured primary and secondary exchange account for spot balances
- archive each observation as one coherent total, free, and used snapshot in `broker_account.balance_snapshots`
- initialize and forward append-only rows while excluding balance snapshots from OTel log mirroring
- add per-account polling and freshness metrics without changing the public balance RPC

## Data contract and failure behavior

- persist CCXT-normalized decimal strings with source, account, scope, timestamp, and precision provenance
- omit raw exchange payloads and credentials
- isolate account failures, prevent overlapping polls, and stop cleanly
- start polling only when durable archive forwarding is configured

## Verification

- `bun test`: 434 passed
- focused archive tests: 53 passed
- `bun run build:ts`
- changed-file Biome checks
- `git diff --check origin/develop...HEAD`

## Follow-up checks

- `bun run check` still reports the repository baseline of 9 errors and 118 warnings outside this change
- live ClickHouse DDL and JSONEachRow ingestion still needs validation in an environment with ClickHouse tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic spot-balance snapshots for configured broker accounts.
  * Added durable archival of account balances with exchange, account, timestamp, asset, and balance details.
  * Added freshness and success/failure monitoring for balance collection.
  * Added safeguards to prevent duplicate polling and ensure clean shutdowns.

* **Bug Fixes**
  * Improved archive routing so only supported execution events are mirrored to telemetry logs.
  * Prevented balance snapshots from being accepted when durable forwarding is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->