### PR TITLE
Fix Node-compatible package output

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -10,7 +10,7 @@ await Bun.build({
 await Bun.build({
 	entrypoints: ["./src/index.ts"],
 	outdir: "./dist",
-	target: "bun",
+	target: "node",
 	external: [
 		"fs",
 		"path",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	"scripts": {
 		"proto-gen": "./proto-gen.sh",
 		"start": "bun run ./src/index.ts",
-		"build": "bun run proto-gen && bun run ./build.ts && bun run build:ts && bun run copy:dts && bun run copy:proto",
+		"build": "bun run proto-gen && bun run ./build.ts && bun run build:ts && bun run copy:dts && bun run copy:proto && node scripts/check-node-package.mjs",
 		"prepack": "bun run build",
 		"start-broker": "bun run ./src/cli.ts",
 		"start-archive-forwarder": "bun run services/archive-forwarder/index.ts",

--- a/scripts/check-node-package.mjs
+++ b/scripts/check-node-package.mjs
@@ -1,0 +1,14 @@
+delete process.env.CEX_BROKER_ARCHIVE_ENABLED;
+
+const { default: CEXBroker } = await import("../dist/index.js");
+const broker = new CEXBroker(
+	{},
+	{
+		withdraw: { rule: [] },
+		deposit: {},
+		order: { rule: { markets: [], limits: [] } },
+	},
+);
+
+await broker.stop();
+console.log("Node package import and construction passed");


### PR DESCRIPTION
## Summary

- build the published library for Node instead of Bun
- run a Node import and constructor smoke test during every build and prepack

## Why

The package entrypoint is consumed by Node, but the published bundle was generated with Bun as its target. That emitted `import.meta.require`, so importing the package in Node failed with `TypeError: __require is not a function` before broker startup. The Node target emits `createRequire(import.meta.url)` and remains loadable by Bun.

## Verification

- `bun run build` including the new Node artifact smoke test
- 461 package tests passed
- Biome lint completed with the existing warnings and no errors
- built package imported and constructed successfully under Bun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility for Node.js runtime environments.
  * Ensured TypeScript compilation runs as part of the standard build process.

* **Tests**
  * Added a runtime validation check to confirm the packaged broker can be loaded and shut down successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->