### PR TITLE
fix(orders): preserve venue error codes for passive submissions

### DIFF
--- a/src/handlers/execute-action/orders.ts
+++ b/src/handlers/execute-action/orders.ts
@@ -209,9 +209,9 @@ async function handleCreateOrder(ctx: ExecuteActionContext): Promise<void> {
 			{ marketMetadataHash },
 		);
 		if (isPassiveOrder && submission === "in_flight") {
-			const passiveErrorCode = classifyPassiveOrderError(error);
+			const stableErrorCode = classifyPassiveOrderError(error);
 			return rejectWithGrpcError(ctx, error, {
-				message: `${passiveErrorCode}: ${sanitizeErrorDetail(error)}`,
+				message: `${stableErrorCode}: ${sanitizeErrorDetail(error)}`,
 				preferStableMessageOnly: true,
 			});
 		}

--- a/src/helpers/grpc/status.ts
+++ b/src/helpers/grpc/status.ts
@@ -3,6 +3,12 @@ import ccxt from "@usherlabs/ccxt";
 import { getErrorMessage } from "../shared/errors";
 
 export function stableGrpcErrorCode(message: string): grpc.status | undefined {
+	if (message.startsWith("AuthenticationError:")) {
+		return grpc.status.UNAUTHENTICATED;
+	}
+	if (message.startsWith("InsufficientFunds:")) {
+		return grpc.status.FAILED_PRECONDITION;
+	}
 	if (message.startsWith("venue_discovery_unavailable:")) {
 		return grpc.status.UNIMPLEMENTED;
 	}

--- a/src/helpers/passive-order.ts
+++ b/src/helpers/passive-order.ts
@@ -46,9 +46,16 @@ function identifiesUnsupported(message: string): boolean {
 export function classifyPassiveOrderError(
 	error: unknown,
 ): PassiveOrderSubmissionErrorCode {
+	// A passive_* code tells the client the venue refused to REST the order for a
+	// post-only reason, so the rung may be re-placed at a new price. Balance and
+	// credential faults fail that promise: re-placing repeats them verbatim, and
+	// labelling them passive turns a shortfall into an unbounded repost loop.
+	// Both carry a typed ccxt class, so classify them before the post-only checks
+	// and report their own stable code — never the passive catch-all below.
 	if (error instanceof ccxt.InsufficientFunds) {
 		return "InsufficientFunds";
 	}
+	// PermissionDenied extends AuthenticationError, so this covers both.
 	if (error instanceof ccxt.AuthenticationError) {
 		return "AuthenticationError";
 	}

--- a/src/helpers/passive-order.ts
+++ b/src/helpers/passive-order.ts
@@ -10,6 +10,11 @@ export const PASSIVE_ORDER_ERROR_CODES = {
 export type PassiveOrderErrorCode =
 	(typeof PASSIVE_ORDER_ERROR_CODES)[keyof typeof PASSIVE_ORDER_ERROR_CODES];
 
+export type PassiveOrderSubmissionErrorCode =
+	| PassiveOrderErrorCode
+	| "AuthenticationError"
+	| "InsufficientFunds";
+
 function identifiesWouldCross(message: string): boolean {
 	const normalized = message.toLowerCase();
 	// Post-only venues reject a crossing limit instead of resting it. Binance
@@ -40,7 +45,13 @@ function identifiesUnsupported(message: string): boolean {
 
 export function classifyPassiveOrderError(
 	error: unknown,
-): PassiveOrderErrorCode {
+): PassiveOrderSubmissionErrorCode {
+	if (error instanceof ccxt.InsufficientFunds) {
+		return "InsufficientFunds";
+	}
+	if (error instanceof ccxt.AuthenticationError) {
+		return "AuthenticationError";
+	}
 	const message = getErrorMessage(error);
 	if (
 		error instanceof ccxt.OrderImmediatelyFillable ||

--- a/test/grpc-status.test.ts
+++ b/test/grpc-status.test.ts
@@ -9,6 +9,12 @@ import {
 
 describe("grpc status", () => {
 	test("stableGrpcErrorCode maps known prefixes", () => {
+		expect(stableGrpcErrorCode("AuthenticationError: x")).toBe(
+			grpc.status.UNAUTHENTICATED,
+		);
+		expect(stableGrpcErrorCode("InsufficientFunds: x")).toBe(
+			grpc.status.FAILED_PRECONDITION,
+		);
 		expect(stableGrpcErrorCode("venue_discovery_unavailable: x")).toBe(
 			grpc.status.UNIMPLEMENTED,
 		);

--- a/test/passive-order.test.ts
+++ b/test/passive-order.test.ts
@@ -203,6 +203,43 @@ describe("passive CreateOrder", () => {
 		);
 	});
 
+	test("preserves insufficient funds as the stable error code", async () => {
+		const fixture = createFixture(
+			new ccxt.InsufficientFunds("binance account has insufficient balance"),
+		);
+		fixture.ctx.call.request.payload = createOrderPayload({
+			orderIntent: "passive_only",
+		});
+
+		await handleOrders(fixture.ctx);
+
+		expect(fixture.getError()?.code).toBe(grpc.status.FAILED_PRECONDITION);
+		expect(fixture.getError()?.message).toStartWith("InsufficientFunds:");
+		expect(fixture.getError()?.message).not.toStartWith("passive_");
+	});
+
+	test.each([
+		[
+			"authentication failure",
+			new ccxt.AuthenticationError("binance invalid api key"),
+		],
+		[
+			"permission failure",
+			new ccxt.PermissionDenied("binance key cannot create orders"),
+		],
+	])("preserves %s as the authentication stable error code", async (_, error) => {
+		const fixture = createFixture(error);
+		fixture.ctx.call.request.payload = createOrderPayload({
+			orderIntent: "passive_only",
+		});
+
+		await handleOrders(fixture.ctx);
+
+		expect(fixture.getError()?.code).toBe(grpc.status.UNAUTHENTICATED);
+		expect(fixture.getError()?.message).toStartWith("AuthenticationError:");
+		expect(fixture.getError()?.message).not.toStartWith("passive_");
+	});
+
 	test("maps any other passive venue rejection to rejected", async () => {
 		const fixture = createFixture(
 			new ccxt.InvalidOrder("binance passive order rejected: invalid price"),
@@ -219,8 +256,9 @@ describe("passive CreateOrder", () => {
 
 	test("does not classify a pre-submission failure as a passive venue rejection", async () => {
 		const fixture = createFixture();
-		(fixture.ctx.broker as unknown as { loadMarkets: () => Promise<void> })
-			.loadMarkets = async () => {
+		(
+			fixture.ctx.broker as unknown as { loadMarkets: () => Promise<void> }
+		).loadMarkets = async () => {
 			throw new Error("market resolution unavailable");
 		};
 		fixture.ctx.call.request.payload = createOrderPayload({


### PR DESCRIPTION
## Problem

`passive_order_rejected` is the code that tells a client "the venue refused to rest this order for a post-only reason" — which is the client's cue that the price level may be re-placed. `classifyPassiveOrderError` was an allowlist for two post-only faults (would-cross, post-only-unsupported) with a catch-all that assigned `passive_order_rejected` to *everything else* that failed during a passive submission.

`ccxt` raises `InsufficientFunds` from the submission call itself, so a plain balance shortfall was reported as a post-only rejection. The client then re-placed the rung, which failed identically, on repeat. In production this ran at 800–1500 failed venue submissions per hour across two markets for as long as the account was short of quote currency — no incorrect exposure (it fails closed), but wasted venue order-rate budget and heavy log/archive noise.

## Change

Balance and credential faults on the passive create path now report their own stable error codes instead of a `passive_*` code:

- `ccxt.InsufficientFunds` → `InsufficientFunds:` (`FAILED_PRECONDITION`)
- `ccxt.AuthenticationError` → `AuthenticationError:` (`UNAUTHENTICATED`); `PermissionDenied` subclasses it, so one check covers both

Both are already established codes in the shared error vocabulary, and the existing convention is that the stable code leads the message — which matters, because clients recover the error kind by reading the leading token. Routing these through the generic `Order Creation failed: …` fallback would not work: that message leads with `Order`, which classifies as unknown, and returns `INTERNAL` for what is a precondition failure.

Detection is by typed `ccxt` class, not message text. The text heuristics remain only for would-cross and post-only-unsupported, where some venues report without a distinct class. The new checks precede those, which is safe: the class hierarchies are disjoint (verified against the `ccxt` prototype chain).

The classification decision stays in one place — the handler emits whatever code the classifier returns.

## Not changed

The `submission` state gate (`not_attempted`/`in_flight`/`placed`), the would-cross and unsupported heuristics, telemetry/archive emission, and the generic fallback are all untouched. No retry, backoff, or balance pre-check is added: the broker reports what the venue said, and the client decides what to do about it.

## Verification

```
bun test test/passive-order.test.ts        13 pass, 0 fail
bun test test/grpc-status.test.ts test/order-error-detail.test.ts    5 pass, 0 fail
bun test                                   480 pass, 0 fail
bunx tsc --noEmit                          clean
bunx biome check src test                  no errors
```

New coverage: a balance fault yields an `InsufficientFunds:`-leading message with no `passive_` prefix; authentication and permission faults yield `AuthenticationError:`; existing would-cross / unsupported / generic-rejection classifications and the pre-submission and post-submission `submission`-state behavior are unchanged.

## Release ordering

The consuming client needs a companion change to treat a venue balance fault as terminal rather than retryable. Without it, the client's stock retry path makes a bounded burst of doomed submissions instead of an unbounded loop — an improvement, but the two should ship together for the intended single-attempt behavior.


Companion client-side change: usherlabs/fiet-maker#965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passive order error reporting for authentication failures and insufficient-funds errors.
  * Preserved stable error types instead of labeling these issues as generic passive-order rejections.
  * Corrected gRPC status mappings for authentication and insufficient-funds failures.
  * Maintained existing handling for post-only, unsupported, and other rejected-order errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->