### PR TITLE
Release cex-broker 0.2.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.26",
+	"version": "0.2.27",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Bumps the package version to 0.2.27 for the next release train, which ships the OHLCV subscription streaming fix (#73) to the broker, archive-forwarder, and OHLCV collector images. Tag `v0.2.27` on the merge commit once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.2.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->