### PR TITLE
Forward caller clientOrderId on the typed CreateOrder path

### DIFF
--- a/src/handlers/execute-action/orders.ts
+++ b/src/handlers/execute-action/orders.ts
@@ -47,6 +47,12 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 
 	const orderValue = parsePayloadForAction(ctx, CreateOrderPayloadSchema);
 	if (orderValue === null) return;
+	const createOrderParams = {
+		...orderValue.params,
+		...(orderValue.clientOrderId !== undefined && {
+			clientOrderId: orderValue.clientOrderId,
+		}),
+	};
 	let resolvedOrderTelemetry: {
 		symbol?: string;
 		side?: string;
@@ -96,7 +102,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 				resolution.symbol,
 			);
 		}
-		const telemetryIds = extractOrderTelemetryIds(orderValue.params);
+		const telemetryIds = extractOrderTelemetryIds(createOrderParams);
 		const submissionTimestamp = new Date().toISOString();
 		const marketMetadataHash = await captureMarketMetadataSnapshot(
 			brokerArchiver,
@@ -116,7 +122,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 			resolution.side,
 			resolution.amountBase ?? orderValue.amount,
 			orderValue.price,
-			orderValue.params ?? {},
+			createOrderParams,
 		);
 		const createOrderContext = {
 			action: "CreateOrder" as const,
@@ -156,7 +162,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 			requestedQuantity:
 				resolvedOrderTelemetry.requestedQuantity ?? orderValue.amount,
 			requestedNotional: orderValue.amount * orderValue.price,
-			...extractOrderTelemetryIds(orderValue.params),
+			...extractOrderTelemetryIds(createOrderParams),
 		};
 		emitOrderExecutionTelemetryInBackground(
 			otelMetrics,

--- a/src/schemas/action-payloads.ts
+++ b/src/schemas/action-payloads.ts
@@ -82,6 +82,7 @@ export const CreateOrderPayloadSchema = z.object({
 	toToken: z.string().min(1),
 	price: z.coerce.number().positive(),
 	marketType: marketTypeSchema,
+	clientOrderId: z.string().min(1).optional(),
 	params: z.preprocess(parseJsonString, stringNumberRecordSchema).default({}),
 });
 

--- a/test/order-telemetry-fixtures.ts
+++ b/test/order-telemetry-fixtures.ts
@@ -59,11 +59,13 @@ export class CapturingOtelMetrics {
 export function createOrderExchangeFixture(options: {
 	createOrderResult?: unknown;
 	fetchOrderResult?: unknown;
+	fetchOrderBookResult?: unknown;
 	createOrderError?: Error;
 }) {
 	const calls: Record<string, unknown[][]> = {
 		createOrder: [],
 		fetchOrder: [],
+		fetchOrderBook: [],
 	};
 	const exchange: Record<string, unknown> = {
 		markets: {
@@ -104,6 +106,12 @@ export function createOrderExchangeFixture(options: {
 			return options.fetchOrderResult;
 		},
 	};
+	if (options.fetchOrderBookResult !== undefined) {
+		exchange.fetchOrderBook = async (...args: unknown[]) => {
+			calls.fetchOrderBook.push(args);
+			return options.fetchOrderBookResult;
+		};
+	}
 	return { exchange: exchange as Exchange, calls };
 }
 

--- a/test/order-telemetry.test.ts
+++ b/test/order-telemetry.test.ts
@@ -228,6 +228,93 @@ describe("order execution telemetry RPC harness", () => {
 		).toBe(21);
 	});
 
+	test("forwards and archives a top-level create-order client id", async () => {
+		const metrics = new CapturingOtelMetrics();
+		const forwarder = await startForwarderServer();
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: forwarder.url,
+			deadLetterPath: join(archiveTestDirectory, "client-order-id-loss.jsonl"),
+			deploymentId: "order-test",
+			batchSize: 100,
+			flushIntervalMs: 60_000,
+		});
+		const { exchange, calls } = createOrderExchangeFixture({
+			createOrderResult: {
+				id: "order-with-client-id",
+				symbol: "ARB/USDT",
+				side: "sell",
+				type: "limit",
+				status: "open",
+				amount: 10,
+				filled: 0,
+				remaining: 10,
+			},
+			fetchOrderBookResult: {
+				bids: [[2.09, 100]],
+				asks: [[2.1, 100]],
+				timestamp: 1_788_000_000_000,
+			},
+		});
+		server = getServer(
+			testPolicy,
+			createBinancePool(exchange),
+			["*"],
+			false,
+			"",
+			metrics.asOtelMetrics(),
+			archiver,
+		);
+		try {
+			client = createClient(await bindServer(server));
+
+			await executeAction(client, {
+				action: Action.CreateOrder,
+				cex: "binance",
+				payload: {
+					orderType: "limit",
+					amount: "10",
+					fromToken: "ARB",
+					toToken: "USDT",
+					price: "2.1",
+					clientOrderId: "caller-order-1",
+					params: JSON.stringify({
+						clientOrderId: "params-order-id",
+						idempotencyKey: "idem-1",
+					}),
+				},
+			});
+
+			expect(calls.createOrder).toHaveLength(1);
+			expect(calls.createOrder[0]?.[5]).toEqual({
+				clientOrderId: "caller-order-1",
+				idempotencyKey: "idem-1",
+			});
+
+			await Promise.resolve();
+			await archiver.flush();
+			const archivedRows = forwarder.requests.flatMap(
+				(request) => request.body.rows ?? [],
+			) as Array<{ table?: string; row: Record<string, unknown> }>;
+			const archivedOrder = archivedRows.find(
+				(entry) => entry.table === "broker_execution.order_events",
+			);
+			const archivedMarketSnapshot = archivedRows.find(
+				(entry) => entry.table === "broker_execution.market_metadata_snapshots",
+			);
+
+			expect(archivedOrder?.row.client_order_id).toBe("caller-order-1");
+			expect(JSON.parse(String(archivedOrder?.row.payload_json))).toMatchObject(
+				{ clientOrderId: "caller-order-1" },
+			);
+			expect(archivedMarketSnapshot?.row.client_order_id).toBe(
+				"caller-order-1",
+			);
+		} finally {
+			await archiver.close();
+			await forwarder.close();
+		}
+	});
+
 	test("handles create-order success without fee fields", async () => {
 		const metrics = new CapturingOtelMetrics();
 		const { exchange } = createOrderExchangeFixture({
@@ -407,6 +494,7 @@ describe("order execution telemetry RPC harness", () => {
 						fromToken: "ARB",
 						toToken: "USDT",
 						price: "2",
+						clientOrderId: "failed-client-order-1",
 					},
 				}),
 			).rejects.toMatchObject({
@@ -434,6 +522,7 @@ describe("order execution telemetry RPC harness", () => {
 						entry.table === "broker_execution.order_events",
 				) as { row: Record<string, unknown> } | undefined;
 			expect(archivedOrder?.row.status).toBe("failed");
+			expect(archivedOrder?.row.client_order_id).toBe("failed-client-order-1");
 			expect(archivedOrder?.row.error_message).toContain(
 				"ExchangeOrderRejected [code=-2010]: exchange rejected order",
 			);


### PR DESCRIPTION
## Problem

The typed \`CreateOrder\` gRPC path silently discards the caller's client order id. Callers send \`clientOrderId\` as a top-level payload field, but \`CreateOrderPayloadSchema\` did not declare it, so zod stripped it and \`broker.createOrder\` was invoked with only \`params\` — the venue never received the id and assigned its own.

Production evidence: every populated \`broker_execution.order_events.client_order_id\` on typed-path CreateOrder rows is a ccxt-autogenerated \`x-TKT…\` id (zero caller-supplied ids), and all \`market_metadata_snapshots\` id columns are NULL, because the telemetry/archive id extraction reads the same empty \`params\`.

Consequences: no venue-side duplicate protection for these orders (the caller's idempotent client id never reaches the exchange), later resolve-by-client-id lookups query an id the venue never saw, and request-side correlation ids never archive.

## Change

- \`CreateOrderPayloadSchema\`: accept optional non-empty \`clientOrderId\`.
- \`handleCreateOrder\`: build one immutable merged params object (\`params\` + top-level \`clientOrderId\`, top-level field wins) and use it for the ccxt \`createOrder\` call and for every telemetry/archive id extraction in the handler (success path, failure path, market-metadata snapshot).

The ccxt \`Call\` passthrough path already delivers \`clientOrderId\` via params on this venue (accepted and echoed), so the delivery mechanism is proven; this closes the gap on the typed path only.

## Testing

- New harness test: venue \`createOrder\` receives the caller id in its params (including precedence over a conflicting \`params\` key), and both \`order_events\` and \`market_metadata_snapshots\` archive rows carry it; failure-path archiving asserted too.
- \`bun test\`: 462 passed, 0 failed. \`bun run build:ts\`, \`bun run lint\`, \`bun run check\`: pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Create Order requests now support an optional client-provided order ID.
  - Client order IDs are forwarded during order execution and preserved in order and market activity records.

- **Bug Fixes**
  - Failed order records now retain the client-provided order ID while maintaining existing error behavior.

- **Tests**
  - Added coverage for successful and failed orders, including forwarding and record persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->