### PR TITLE
chore(release): bump cex-broker to 0.2.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.34",
+	"version": "0.2.35",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Releases the venue-deposit archive capture merged in #92.

Contents since 0.2.34:
- Background deposit poller archiving every venue inflow, so the CEX accounting identity stops treating uncaptured deposits as profit.
- Both deposit writers now archive ccxt's status vocabulary, which the accounting consumer actually filters on; the RPC response keeps returning its own lifecycle vocabulary.

Verification on the merged tree: `bun test` 484 pass / 0 fail, Biome and TypeScript clean.

Downstream chain after this merges and is tagged for publish: the periphery pin bump, then the consuming repo's submodule bump with its root lockfile regenerated and the new version added to the release-age exclusion list, then the image build and the enclave-host deploy alongside the forwarder.