### PR TITLE
Release cex-broker 0.2.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.28",
+	"version": "0.2.29",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- release `@usherlabs/cex-broker` 0.2.29
- ship Node-compatible package output
- validate Node import and broker construction as part of the package build

## Verification

- `bun run build`
- `bun test` — 461 passed
- `bunx @biomejs/biome lint .` — passed with 116 existing warnings