### PR TITLE
chore(release): bump cex-broker to 0.2.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.24",
+	"version": "0.2.25",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Release 0.2.25.

Ships the Binance user-data WebSocket fix (#68): WS-API request ids now conform to Binance's required format, and unmatched error responses are surfaced instead of silently dropped. Fixes the repeated code-1008 user-data stream disconnects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.2.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->