### PR TITLE
Release cex-broker 0.2.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.33",
+	"version": "0.2.34",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Version bump to 0.2.34. Ships the per-run seq column on the five strategy_data tables (#89) so archive gap detection can go live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.2.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->