### PR TITLE
chore(release): bump cex-broker to 0.2.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.31",
+	"version": "0.2.32",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Version bump only. Nothing is published by merging this — the `Publish` workflow triggers on a pushed `v*` tag, so the release happens when `v0.2.32` is tagged after this lands.

## What 0.2.32 contains

One change, #84 — the transfer archive now carries `client_withdrawal_id`, the caller's request-side withdrawal key, on submission rows.

`git log v0.2.31..develop` is exactly that PR and its two commits; there is no other unreleased work in this version.

## Why it matters to consumers

`broker_execution.transfer_events` previously had no key tying a withdrawal submission back to the caller's request: `external_id` is venue-owned and empty on rejected submissions and on responses carrying no id. Consumers had to fall back to window + account + asset matching. `client_withdrawal_id` is the caller-owned identity, populated on both the success and failure submit paths.

## Upgrade note

The schema file carries an idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, applied by the archive forwarder on startup, so no manual migration is needed. The forwarder must start on the new schema before a broker carrying this version emits — it exits non-zero if it cannot apply schema, so a forwarder-first or joint release is self-enforcing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.2.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->