### PR TITLE
Release cex-broker 0.2.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- release package-owned archive delivery, retry, and durable loss handling
- preserve actionable failed-order evidence while keeping operational telemetry redacted
- bump `@usherlabs/cex-broker` to `0.2.28`

## Verification

- `bun test` (461 passed, 0 failed)
- `bunx @biomejs/biome lint .` (passes with 116 existing warnings)
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package to version 0.2.28.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->