### PR TITLE
chore(release): bump cex-broker to 0.2.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.30",
+	"version": "0.2.31",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Release 0.2.31.

Includes since 0.2.30:
- #81 — CreateOrder archive/telemetry emission for `createOrder` Call passthrough orders (submission-time `order_events` rows with the caller's client id, market-metadata snapshots, failed-order emission)
- #82 — failed typed create orders now link to their market snapshot via `market_metadata_hash`

After merge, tagging `v0.2.31` triggers the npm + GHCR publish workflow.