### PR TITLE
Archive the caller withdrawal id on transfer submissions

### DIFF
--- a/schema/clickhouse/broker_execution.sql
+++ b/schema/clickhouse/broker_execution.sql
@@ -112,6 +112,16 @@ ENGINE = MergeTree
 PARTITION BY toDate(broker_observed_timestamp)
 ORDER BY (account_selector, broker_observed_timestamp, exchange, symbol, event_kind, lifecycle_action);
 
+-- CREATE TABLE IF NOT EXISTS is a no-op on an already-populated table, so an
+-- added column reaches fresh deployments only. Inserts name every column, so a
+-- broker emitting client_withdrawal_id against a table that lacks it fails the
+-- insert and the batch is dropped with a counter — silent loss in the ledger
+-- that proves where money went. This runs on forwarder startup ahead of serving
+-- and fail-closes (services/archive-forwarder/index.ts), so the column cannot
+-- be missing while rows are accepted.
+ALTER TABLE broker_execution.transfer_events
+ADD COLUMN IF NOT EXISTS client_withdrawal_id String DEFAULT '' AFTER external_id;
+
 -- Per-fill execution facts from the venue trade-history endpoint (fetchMyTrades),
 -- captured by the broker-internal fill poller. GetOrderDetails/createOrder payloads
 -- carry no per-trade breakdown and no fee on most venues, so per-fill truth

--- a/schema/clickhouse/broker_execution.sql
+++ b/schema/clickhouse/broker_execution.sql
@@ -71,8 +71,9 @@ ORDER BY (exchange, symbol, broker_observed_timestamp);
 -- (docs/CEX_EXECUTION_ARCHIVE_CONTRACT.md): MergeTree, DateTime64(3,'UTC')
 -- timestamps, string quantities, result_index UInt32, error_summary. The contract
 -- does not constrain retention; like every table in this file these are execution
--- audit facts (the venue cash-flow ledger) and must not expire, so no TTL. Two
--- ADDITIVE columns not in the consumer contract: fee_amount / fee_currency (the
+-- audit facts (the venue cash-flow ledger) and must not expire, so no TTL. Three
+-- ADDITIVE columns not in the consumer contract: client_withdrawal_id (the
+-- caller's request-side withdrawal identity) and fee_amount / fee_currency (the
 -- ccxt withdrawal object exposes the fee, the dominant small-commit cost).
 -- broker_observed_timestamp is emitted as an ISO-8601 UTC string and parsed on
 -- insert via the forwarder's date_time_input_format=best_effort (see
@@ -98,6 +99,7 @@ CREATE TABLE IF NOT EXISTS broker_execution.transfer_events
     address String DEFAULT '',
     network LowCardinality(String) DEFAULT '',
     external_id String DEFAULT '',
+    client_withdrawal_id String DEFAULT '',
     txid String DEFAULT '',
     result_index UInt32 DEFAULT 0,
     fee_amount String DEFAULT '',

--- a/src/handlers/execute-action/withdraw.ts
+++ b/src/handlers/execute-action/withdraw.ts
@@ -108,6 +108,12 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 		);
 	}
 
+	const withdrawOrderId = transferValue.params.withdrawOrderId;
+	const clientWithdrawalId =
+		typeof withdrawOrderId === "string" && withdrawOrderId.length > 0
+			? withdrawOrderId
+			: undefined;
+
 	try {
 		const transaction =
 			travelRule.mode === "localentity"
@@ -145,6 +151,7 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 				address: normalized.address ?? transferValue.recipientAddress,
 				network: normalized.network ?? withdrawNetwork.exchangeNetworkId,
 				externalId: normalized.externalId,
+				clientWithdrawalId,
 				txid: normalized.txid,
 				feeAmount: normalized.feeAmount,
 				feeCurrency: normalized.feeCurrency,
@@ -176,6 +183,7 @@ export async function handleWithdraw(ctx: ExecuteActionContext): Promise<void> {
 				amount: String(transferValue.amount),
 				address: transferValue.recipientAddress,
 				network: withdrawNetwork.exchangeNetworkId,
+				clientWithdrawalId,
 				errorSummary: getErrorMessage(error),
 				payload: { recipientAddress: transferValue.recipientAddress },
 			},

--- a/src/helpers/broker-execution-archive/rows.ts
+++ b/src/helpers/broker-execution-archive/rows.ts
@@ -359,9 +359,10 @@ export function buildSubscribeStreamArchiveRow(input: {
 // tags + contract columns, all quantities/prices as strings (venue precision
 // varies by asset), fill_index/result_index as numbers (UInt32 columns). Two
 // deliberate ADDITIVE divergences the consumer contract doesn't yet list:
-// transfer_events carries fee_amount/fee_currency (the ccxt withdrawal object
-// exposes the fee, which is the dominant small-commit cost), and fill_events.event_kind
-// is stamped with the true trade-history-poller source rather than "create_order_fill".
+// transfer_events carries client_withdrawal_id plus fee_amount/fee_currency (the
+// ccxt withdrawal object exposes the fee, which is the dominant small-commit
+// cost), and fill_events.event_kind is stamped with the true trade-history-poller
+// source rather than "create_order_fill".
 
 // Preserve venue precision: prefer the raw string the venue returned (usually in
 // `info`) over ccxt's parsed number, stringifying a number only as a fallback.
@@ -377,6 +378,7 @@ export type TransferArchiveFields = {
 	address?: string;
 	network?: string;
 	externalId?: string;
+	clientWithdrawalId?: string;
 	txid?: string;
 	resultIndex?: number;
 	feeAmount?: string;
@@ -387,8 +389,9 @@ export type TransferArchiveFields = {
 };
 
 // asset_symbol mirrors the shared `symbol` tag for transfers (the moved asset,
-// e.g. "USDC"), per the contract. event_kind/lifecycle_action/external_id are the
-// primary read keys; they are always emitted (external_id/status default to "").
+// e.g. "USDC"), per the contract. event_kind/lifecycle_action and the two
+// withdrawal identities are primary read keys; they are always emitted
+// (external_id/client_withdrawal_id/status default to "").
 export function buildTransferEventArchiveRow(input: {
 	tags: BrokerArchiveCommonTags;
 	transfer: TransferArchiveFields;
@@ -407,6 +410,7 @@ export function buildTransferEventArchiveRow(input: {
 			address: transfer.address,
 			network: transfer.network,
 			external_id: transfer.externalId ?? "",
+			client_withdrawal_id: transfer.clientWithdrawalId ?? "",
 			txid: transfer.txid,
 			result_index: transfer.resultIndex ?? 0,
 			// Additive (not in the consumer contract's transfer_events column set).

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -11,7 +11,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LogRecord } from "@opentelemetry/api-logs";
+import type { Exchange } from "@usherlabs/ccxt";
 import { MAX_ARCHIVE_BODY_BYTES } from "../services/archive-forwarder/limits";
+import type { ExecuteActionContext } from "../src/handlers/execute-action/context";
+import { handleWithdraw } from "../src/handlers/execute-action/withdraw";
 import {
 	redactSecretLiterals,
 	redactStreamPayload,
@@ -402,6 +405,7 @@ describe("broker execution archive rows", () => {
 				address: "0xdead",
 				network: "ARBITRUM",
 				externalId: "wd-1",
+				clientWithdrawalId: "lane-withdrawal-1",
 				txid: "0xabc",
 				feeAmount: "4.89",
 				feeCurrency: "USDC",
@@ -424,6 +428,7 @@ describe("broker execution archive rows", () => {
 			status: "ok",
 			amount: "100",
 			external_id: "wd-1",
+			client_withdrawal_id: "lane-withdrawal-1",
 			result_index: 0,
 			// Additive columns (ccxt exposes the withdrawal fee).
 			fee_amount: "4.89",
@@ -445,6 +450,7 @@ describe("broker execution archive rows", () => {
 			},
 		});
 		expect(row.row.external_id).toBe("");
+		expect(row.row.client_withdrawal_id).toBe("");
 		expect(row.row.status).toBe("");
 		expect(row.row.result_index).toBe(0);
 		expect(row.row.event_kind).toBe("deposit");
@@ -747,6 +753,110 @@ describe("withdrawal observation tracker", () => {
 			expect(tracker.getSize()).toBe(
 				DEFAULT_WITHDRAWAL_OBSERVATION_TRACKER_MAX_ENTRIES,
 			);
+		}
+	});
+});
+
+describe("withdraw submission archive", () => {
+	test("carries valid caller ids on successful and failed submissions without deriving invalid ids", async () => {
+		const forwarder = await startForwarderServer();
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: forwarder.url,
+			deadLetterPath: createDeadLetterPath(),
+			deploymentId: "test-deploy",
+			batchSize: 100,
+			flushIntervalMs: 60_000,
+		});
+		const broker = {
+			has: { fetchCurrencies: false },
+			currencies: {
+				USDC: {
+					networks: {
+						BSC: { id: "BSC", network: "BSC" },
+					},
+				},
+			},
+			withdraw: async (
+				_code: string,
+				_amount: number,
+				_address: string,
+				_tag: undefined,
+				params: Record<string, unknown>,
+			) => {
+				if (params.withdrawOrderId === "failed-lane") {
+					throw new Error("venue rejected withdrawal");
+				}
+				return { id: "venue-withdrawal-id" };
+			},
+		} as unknown as Exchange;
+
+		const context = (withdrawOrderId: string | number) =>
+			({
+				call: {
+					request: {
+						payload: {
+							recipientAddress: "0xrecipient",
+							amount: "10",
+							chain: "BNB",
+							params: JSON.stringify({ withdrawOrderId }),
+						},
+					},
+				},
+				wrappedCallback: () => {},
+				policy: {
+					withdraw: {
+						rule: [
+							{
+								exchange: "BINANCE",
+								network: "BNB",
+								whitelist: ["0xrecipient"],
+								coins: ["USDC"],
+							},
+						],
+					},
+					deposit: {},
+					order: { rule: { markets: [], limits: [] } },
+				},
+				brokers: {},
+				metadata: {},
+				normalizedCex: "binance",
+				cex: "binance",
+				symbol: "USDC",
+				selectedBrokerAccount: { exchange: broker, label: "primary" },
+				broker,
+				verity: { proof: "" },
+				applyVerityToBroker: () => {},
+				useVerity: false,
+				verityProverUrl: "",
+				brokerArchiver: archiver,
+			}) as unknown as ExecuteActionContext;
+
+		try {
+			await handleWithdraw(context("successful-lane"));
+			await handleWithdraw(context("failed-lane"));
+			await handleWithdraw(context(123));
+			await Promise.resolve();
+			await archiver.flush();
+
+			const rows = forwarder.requests.flatMap(
+				(request) => request.body.rows ?? [],
+			) as Array<{ row: Record<string, unknown> }>;
+			expect(rows).toHaveLength(3);
+			expect(rows[0]?.row).toMatchObject({
+				external_id: "venue-withdrawal-id",
+				client_withdrawal_id: "successful-lane",
+				status: "",
+			});
+			expect(rows[1]?.row).toMatchObject({
+				external_id: "",
+				client_withdrawal_id: "failed-lane",
+				status: "failed",
+				error_summary: "venue rejected withdrawal",
+			});
+			expect(rows[2]?.row.client_withdrawal_id).toBe("");
+		} finally {
+			await archiver.close();
+			await forwarder.close();
 		}
 	});
 });


### PR DESCRIPTION
## Problem

`broker_execution.transfer_events` carries no key tying a withdrawal **submission** back to the caller's request. `external_id` is populated only from the venue response and is empty on rejected submissions and on responses that carry no id; `payload_json` holds only the venue response object. Consumers therefore cannot prove a submission belongs to a specific caller-side movement, and must fall back to window + account + asset matching.

The caller already sends a stable per-withdrawal key as `params.withdrawOrderId`. `handleWithdraw` spreads that into the venue call, then drops it when building the archive row.

## Change

Add a first-class `client_withdrawal_id` column to `transfer_events` and populate it from that request-side key on **both** the success and the failure submit paths — the failure path is where the caller most needs to identify its own attempt, and it is exactly where `external_id` is always empty.

- `schema/clickhouse/broker_execution.sql` — new `client_withdrawal_id String DEFAULT ''` beside `external_id`. High-cardinality by nature, so deliberately not `LowCardinality`.
- `src/helpers/broker-execution-archive/rows.ts` — new optional field on `TransferArchiveFields`, emitted with an empty-string default.
- `src/handlers/execute-action/withdraw.ts` — read once before the venue call so both archive paths share it.

## Invariants

- `external_id` keeps its meaning (venue-owned withdrawal id). Withdrawal *observation* rows rely on that to correlate with submissions, so the caller-owned identity is a separate column rather than an overload.
- The value is never derived or synthesized. A missing, empty, or non-string key emits the empty-string default — no fallback to amount, address, timestamp, or a generated id, because a wrong attribution is worse than an absent one.
- Observations and deposits have no caller-side request and keep the default.
- Archiving stays best-effort and does not affect the withdraw call's own success/error path.

## Verification

`bun test` — 466 pass, 0 fail (466 tests across 40 files).
`bun test test/broker-execution-archive.test.ts` — 40 pass, 0 fail.
`bun run build:ts` — clean.

The new test drives the real `handleWithdraw` through the archiver into a stub forwarder and asserts three cases: successful submission (venue id and caller id both present), venue-rejected submission (empty `external_id`, caller id still present, `error_summary` set), and a non-string key landing as `""`.

## Migration

`CREATE TABLE IF NOT EXISTS` is a no-op on a populated table, so the new column
would otherwise reach fresh deployments only. Inserts name every column, so a
broker emitting `client_withdrawal_id` against a table still on the old layout
fails the insert and the batch is dropped with a counter — silent loss in the
ledger that proves where money went.

The schema file therefore carries an idempotent
`ALTER TABLE ... ADD COLUMN IF NOT EXISTS ... AFTER external_id` beside the table
definition, matching the existing convention in `strategy_data.sql`. The
forwarder applies schema on startup ahead of serving and exits non-zero when it
cannot, so the column cannot be missing while rows are being accepted, and no
manual production step has to be remembered.

The forwarder still needs no code change — it passes rows through as
`JSONEachRow` — but it must start with this schema before a broker carrying the
change emits, which the existing joint-release practice already covers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Withdrawal transfer records now store the originating client withdrawal identifier when provided.
  * Archive entries include this identifier for both successful and failed withdrawal submissions (defaulting to an empty value when not present).
* **Bug Fixes**
  * Improved traceability by aligning withdrawal requests with archived transfer history fields.
* **Tests**
  * Added coverage to verify identifier propagation and correct defaulting/handling across success, failure, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
