### PR TITLE
Link failed typed create orders to their market snapshot

### DIFF
--- a/src/handlers/execute-action/orders.ts
+++ b/src/handlers/execute-action/orders.ts
@@ -58,6 +58,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 		side?: string;
 		requestedQuantity?: number;
 	} = {};
+	let marketMetadataHash: string | undefined;
 	try {
 		if (!broker) {
 			return ctx.wrappedCallback(
@@ -104,7 +105,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 		}
 		const telemetryIds = extractOrderTelemetryIds(createOrderParams);
 		const submissionTimestamp = new Date().toISOString();
-		const marketMetadataHash = await captureMarketMetadataSnapshot(
+		marketMetadataHash = await captureMarketMetadataSnapshot(
 			brokerArchiver,
 			broker,
 			{
@@ -175,6 +176,7 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 			failedCreateContext,
 			undefined,
 			error,
+			{ marketMetadataHash },
 		);
 		ctx.wrappedCallback(
 			{

--- a/test/order-telemetry.test.ts
+++ b/test/order-telemetry.test.ts
@@ -741,6 +741,10 @@ describe("order execution telemetry RPC harness", () => {
 		const errorLog = spyOn(log, "error").mockImplementation(() => {});
 		const { exchange } = createOrderExchangeFixture({
 			createOrderError: new ExchangeOrderRejected(exchangeMessage),
+			fetchOrderBookResult: {
+				bids: [[1.99, 100]],
+				asks: [[2.0, 100]],
+			},
 		});
 		server = getServer(
 			testPolicy,
@@ -785,14 +789,23 @@ describe("order execution telemetry RPC harness", () => {
 
 			await Promise.resolve();
 			await archiver.flush();
-			const archivedOrder = forwarder.requests
-				.flatMap((request) => request.body.rows ?? [])
-				.find(
-					(entry: { table?: string }) =>
-						entry.table === "broker_execution.order_events",
-				) as { row: Record<string, unknown> } | undefined;
+			const archivedRows = forwarder.requests.flatMap(
+				(request) => request.body.rows ?? [],
+			) as Array<{ table?: string; row: Record<string, unknown> }>;
+			const archivedOrder = archivedRows.find(
+				(entry) => entry.table === "broker_execution.order_events",
+			);
+			const archivedMarketSnapshot = archivedRows.find(
+				(entry) => entry.table === "broker_execution.market_metadata_snapshots",
+			);
 			expect(archivedOrder?.row.status).toBe("failed");
 			expect(archivedOrder?.row.client_order_id).toBe("failed-client-order-1");
+			expect(archivedMarketSnapshot?.row.client_order_id).toBe(
+				"failed-client-order-1",
+			);
+			expect(archivedOrder?.row.market_metadata_hash).toBe(
+				archivedMarketSnapshot?.row.market_metadata_hash,
+			);
 			expect(archivedOrder?.row.error_message).toContain(
 				"ExchangeOrderRejected [code=-2010]: exchange rejected order",
 			);


### PR DESCRIPTION
## Problem

The typed CreateOrder path captures a market-metadata snapshot before submitting the order, but its failure branch archived the failed `order_events` row without `{ marketMetadataHash }`, so failed typed orders had no link to the market snapshot taken at submission time. The passthrough create-order path received this linkage in #81; this applies the same fix to the typed path.

## Change

- `marketMetadataHash` is hoisted out of the `try` block in `handleCreateOrder` so the catch branch can see it, and the failure-path `archiveOrderExecutionInBackground` call now forwards `{ marketMetadataHash }`, matching the success path.
- The failed-order test now stubs an order book (so a snapshot is actually captured in that scenario) and asserts the failed order row's `market_metadata_hash` matches the snapshot row's, mirroring the success-path linkage assertions.

No behavior change to order submission, responses, or error propagation — archive emission remains background-only.

## Verification

- `bun test test/order-telemetry.test.ts`: 11 pass, 0 fail (51 expects). The new assertion fails without the handler change (verified: the failed row previously archived with no snapshot link).
- Full `bun test` via commit hook: 465 pass, 0 fail
- `bunx tsc --noEmit` exit 0; biome lint warnings unchanged from base (pre-existing)