### PR TITLE
Release cex-broker 0.2.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.29",
+	"version": "0.2.30",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Bumps \`@usherlabs/cex-broker\` to 0.2.30.

Changes since 0.2.29:

- Forward caller \`clientOrderId\` on the typed CreateOrder path (#79) — the venue now receives the caller's client order id (duplicate protection + resolve-by-client-id), and request-side correlation ids populate in the execution archive.

After merge: tag the merge commit \`v0.2.30\` to trigger the npm + image publish.