### PR TITLE
Capture venue deposits in the execution archive

### DIFF
--- a/src/handlers/execute-action/deposit.ts
+++ b/src/handlers/execute-action/deposit.ts
@@ -1,6 +1,9 @@
 import * as grpc from "@grpc/grpc-js";
 import ccxt from "@usherlabs/ccxt";
-import { archiveTransferEventInBackground } from "../../helpers/broker-execution-archive";
+import {
+	archiveTransferEventInBackground,
+	normalizeCcxtTransactionForArchive,
+} from "../../helpers/broker-execution-archive";
 import {
 	depositField,
 	depositMatchesTransaction,
@@ -121,9 +124,13 @@ export async function handleDeposit(ctx: ExecuteActionContext): Promise<void> {
 					null,
 				);
 			}
-			const status = normalizeDepositStatus(
+			const responseStatus = normalizeDepositStatus(
 				depositField(deposit, ["status", "state"]),
 			);
+			// The RPC contract uses deposit lifecycle statuses such as "credited";
+			// transfer_events retains ccxt's raw lowercased vocabulary such as "ok"
+			// because accounting consumers query that archive contract directly.
+			const archiveStatus = normalizeCcxtTransactionForArchive(deposit).status;
 			const depositTxid = String(
 				depositField(deposit, ["txid", "txId", "tx_hash", "txHash"]) ??
 					value.transactionHash,
@@ -146,7 +153,7 @@ export async function handleDeposit(ctx: ExecuteActionContext): Promise<void> {
 				transfer: {
 					eventKind: "deposit",
 					lifecycleAction: "observe_deposit",
-					status,
+					status: archiveStatus,
 					amount:
 						observedAmount !== undefined ? String(observedAmount) : undefined,
 					address: String(observedAddress ?? value.recipientAddress),
@@ -164,7 +171,7 @@ export async function handleDeposit(ctx: ExecuteActionContext): Promise<void> {
 			return ctx.wrappedCallback(null, {
 				proof: ctx.verity.proof,
 				result: JSON.stringify({
-					status,
+					status: responseStatus,
 					exchange: normalizedCex,
 					accountSelector: selectedBrokerAccount?.label,
 					asset: symbol,

--- a/src/helpers/deposit-archive-poller.ts
+++ b/src/helpers/deposit-archive-poller.ts
@@ -1,0 +1,305 @@
+import type { BrokerAccount, BrokerPoolEntry } from "./broker";
+import {
+	type BrokerExecutionArchiver,
+	buildCommonArchiveTags,
+	buildTransferEventArchiveRow,
+	rethrowArchiveDurabilityError,
+} from "./broker-execution-archive";
+import { depositField, normalizeDepositStatus } from "./deposit";
+import { log } from "./logger";
+import type { OtelMetrics } from "./otel";
+import { asRecord } from "./shared/guards";
+
+// ccxt method surface used by the poller (typed defensively — not every exchange
+// build exposes fetchDeposits).
+type ExchangeWithDeposits = {
+	fetchDeposits?: (
+		code?: string,
+		since?: number,
+		limit?: number,
+		params?: Record<string, unknown>,
+	) => Promise<unknown[]>;
+	has?: Record<string, unknown>;
+};
+
+export type DepositArchivePollerConfig = {
+	// Constant defaults (no env vars): every broker env var must be allowlisted in a
+	// Gramine manifest in another repo, so the poller intentionally introduces none.
+	pollIntervalMs: number;
+	// How far back the first poll of an account reaches. A restart loses the
+	// in-memory cursor and re-scans this window; duplicate rows are acceptable
+	// because transfer_events is plain MergeTree and consumers deduplicate at read
+	// time over (exchange, account, symbol, external_id, status).
+	lookbackMs: number;
+	depositsLimit: number;
+};
+
+const DEFAULT_CONFIG: DepositArchivePollerConfig = {
+	pollIntervalMs: 60_000,
+	lookbackMs: 24 * 60 * 60 * 1000,
+	depositsLimit: 50,
+};
+
+const ALL_CURRENCIES_CODE = "*";
+
+type DepositPollTarget = {
+	exchangeId: string;
+	account: BrokerAccount;
+	code: typeof ALL_CURRENCIES_CODE;
+};
+
+/**
+ * Advances a since-cursor past the newest deposit in a batch. ccxt deposits
+ * normally carry a numeric timestamp, but venue-specific credited-at fields and
+ * unified datetime strings are accepted as fallbacks.
+ */
+export function nextDepositCursor(
+	deposits: unknown[],
+	currentSince: number,
+): number {
+	let next = currentSince;
+	for (const deposit of deposits) {
+		const record = asRecord(deposit);
+		if (!record) {
+			continue;
+		}
+		const creditedAt = depositField(record, [
+			"timestamp",
+			"creditedAt",
+			"credited_at",
+			"updated",
+			"updatedAt",
+			"datetime",
+		]);
+		const timestamp =
+			typeof creditedAt === "number"
+				? creditedAt
+				: typeof creditedAt === "string"
+					? Date.parse(creditedAt)
+					: Number.NaN;
+		if (Number.isFinite(timestamp) && timestamp + 1 > next) {
+			next = timestamp + 1;
+		}
+	}
+	return next;
+}
+
+/**
+ * Broker-internal periodic capture of venue deposit history. It polls every
+ * configured account sequentially, using ccxt's unfiltered deposit-history
+ * surface so newly funded currencies do not depend on balance or market
+ * discovery.
+ */
+export class DepositArchivePoller {
+	#timer: ReturnType<typeof setTimeout> | null = null;
+	#stopped = false;
+	#running: Promise<boolean> | null = null;
+	readonly #cursors = new Map<string, number>();
+	readonly #unsupportedLogged = new Set<string>();
+	readonly #config: DepositArchivePollerConfig;
+
+	constructor(
+		private readonly params: {
+			brokers: Record<string, BrokerPoolEntry>;
+			archiver: BrokerExecutionArchiver;
+			metrics?: OtelMetrics;
+			config?: Partial<DepositArchivePollerConfig>;
+		},
+	) {
+		this.#config = { ...DEFAULT_CONFIG, ...params.config };
+	}
+
+	start(): void {
+		if (this.#timer || this.#stopped || !this.params.archiver.isEnabled()) {
+			return;
+		}
+		log.info("📥 Deposit archive poller started");
+		this.#schedule(0);
+	}
+
+	async stop(): Promise<void> {
+		this.#stopped = true;
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = null;
+		}
+		await this.#running;
+	}
+
+	async pollAllOnce(): Promise<boolean> {
+		if (this.#stopped || this.#running || !this.params.archiver.isEnabled()) {
+			return false;
+		}
+		this.#running = this.#pollAllSequentially();
+		try {
+			return await this.#running;
+		} finally {
+			this.#running = null;
+		}
+	}
+
+	#targets(): DepositPollTarget[] {
+		const targets: DepositPollTarget[] = [];
+		for (const [exchangeId, pool] of Object.entries(this.params.brokers)) {
+			for (const account of [pool.primary, ...pool.secondaryBrokers]) {
+				targets.push({
+					exchangeId,
+					account,
+					code: ALL_CURRENCIES_CODE,
+				});
+			}
+		}
+		return targets;
+	}
+
+	async #pollAllSequentially(): Promise<boolean> {
+		for (const target of this.#targets()) {
+			if (this.#stopped) {
+				break;
+			}
+			await this.#pollOne(target);
+		}
+		return true;
+	}
+
+	async #pollOne(target: DepositPollTarget): Promise<void> {
+		const exchange = target.account
+			.exchange as unknown as ExchangeWithDeposits;
+		const key = this.#targetKey(target);
+		if (
+			typeof exchange.fetchDeposits !== "function" ||
+			exchange.has?.fetchDeposits === false
+		) {
+			if (!this.#unsupportedLogged.has(key)) {
+				this.#unsupportedLogged.add(key);
+				log.info("Deposit archive poll skipped: fetchDeposits unsupported", {
+					exchange: target.exchangeId,
+					account: target.account.label,
+				});
+			}
+			return;
+		}
+
+		const since =
+			this.#cursors.get(key) ?? Date.now() - this.#config.lookbackMs;
+		let deposits: unknown[];
+		try {
+			deposits = await exchange.fetchDeposits(
+				undefined,
+				since,
+				this.#config.depositsLimit,
+			);
+		} catch (error) {
+			void this.params.metrics?.recordCounter(
+				"cex_deposit_poller_errors_total",
+				1,
+				{ exchange: target.exchangeId },
+			);
+			log.warn("Deposit archive poll failed", {
+				exchange: target.exchangeId,
+				account: target.account.label,
+				error,
+			});
+			return;
+		}
+		if (!Array.isArray(deposits) || deposits.length === 0) {
+			return;
+		}
+
+		let archived = 0;
+		for (const deposit of deposits) {
+			const record = asRecord(deposit);
+			if (!record) {
+				continue;
+			}
+			const assetSymbol = depositField(record, [
+				"currency",
+				"code",
+				"asset",
+			]);
+			const amount = depositField(record, ["amount"]);
+			const address = depositField(record, [
+				"address",
+				"recipientAddress",
+				"to",
+				"destination",
+			]);
+			const txid = depositField(record, [
+				"txid",
+				"txId",
+				"tx_hash",
+				"txHash",
+			]);
+			const network = depositField(record, ["network", "chain"]);
+			const creditedAt = depositField(record, [
+				"creditedAt",
+				"credited_at",
+				"updated",
+				"updatedAt",
+				"timestamp",
+				"datetime",
+			]);
+			const depositTxid = txid === undefined ? undefined : String(txid);
+
+			this.params.archiver.enqueue(
+				buildTransferEventArchiveRow({
+					tags: buildCommonArchiveTags({
+						deploymentId: this.params.archiver.getDeploymentId(),
+						accountSelector: target.account.label,
+						exchange: target.exchangeId,
+						symbol:
+							assetSymbol === undefined ? undefined : String(assetSymbol),
+					}),
+					transfer: {
+						eventKind: "deposit",
+						lifecycleAction: "observe_deposit",
+						status: normalizeDepositStatus(
+							depositField(record, ["status", "state"]),
+						),
+						amount: amount === undefined ? undefined : String(amount),
+						address: address === undefined ? undefined : String(address),
+						network: network === undefined ? undefined : String(network),
+						externalId: depositTxid,
+						txid: depositTxid,
+						exchangeTimestamp:
+							typeof creditedAt === "string" ? creditedAt : undefined,
+						payload: record,
+					},
+				}),
+			);
+			archived += 1;
+		}
+
+		if (archived > 0) {
+			void this.params.metrics?.recordCounter(
+				"cex_deposit_poller_deposits_archived_total",
+				archived,
+				{ exchange: target.exchangeId },
+			);
+		}
+		this.#cursors.set(key, nextDepositCursor(deposits, since));
+	}
+
+	#targetKey(target: DepositPollTarget): string {
+		return `${target.exchangeId}|${target.account.label}|${target.code}`;
+	}
+
+	#schedule(delayMs: number): void {
+		this.#timer = setTimeout(() => void this.#tick(), delayMs);
+		this.#timer.unref?.();
+	}
+
+	async #tick(): Promise<void> {
+		this.#timer = null;
+		try {
+			await this.pollAllOnce();
+		} catch (error) {
+			rethrowArchiveDurabilityError(error);
+			log.error("Deposit archive poller tick failed", error);
+		} finally {
+			if (!this.#stopped) {
+				this.#schedule(this.#config.pollIntervalMs);
+			}
+		}
+	}
+}

--- a/src/helpers/deposit-archive-poller.ts
+++ b/src/helpers/deposit-archive-poller.ts
@@ -49,21 +49,29 @@ type DepositPollTarget = {
 };
 
 /**
- * Advances a since-cursor past the newest deposit in a batch. ccxt deposits
- * normally carry a numeric timestamp, but venue-specific credited-at fields and
- * unified datetime strings are accepted as fallbacks.
+ * Advances the inclusive since-watermark only across a fully observed,
+ * terminal prefix of deposit history.
  */
 export function nextDepositCursor(
 	deposits: unknown[],
 	currentSince: number,
+	depositsLimit: number,
 ): number {
+	// A full batch may be either end of a truncated window. Without a portable
+	// ccxt pagination boundary, moving the watermark could permanently skip the
+	// unseen side of a newest-first response.
+	if (deposits.length >= depositsLimit) {
+		return currentSince;
+	}
+
 	let next = currentSince;
+	let oldestPending = Number.POSITIVE_INFINITY;
 	for (const deposit of deposits) {
 		const record = asRecord(deposit);
 		if (!record) {
-			continue;
+			return currentSince;
 		}
-		const creditedAt = depositField(record, [
+		const observedAt = depositField(record, [
 			"timestamp",
 			"creditedAt",
 			"credited_at",
@@ -72,16 +80,29 @@ export function nextDepositCursor(
 			"datetime",
 		]);
 		const timestamp =
-			typeof creditedAt === "number"
-				? creditedAt
-				: typeof creditedAt === "string"
-					? Date.parse(creditedAt)
+			typeof observedAt === "number"
+				? observedAt
+				: typeof observedAt === "string"
+					? Date.parse(observedAt)
 					: Number.NaN;
-		if (Number.isFinite(timestamp) && timestamp + 1 > next) {
-			next = timestamp + 1;
+		const status = normalizeDepositStatus(
+			depositField(record, ["status", "state"]),
+		);
+		if (!Number.isFinite(timestamp)) {
+			if (status === "pending") {
+				return currentSince;
+			}
+			continue;
+		}
+		if (status === "pending") {
+			oldestPending = Math.min(oldestPending, timestamp);
+		} else {
+			next = Math.max(next, timestamp + 1);
 		}
 	}
-	return next;
+	return Number.isFinite(oldestPending)
+		? Math.max(currentSince, oldestPending)
+		: next;
 }
 
 /**
@@ -221,6 +242,7 @@ export class DepositArchivePoller {
 			]);
 			const txid = depositField(record, ["txid", "txId", "tx_hash", "txHash"]);
 			const network = depositField(record, ["network", "chain"]);
+			const status = depositField(record, ["status", "state"]);
 			const creditedAt = depositField(record, [
 				"creditedAt",
 				"credited_at",
@@ -242,9 +264,10 @@ export class DepositArchivePoller {
 					transfer: {
 						eventKind: "deposit",
 						lifecycleAction: "observe_deposit",
-						status: normalizeDepositStatus(
-							depositField(record, ["status", "state"]),
-						),
+						status:
+							status === undefined
+								? undefined
+								: String(status).trim().toLowerCase(),
 						amount: amount === undefined ? undefined : String(amount),
 						address: address === undefined ? undefined : String(address),
 						network: network === undefined ? undefined : String(network),
@@ -266,7 +289,10 @@ export class DepositArchivePoller {
 				{ exchange: target.exchangeId },
 			);
 		}
-		this.#cursors.set(key, nextDepositCursor(deposits, since));
+		this.#cursors.set(
+			key,
+			nextDepositCursor(deposits, since, this.#config.depositsLimit),
+		);
 	}
 
 	#targetKey(target: DepositPollTarget): string {

--- a/src/helpers/deposit-archive-poller.ts
+++ b/src/helpers/deposit-archive-poller.ts
@@ -3,6 +3,7 @@ import {
 	type BrokerExecutionArchiver,
 	buildCommonArchiveTags,
 	buildTransferEventArchiveRow,
+	normalizeCcxtTransactionForArchive,
 	rethrowArchiveDurabilityError,
 } from "./broker-execution-archive";
 import { depositField, normalizeDepositStatus } from "./deposit";
@@ -242,7 +243,7 @@ export class DepositArchivePoller {
 			]);
 			const txid = depositField(record, ["txid", "txId", "tx_hash", "txHash"]);
 			const network = depositField(record, ["network", "chain"]);
-			const status = depositField(record, ["status", "state"]);
+			const archiveStatus = normalizeCcxtTransactionForArchive(record).status;
 			const creditedAt = depositField(record, [
 				"creditedAt",
 				"credited_at",
@@ -264,10 +265,7 @@ export class DepositArchivePoller {
 					transfer: {
 						eventKind: "deposit",
 						lifecycleAction: "observe_deposit",
-						status:
-							status === undefined
-								? undefined
-								: String(status).trim().toLowerCase(),
+						status: archiveStatus,
 						amount: amount === undefined ? undefined : String(amount),
 						address: address === undefined ? undefined : String(address),
 						network: network === undefined ? undefined : String(network),

--- a/src/helpers/deposit-archive-poller.ts
+++ b/src/helpers/deposit-archive-poller.ts
@@ -163,8 +163,7 @@ export class DepositArchivePoller {
 	}
 
 	async #pollOne(target: DepositPollTarget): Promise<void> {
-		const exchange = target.account
-			.exchange as unknown as ExchangeWithDeposits;
+		const exchange = target.account.exchange as unknown as ExchangeWithDeposits;
 		const key = this.#targetKey(target);
 		if (
 			typeof exchange.fetchDeposits !== "function" ||
@@ -212,11 +211,7 @@ export class DepositArchivePoller {
 			if (!record) {
 				continue;
 			}
-			const assetSymbol = depositField(record, [
-				"currency",
-				"code",
-				"asset",
-			]);
+			const assetSymbol = depositField(record, ["currency", "code", "asset"]);
 			const amount = depositField(record, ["amount"]);
 			const address = depositField(record, [
 				"address",
@@ -224,12 +219,7 @@ export class DepositArchivePoller {
 				"to",
 				"destination",
 			]);
-			const txid = depositField(record, [
-				"txid",
-				"txId",
-				"tx_hash",
-				"txHash",
-			]);
+			const txid = depositField(record, ["txid", "txId", "tx_hash", "txHash"]);
 			const network = depositField(record, ["network", "chain"]);
 			const creditedAt = depositField(record, [
 				"creditedAt",
@@ -247,8 +237,7 @@ export class DepositArchivePoller {
 						deploymentId: this.params.archiver.getDeploymentId(),
 						accountSelector: target.account.label,
 						exchange: target.exchangeId,
-						symbol:
-							assetSymbol === undefined ? undefined : String(assetSymbol),
+						symbol: assetSymbol === undefined ? undefined : String(assetSymbol),
 					}),
 					transfer: {
 						eventKind: "deposit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 	createBrokerExecutionArchiverFromEnv,
 	WithdrawalObservationTracker,
 } from "./helpers/broker-execution-archive";
+import { DepositArchivePoller } from "./helpers/deposit-archive-poller";
 import { FillArchivePoller } from "./helpers/fill-archive-poller";
 import { log } from "./helpers/logger";
 import { OrderActivityTracker } from "./helpers/order-activity-tracker";
@@ -64,6 +65,7 @@ export default class CEXBroker {
 	private readonly withdrawalObservationTracker =
 		new WithdrawalObservationTracker();
 	private fillArchivePoller?: FillArchivePoller;
+	private depositArchivePoller?: DepositArchivePoller;
 	private accountBalanceArchivePoller?: AccountBalanceArchivePoller;
 
 	/**
@@ -290,6 +292,10 @@ export default class CEXBroker {
 			this.fillArchivePoller.stop();
 			this.fillArchivePoller = undefined;
 		}
+		if (this.depositArchivePoller) {
+			await this.depositArchivePoller.stop();
+			this.depositArchivePoller = undefined;
+		}
 		if (this.accountBalanceArchivePoller) {
 			await this.accountBalanceArchivePoller.stop();
 			this.accountBalanceArchivePoller = undefined;
@@ -324,6 +330,10 @@ export default class CEXBroker {
 		if (this.fillArchivePoller) {
 			this.fillArchivePoller.stop();
 			this.fillArchivePoller = undefined;
+		}
+		if (this.depositArchivePoller) {
+			await this.depositArchivePoller.stop();
+			this.depositArchivePoller = undefined;
 		}
 		if (this.accountBalanceArchivePoller) {
 			await this.accountBalanceArchivePoller.stop();
@@ -381,6 +391,13 @@ export default class CEXBroker {
 				metrics: this.otelMetrics,
 			});
 			this.fillArchivePoller.start();
+
+			this.depositArchivePoller = new DepositArchivePoller({
+				brokers: this.brokers,
+				archiver: this.brokerArchiver,
+				metrics: this.otelMetrics,
+			});
+			this.depositArchivePoller.start();
 		}
 
 		if (this.brokerArchiver?.canPersistAccountBalanceSnapshots()) {

--- a/test/deposit-archive-poller.test.ts
+++ b/test/deposit-archive-poller.test.ts
@@ -71,10 +71,9 @@ describe("DepositArchivePoller.pollAllOnce", () => {
 			amount: "25.500000",
 			address: "0xrecipient",
 			network: "ARBITRUM",
-			status: "complete",
 			timestamp: 1_775_000_000_000,
 			creditedAt: "2026-04-01T12:00:00.000Z",
-			info: { venueField: "preserved" },
+			info: { status: "OK", venueField: "preserved" },
 		};
 		const calls: unknown[][] = [];
 		const exchange = {
@@ -107,7 +106,7 @@ describe("DepositArchivePoller.pollAllOnce", () => {
 			schema_version: "1",
 			event_kind: "deposit",
 			lifecycle_action: "observe_deposit",
-			status: "complete",
+			status: "ok",
 			amount: "25.500000",
 			address: "0xrecipient",
 			network: "ARBITRUM",

--- a/test/deposit-archive-poller.test.ts
+++ b/test/deposit-archive-poller.test.ts
@@ -36,17 +36,29 @@ function fakeArchiver(sink: BrokerArchiveRow[]): BrokerExecutionArchiver {
 }
 
 describe("nextDepositCursor", () => {
-	test("advances past the newest credited-at timestamp", () => {
+	test("stops at the oldest pending deposit while advancing past older terminal deposits", () => {
 		expect(
 			nextDepositCursor(
 				[
-					{ timestamp: 100 },
-					{ creditedAt: "2026-07-30T10:00:00.000Z" },
-					{ timestamp: 200 },
+					{ timestamp: 100, status: "ok" },
+					{ timestamp: 300, status: "complete" },
+					{ timestamp: 200, status: "processing" },
 				],
 				0,
+				50,
 			),
-		).toBe(Date.parse("2026-07-30T10:00:00.000Z") + 1);
+		).toBe(200);
+	});
+
+	test("holds the watermark for a full batch under either venue ordering", () => {
+		const oldestFirst = [
+			{ timestamp: 100, status: "ok" },
+			{ timestamp: 200, status: "ok" },
+		];
+		const newestFirst = [...oldestFirst].reverse();
+
+		expect(nextDepositCursor(oldestFirst, 50, 2)).toBe(50);
+		expect(nextDepositCursor(newestFirst, 50, 2)).toBe(50);
 	});
 });
 
@@ -95,7 +107,7 @@ describe("DepositArchivePoller.pollAllOnce", () => {
 			schema_version: "1",
 			event_kind: "deposit",
 			lifecycle_action: "observe_deposit",
-			status: "credited",
+			status: "complete",
 			amount: "25.500000",
 			address: "0xrecipient",
 			network: "ARBITRUM",
@@ -144,6 +156,48 @@ describe("DepositArchivePoller.pollAllOnce", () => {
 		expect(sink[0]?.row).toMatchObject({
 			symbol: "USDT",
 			external_id: "0xonce",
+		});
+	});
+
+	test("re-observes a pending deposit until its normalized status is terminal", async () => {
+		const depositTimestamp = Date.now() + 10_000;
+		const sinceValues: Array<number | undefined> = [];
+		let calls = 0;
+		const exchange = {
+			has: { fetchDeposits: true },
+			fetchDeposits: async (code?: string, since?: number, limit?: number) => {
+				expect(code).toBeUndefined();
+				expect(limit).toBe(50);
+				sinceValues.push(since);
+				calls += 1;
+				return [
+					{
+						txid: "0xtransition",
+						currency: "USDC",
+						amount: 15,
+						status: calls === 1 ? "pending" : "ok",
+						timestamp: depositTimestamp,
+					},
+				];
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const poller = new DepositArchivePoller({
+			brokers: poolWith(exchange),
+			archiver: fakeArchiver(sink),
+		});
+
+		await poller.pollAllOnce();
+		await poller.pollAllOnce();
+
+		expect(sinceValues).toHaveLength(2);
+		expect(sinceValues[1]).toBe(depositTimestamp);
+		expect(sink).toHaveLength(2);
+		expect(sink.map(({ row }) => row.status)).toEqual(["pending", "ok"]);
+		expect(sink[1]?.row).toMatchObject({
+			lifecycle_action: "observe_deposit",
+			external_id: "0xtransition",
+			status: "ok",
 		});
 	});
 
@@ -214,7 +268,7 @@ describe("DepositArchivePoller.pollAllOnce", () => {
 			expect(sink).toHaveLength(1);
 			expect(sink[0]?.row).toMatchObject({
 				external_id: "0xrecovered",
-				status: "credited",
+				status: "ok",
 			});
 		} finally {
 			warn.mockRestore();

--- a/test/deposit-archive-poller.test.ts
+++ b/test/deposit-archive-poller.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import type { BrokerAccount, BrokerPoolEntry } from "../src/helpers/broker";
+import type {
+	BrokerArchiveRow,
+	BrokerExecutionArchiver,
+} from "../src/helpers/broker-execution-archive";
+import {
+	DepositArchivePoller,
+	nextDepositCursor,
+} from "../src/helpers/deposit-archive-poller";
+import { log } from "../src/helpers/logger";
+
+function account(
+	exchange: unknown,
+	label: BrokerAccount["label"] = "primary",
+	index?: number,
+): BrokerAccount {
+	return { exchange, label, index } as unknown as BrokerAccount;
+}
+
+function poolWith(exchange: unknown): Record<string, BrokerPoolEntry> {
+	return {
+		binance: {
+			primary: account(exchange),
+			secondaryBrokers: [],
+		},
+	};
+}
+
+function fakeArchiver(sink: BrokerArchiveRow[]): BrokerExecutionArchiver {
+	return {
+		isEnabled: () => true,
+		getDeploymentId: () => "deploy-a",
+		enqueue: (row: BrokerArchiveRow) => sink.push(row),
+	} as unknown as BrokerExecutionArchiver;
+}
+
+describe("nextDepositCursor", () => {
+	test("advances past the newest credited-at timestamp", () => {
+		expect(
+			nextDepositCursor(
+				[
+					{ timestamp: 100 },
+					{ creditedAt: "2026-07-30T10:00:00.000Z" },
+					{ timestamp: 200 },
+				],
+				0,
+			),
+		).toBe(Date.parse("2026-07-30T10:00:00.000Z") + 1);
+	});
+});
+
+describe("DepositArchivePoller.pollAllOnce", () => {
+	test("archives deposits with the transfer-event row shape", async () => {
+		const rawDeposit = {
+			id: "deposit-1",
+			txid: "0xdeposit",
+			currency: "USDC",
+			amount: "25.500000",
+			address: "0xrecipient",
+			network: "ARBITRUM",
+			status: "complete",
+			timestamp: 1_775_000_000_000,
+			creditedAt: "2026-04-01T12:00:00.000Z",
+			info: { venueField: "preserved" },
+		};
+		const calls: unknown[][] = [];
+		const exchange = {
+			has: { fetchDeposits: true },
+			fetchDeposits: async (...args: unknown[]) => {
+				calls.push(args);
+				return [rawDeposit];
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const poller = new DepositArchivePoller({
+			brokers: poolWith(exchange),
+			archiver: fakeArchiver(sink),
+		});
+
+		expect(await poller.pollAllOnce()).toBe(true);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.[0]).toBeUndefined();
+		expect(calls[0]?.[2]).toBe(50);
+		expect(sink).toHaveLength(1);
+		expect(sink[0]?.table).toBe("broker_execution.transfer_events");
+		expect(sink[0]?.row).toMatchObject({
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			exchange: "binance",
+			account_selector: "primary",
+			symbol: "USDC",
+			asset_symbol: "USDC",
+			schema_version: "1",
+			event_kind: "deposit",
+			lifecycle_action: "observe_deposit",
+			status: "credited",
+			amount: "25.500000",
+			address: "0xrecipient",
+			network: "ARBITRUM",
+			external_id: "0xdeposit",
+			client_withdrawal_id: "",
+			txid: "0xdeposit",
+			result_index: 0,
+			exchange_timestamp: "2026-04-01T12:00:00.000Z",
+			payload_json: JSON.stringify(rawDeposit),
+		});
+	});
+
+	test("advances the account cursor and does not re-archive within a session", async () => {
+		const depositTimestamp = Date.now() + 10_000;
+		const deposit = {
+			txid: "0xonce",
+			currency: "USDT",
+			amount: 10,
+			status: "ok",
+			timestamp: depositTimestamp,
+		};
+		const sinceValues: Array<number | undefined> = [];
+		const exchange = {
+			has: { fetchDeposits: true },
+			fetchDeposits: async (code?: string, since?: number, limit?: number) => {
+				expect(code).toBeUndefined();
+				expect(limit).toBe(50);
+				sinceValues.push(since);
+				return since !== undefined && since <= depositTimestamp
+					? [deposit]
+					: [];
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const poller = new DepositArchivePoller({
+			brokers: poolWith(exchange),
+			archiver: fakeArchiver(sink),
+		});
+
+		await poller.pollAllOnce();
+		await poller.pollAllOnce();
+
+		expect(sinceValues).toHaveLength(2);
+		expect(sinceValues[1]).toBe(depositTimestamp + 1);
+		expect(sink).toHaveLength(1);
+		expect(sink[0]?.row).toMatchObject({
+			symbol: "USDT",
+			external_id: "0xonce",
+		});
+	});
+
+	test("logs once and cleanly skips an account without fetchDeposits", async () => {
+		const info = spyOn(log, "info").mockImplementation(() => {});
+		try {
+			const sink: BrokerArchiveRow[] = [];
+			const poller = new DepositArchivePoller({
+				brokers: poolWith({ has: { fetchDeposits: false } }),
+				archiver: fakeArchiver(sink),
+			});
+
+			expect(await poller.pollAllOnce()).toBe(true);
+			expect(await poller.pollAllOnce()).toBe(true);
+
+			expect(sink).toHaveLength(0);
+			expect(info).toHaveBeenCalledTimes(1);
+			expect(info).toHaveBeenCalledWith(
+				"Deposit archive poll skipped: fetchDeposits unsupported",
+				{
+					exchange: "binance",
+					account: "primary",
+				},
+			);
+		} finally {
+			info.mockRestore();
+		}
+	});
+
+	test("logs a fetch error and archives on the next pass", async () => {
+		const warn = spyOn(log, "warn").mockImplementation(() => {});
+		try {
+			let calls = 0;
+			const exchange = {
+				has: { fetchDeposits: true },
+				fetchDeposits: async () => {
+					calls += 1;
+					if (calls === 1) {
+						throw new Error("rate limited");
+					}
+					return [
+						{
+							txid: "0xrecovered",
+							currency: "USDC",
+							amount: "5",
+							status: "ok",
+							timestamp: Date.now() + 10_000,
+						},
+					];
+				},
+			};
+			const sink: BrokerArchiveRow[] = [];
+			const poller = new DepositArchivePoller({
+				brokers: poolWith(exchange),
+				archiver: fakeArchiver(sink),
+			});
+
+			expect(await poller.pollAllOnce()).toBe(true);
+			expect(await poller.pollAllOnce()).toBe(true);
+
+			expect(calls).toBe(2);
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0]?.[0]).toBe("Deposit archive poll failed");
+			expect(warn.mock.calls[0]?.[1]).toMatchObject({
+				exchange: "binance",
+				account: "primary",
+			});
+			expect(sink).toHaveLength(1);
+			expect(sink[0]?.row).toMatchObject({
+				external_id: "0xrecovered",
+				status: "credited",
+			});
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});

--- a/test/treasury-discovery-rpc.test.ts
+++ b/test/treasury-discovery-rpc.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
 import {
+	type BrokerArchiveRow,
 	BrokerExecutionArchiver,
 	WithdrawalObservationTracker,
 } from "../src/helpers/broker-execution-archive";
@@ -665,7 +666,13 @@ describe("Treasury discovery and transfer observation RPC", () => {
 				},
 			],
 		});
-		const rpc = await start(exchange);
+		const archivedRows: BrokerArchiveRow[] = [];
+		const archiver = {
+			isEnabled: () => true,
+			getDeploymentId: () => "test-deploy",
+			enqueue: (row: BrokerArchiveRow) => archivedRows.push(row),
+		} as unknown as BrokerExecutionArchiver;
+		const rpc = await start(exchange, testPolicy, archiver);
 
 		const credited = await executeAction(rpc, {
 			action: Action.Deposit,
@@ -693,6 +700,17 @@ describe("Treasury discovery and transfer observation RPC", () => {
 			address: "0xdeposit",
 			confirmations: 15,
 			creditedAt: "2026-06-04T00:00:00.000Z",
+		});
+		await Promise.resolve();
+		expect(archivedRows).toHaveLength(1);
+		expect(archivedRows[0]).toMatchObject({
+			table: "broker_execution.transfer_events",
+			row: {
+				event_kind: "deposit",
+				lifecycle_action: "observe_deposit",
+				status: "ok",
+				external_id: "0xtx",
+			},
 		});
 		expect(calls.fetchDeposits[0]).toEqual([
 			"USDC",


### PR DESCRIPTION
Venue deposits were never reaching `broker_execution.transfer_events`. Over a
24-hour production window the table held only `withdrawal` and
`internal_transfer` rows — no deposit event of any kind, ever. Because the CEX
accounting identity is

    net_pnl = ΔNAV − (deposits − withdrawals)

every uncaptured inflow was being counted as profit: a ~$500 book measured
NAV 552 → 470 with $1,144 withdrawn and $0 deposited, reporting +$1,062, which
reads as a >200% daily return and is arithmetically impossible.

Two distinct defects produced that.

### 1. No routine writer

The `observe_deposit` archive row was only ever emitted by the explicit `Deposit`
execute-action, whose callers are the manual treasury paths. Routine funding
confirms arrival from its own withdrawal record and custody balance and never
emits a venue-side deposit fact, so nothing archived deposits during normal
operation.

Fixed by `DepositArchivePoller`, wired beside the existing fill and
account-balance pollers and following the same pattern: one unfiltered
`fetchDeposits` per configured account so newly funded and zero-balance
currencies do not depend on market or balance discovery, defensive typing for
exchange builds without the method, and **no new environment variables** —
constant defaults only (60s interval, 24h restart lookback, limit 50). This
catches every inflow, whether routine, manual or external.

The cursor is a watermark rather than a high-water mark, which is load-bearing:
a ccxt deposit's timestamp does not change when it transitions `pending → ok`, so
advancing past the newest row in a batch would permanently skip the credited
observation. The watermark therefore stops at the oldest non-terminal deposit and
does not advance at all when a batch fills the fetch limit, which would otherwise
skip the unseen older side of a newest-first response. Duplicate re-observation
is intentional — `transfer_events` is plain MergeTree with read-time dedup, and
suppressing duplicates would drop status transitions.

### 2. The archived status vocabulary could never match its consumer

`transfer_events` carries ccxt's raw lowercased status — which is why production
withdrawals read `ok` / `pending` / `failed` — but the deposit handler archived
`normalizeDepositStatus(...)`, which maps `ok → credited`. The consuming flow view
filters `lower(status) = 'ok'`, so deposits archived through the manual path had
always been uncountable too, and the new poller would have inherited the same
blindness.

Both writers now derive the archived status from the shared
`normalizeCcxtTransactionForArchive`, including its `info.status` fallback — a
hand-rolled `record.status` read misses venues that report status only inside
`info`.

**The RPC response is deliberately unchanged** and still returns `credited`:
callers match on that value exactly. The two vocabularies are now named in a
comment at that seam so the next reader does not "unify" them and break those
callers.

Changing the archived vocabulary is safe because production holds zero deposit
rows all-time, so no consumer depends on the old value.

### Verification

`bun test` — 484 pass, 0 fail; Biome and TypeScript clean. New and extended cases
pin: a `pending` deposit re-observed as `ok` with an unchanged venue timestamp
(both observations archived), no deposit skipped when a batch is truncated under
either venue ordering, unsupported `fetchDeposits` skipping cleanly, fetch errors
logged without stopping the poller, and the handler archiving the ccxt vocabulary
while its response still returns `credited`.

### After merge

Needs a release bump and the broker and forwarder deployed together. Acceptance
is measured on production, not in tests: deposits non-zero over a 24-hour window
and net PnL falling to a plausible magnitude for the book size.
