### PR TITLE
Fix Binance user-data stream subscriptions rejected over request id

### DIFF
--- a/src/helpers/binance-user-data-stream.ts
+++ b/src/helpers/binance-user-data-stream.ts
@@ -235,6 +235,8 @@ export class BinanceSpotUserDataStream
 {
 	private readonly ws: WebSocketLike;
 	private readonly secretValues: string[];
+	// Binance rejects request ids not matching ^[a-zA-Z0-9-_]{1,36}$ with
+	// error -1135 and then closes the socket (1008 "disconnected").
 	private readonly requestId =
 		`user-data-${Date.now()}-${userDataRequestCounter++}`;
 	private readonly maxBufferedEvents: number;

--- a/src/helpers/binance-user-data-stream.ts
+++ b/src/helpers/binance-user-data-stream.ts
@@ -13,9 +13,9 @@ export type BinanceUserDataEvent = {
 
 type BinanceUserDataMessage =
 	| {
-			id?: string;
+			id?: string | null;
 			status?: number;
-			error?: { msg?: string; message?: string };
+			error?: { code?: number; msg?: string; message?: string };
 			result?: { subscriptionId?: number };
 	  }
 	| {
@@ -43,6 +43,7 @@ type BinanceSpotUserDataStreamOptions = {
 
 let createWebSocket: WebSocketFactory = (url) =>
 	new WebSocket(url) as WebSocketLike;
+let userDataRequestCounter = 0;
 
 export function setBinanceUserDataWebSocketFactoryForTests(
 	factory: WebSocketFactory,
@@ -234,7 +235,8 @@ export class BinanceSpotUserDataStream
 {
 	private readonly ws: WebSocketLike;
 	private readonly secretValues: string[];
-	private readonly requestId = `user-data-${Date.now()}-${Math.random()}`;
+	private readonly requestId =
+		`user-data-${Date.now()}-${userDataRequestCounter++}`;
 	private readonly maxBufferedEvents: number;
 	private readonly queue: BinanceUserDataEvent[] = [];
 	private readonly waiters: Array<{
@@ -346,6 +348,26 @@ export class BinanceSpotUserDataStream
 				return;
 			}
 			this.subscriptionId = message.result?.subscriptionId ?? null;
+			return;
+		}
+
+		if (
+			"status" in message &&
+			typeof message.status === "number" &&
+			message.status !== 200
+		) {
+			const errorMessage =
+				message.error?.msg ??
+				message.error?.message ??
+				`Binance user-data request failed with status ${message.status}`;
+			const errorCode = message.error?.code;
+			this.fail(
+				new Error(
+					typeof errorCode === "number"
+						? `${errorMessage} (code ${errorCode})`
+						: errorMessage,
+				),
+			);
 			return;
 		}
 

--- a/test/subscribe-user-stream.test.ts
+++ b/test/subscribe-user-stream.test.ts
@@ -92,15 +92,14 @@ class FakeWebSocket {
 	}
 
 	emitEvent(event: Record<string, unknown>) {
-		this.emit(
-			"message",
-			Buffer.from(
-				JSON.stringify({
-					subscriptionId: FakeWebSocket.instances.indexOf(this),
-					event,
-				}),
-			),
-		);
+		this.emitMessage({
+			subscriptionId: FakeWebSocket.instances.indexOf(this),
+			event,
+		});
+	}
+
+	emitMessage(message: unknown) {
+		this.emit("message", Buffer.from(JSON.stringify(message)));
 	}
 
 	emitError(error: unknown) {
@@ -308,6 +307,75 @@ describe("Binance Subscribe user-data streams", () => {
 				"Binance user-data stream buffered event limit exceeded (1)",
 			);
 			expect(socket.closed).toBe(true);
+		} finally {
+			stream.close();
+		}
+	});
+
+	test("sends a Binance-compatible user-data request id", async () => {
+		const primary = createBinanceExchange("primary-key", "primary-secret");
+		const stream = new BinanceSpotUserDataStream(primary.exchange);
+
+		try {
+			const socket = await waitForSocket();
+			const request = JSON.parse(socket.sent[0] ?? "{}") as { id?: string };
+
+			expect(request.id).toMatch(/^[a-zA-Z0-9-_]{1,36}$/);
+		} finally {
+			stream.close();
+		}
+	});
+
+	test("uses different request ids for concurrent Binance user-data streams", async () => {
+		const primary = createBinanceExchange("primary-key", "primary-secret");
+		const firstStream = new BinanceSpotUserDataStream(primary.exchange);
+		const secondStream = new BinanceSpotUserDataStream(primary.exchange);
+
+		try {
+			await waitForSocket();
+			const requestIds = FakeWebSocket.instances.map((socket) => {
+				const request = JSON.parse(socket.sent[0] ?? "{}") as { id?: string };
+				return request.id;
+			});
+
+			expect(requestIds).toHaveLength(2);
+			expect(requestIds[0]).not.toBe(requestIds[1]);
+		} finally {
+			firstStream.close();
+			secondStream.close();
+		}
+	});
+
+	test("surfaces unmatched Binance user-data request errors", async () => {
+		const primary = createBinanceExchange("primary-key", "primary-secret");
+		const stream = new BinanceSpotUserDataStream(primary.exchange);
+
+		try {
+			const iterator = stream[Symbol.asyncIterator]();
+			const nextEvent = iterator.next();
+			const socket = await waitForSocket();
+			socket.emitMessage({
+				id: null,
+				status: 400,
+				error: {
+					code: -1135,
+					msg: "Invalid 'id' in JSON request",
+				},
+			});
+
+			let error: unknown;
+			try {
+				await nextEvent;
+			} catch (caught) {
+				error = caught;
+			}
+
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toContain(
+				"Invalid 'id' in JSON request",
+			);
+			expect((error as Error).message).toContain("code -1135");
+			expect((error as Error).message).not.toContain("closed unexpectedly");
 		} finally {
 			stream.close();
 		}


### PR DESCRIPTION
## Problem

Binance user-data stream subscriptions over the WebSocket API never succeed: every connection is closed by Binance ~1s after the subscribe request with `1008 "disconnected"`, and the broker retries at the backoff cap indefinitely (observed in production at ~87 disconnects per 15 minutes, with order/fill updates falling back to REST polling).

Root cause, reproduced against the live endpoint:

1. `BinanceSpotUserDataStream` built its request id as `user-data-${Date.now()}-${Math.random()}` — ~42 chars containing a `.`. Binance requires ids matching `^[a-zA-Z0-9-_]{1,36}$` and rejects the request with `{"id":null,"status":400,"error":{"code":-1135,...}}`, then closes the socket with `1008 "disconnected"`.
2. `handleMessage` only handled responses whose id matched the request id, or event frames. The `id: null` error response matched neither and was silently discarded, so the only surfaced error was the generic close — which is why the real rejection never appeared in logs.

## Fix

- Request ids now use a module-level monotonic counter (`user-data-<epoch-ms>-<n>`), always conforming to Binance's id constraint and unique across concurrent streams. A comment documents the constraint and its failure mode.
- `handleMessage` now fails the stream on any non-200 response that does not match the request id (including `id: null`), surfacing the server's error message and numeric code instead of dropping it.

Matching-id responses, event delivery, and the reconnect loop are unchanged.

## Verification

- New tests: subscribe frame id matches `^[a-zA-Z0-9-_]{1,36}$`; concurrent streams use distinct ids; an `id: null` status-400 response fails the stream with the server message and `code -1135` rather than the generic close error.
- `bun test test/subscribe-user-stream.test.ts`: 9 pass / 0 fail.
- `bun test` (full suite): 419 pass / 0 fail.
- `biome check` and `tsc --noEmit` clean.

Note: with the id rejection fixed, the subscribe request reaches Binance's auth layer for the first time — the first deployment should watch the initial live subscribe for `-2015` (key/IP/permission) errors, which will now be visible in logs thanks to the error-surfacing change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Binance user-data subscription errors, including clearer messages and error codes when available.
  * Ensured subscription request identifiers are reliably unique.
  * Improved error propagation for invalid or unmatched WebSocket responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->