### PR TITLE
fix(deposits): preserve venue status transitions for locked Binance deposits

### DIFF
--- a/src/helpers/deposit-archive-poller.ts
+++ b/src/helpers/deposit-archive-poller.ts
@@ -30,7 +30,8 @@ export type DepositArchivePollerConfig = {
 	// How far back the first poll of an account reaches. A restart loses the
 	// in-memory cursor and re-scans this window; duplicate rows are acceptable
 	// because transfer_events is plain MergeTree and consumers deduplicate at read
-	// time over (exchange, account, symbol, external_id, status).
+	// time over (exchange, account, symbol, external_id, status). A Binance deposit
+	// unlocking intentionally produces distinct credited_not_withdrawable and ok rows.
 	lookbackMs: number;
 	depositsLimit: number;
 };
@@ -49,6 +50,43 @@ type DepositPollTarget = {
 	code: typeof ALL_CURRENCIES_CODE;
 };
 
+type LastArchivedDeposit = {
+	status: string | undefined;
+	timestamp: number | undefined;
+};
+
+function depositTimestamp(record: Record<string, unknown>): number | undefined {
+	const observedAt = depositField(record, [
+		"timestamp",
+		"creditedAt",
+		"credited_at",
+		"updated",
+		"updatedAt",
+		"datetime",
+	]);
+	const timestamp =
+		typeof observedAt === "number"
+			? observedAt
+			: typeof observedAt === "string"
+				? Date.parse(observedAt)
+				: Number.NaN;
+	return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function archivedDepositStatus(
+	exchangeId: string | undefined,
+	record: Record<string, unknown>,
+): string | undefined {
+	const rawStatus = asRecord(record.info)?.status;
+	if (
+		exchangeId?.toLowerCase() === "binance" &&
+		String(rawStatus ?? "").trim() === "6"
+	) {
+		return "credited_not_withdrawable";
+	}
+	return normalizeCcxtTransactionForArchive(record).status;
+}
+
 /**
  * Advances the inclusive since-watermark only across a fully observed,
  * terminal prefix of deposit history.
@@ -57,6 +95,7 @@ export function nextDepositCursor(
 	deposits: unknown[],
 	currentSince: number,
 	depositsLimit: number,
+	exchangeId?: string,
 ): number {
 	// A full batch may be either end of a truncated window. Without a portable
 	// ccxt pagination boundary, moving the watermark could permanently skip the
@@ -72,30 +111,20 @@ export function nextDepositCursor(
 		if (!record) {
 			return currentSince;
 		}
-		const observedAt = depositField(record, [
-			"timestamp",
-			"creditedAt",
-			"credited_at",
-			"updated",
-			"updatedAt",
-			"datetime",
-		]);
-		const timestamp =
-			typeof observedAt === "number"
-				? observedAt
-				: typeof observedAt === "string"
-					? Date.parse(observedAt)
-					: Number.NaN;
+		const timestamp = depositTimestamp(record);
+		const archiveStatus = archivedDepositStatus(exchangeId, record);
 		const status = normalizeDepositStatus(
 			depositField(record, ["status", "state"]),
 		);
-		if (!Number.isFinite(timestamp)) {
-			if (status === "pending") {
+		const isPending =
+			archiveStatus === "credited_not_withdrawable" || status === "pending";
+		if (timestamp === undefined) {
+			if (isPending) {
 				return currentSince;
 			}
 			continue;
 		}
-		if (status === "pending") {
+		if (isPending) {
 			oldestPending = Math.min(oldestPending, timestamp);
 		} else {
 			next = Math.max(next, timestamp + 1);
@@ -117,6 +146,10 @@ export class DepositArchivePoller {
 	#stopped = false;
 	#running: Promise<boolean> | null = null;
 	readonly #cursors = new Map<string, number>();
+	readonly #lastArchivedByTarget = new Map<
+		string,
+		Map<string, LastArchivedDeposit>
+	>();
 	readonly #unsupportedLogged = new Set<string>();
 	readonly #config: DepositArchivePollerConfig;
 
@@ -243,7 +276,7 @@ export class DepositArchivePoller {
 			]);
 			const txid = depositField(record, ["txid", "txId", "tx_hash", "txHash"]);
 			const network = depositField(record, ["network", "chain"]);
-			const archiveStatus = normalizeCcxtTransactionForArchive(record).status;
+			const archiveStatus = archivedDepositStatus(target.exchangeId, record);
 			const creditedAt = depositField(record, [
 				"creditedAt",
 				"credited_at",
@@ -253,6 +286,13 @@ export class DepositArchivePoller {
 				"datetime",
 			]);
 			const depositTxid = txid === undefined ? undefined : String(txid);
+			const lastArchived =
+				depositTxid === undefined
+					? undefined
+					: this.#lastArchivedByTarget.get(key)?.get(depositTxid);
+			if (lastArchived && lastArchived.status === archiveStatus) {
+				continue;
+			}
 
 			this.params.archiver.enqueue(
 				buildTransferEventArchiveRow({
@@ -277,6 +317,17 @@ export class DepositArchivePoller {
 					},
 				}),
 			);
+			if (depositTxid !== undefined) {
+				let targetDeposits = this.#lastArchivedByTarget.get(key);
+				if (!targetDeposits) {
+					targetDeposits = new Map();
+					this.#lastArchivedByTarget.set(key, targetDeposits);
+				}
+				targetDeposits.set(depositTxid, {
+					status: archiveStatus,
+					timestamp: depositTimestamp(record),
+				});
+			}
 			archived += 1;
 		}
 
@@ -287,10 +338,27 @@ export class DepositArchivePoller {
 				{ exchange: target.exchangeId },
 			);
 		}
-		this.#cursors.set(
-			key,
-			nextDepositCursor(deposits, since, this.#config.depositsLimit),
+		const nextCursor = nextDepositCursor(
+			deposits,
+			since,
+			this.#config.depositsLimit,
+			target.exchangeId,
 		);
+		this.#cursors.set(key, nextCursor);
+		const targetDeposits = this.#lastArchivedByTarget.get(key);
+		if (targetDeposits) {
+			for (const [externalId, lastArchived] of targetDeposits) {
+				if (
+					lastArchived.timestamp !== undefined &&
+					lastArchived.timestamp < nextCursor
+				) {
+					targetDeposits.delete(externalId);
+				}
+			}
+			if (targetDeposits.size === 0) {
+				this.#lastArchivedByTarget.delete(key);
+			}
+		}
 	}
 
 	#targetKey(target: DepositPollTarget): string {

--- a/test/deposit-archive-poller.test.ts
+++ b/test/deposit-archive-poller.test.ts
@@ -200,6 +200,92 @@ describe("DepositArchivePoller.pollAllOnce", () => {
 		});
 	});
 
+	test("archives Binance locked and unlocked deposit states as distinct rows", async () => {
+		const depositTimestamp = Date.now() + 10_000;
+		const sinceValues: Array<number | undefined> = [];
+		let calls = 0;
+		const exchange = {
+			has: { fetchDeposits: true },
+			fetchDeposits: async (code?: string, since?: number, limit?: number) => {
+				expect(code).toBeUndefined();
+				expect(limit).toBe(50);
+				sinceValues.push(since);
+				calls += 1;
+				return since !== undefined && since <= depositTimestamp
+					? [
+							{
+								txid: "0xlocked",
+								currency: "ARB",
+								amount: 25,
+								status: "ok",
+								timestamp: depositTimestamp,
+								info: { status: calls === 1 ? "6" : "1" },
+							},
+						]
+					: [];
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const poller = new DepositArchivePoller({
+			brokers: poolWith(exchange),
+			archiver: fakeArchiver(sink),
+		});
+
+		await poller.pollAllOnce();
+		await poller.pollAllOnce();
+
+		expect(sinceValues).toHaveLength(2);
+		expect(sinceValues[1]).toBe(depositTimestamp);
+		expect(sink.map(({ row }) => row.status)).toEqual([
+			"credited_not_withdrawable",
+			"ok",
+		]);
+		expect(sink[0]?.row).toMatchObject({
+			external_id: "0xlocked",
+			status: "credited_not_withdrawable",
+		});
+
+		await poller.pollAllOnce();
+
+		expect(sinceValues[2]).toBe(depositTimestamp + 1);
+		expect(sink).toHaveLength(2);
+	});
+
+	test("does not re-archive an unchanged Binance locked deposit", async () => {
+		const depositTimestamp = Date.now() + 10_000;
+		const sinceValues: Array<number | undefined> = [];
+		const exchange = {
+			has: { fetchDeposits: true },
+			fetchDeposits: async (code?: string, since?: number, limit?: number) => {
+				expect(code).toBeUndefined();
+				expect(limit).toBe(50);
+				sinceValues.push(since);
+				return [
+					{
+						txid: "0xstill-locked",
+						currency: "ARB",
+						amount: 25,
+						status: "ok",
+						timestamp: depositTimestamp,
+						info: { status: 6 },
+					},
+				];
+			},
+		};
+		const sink: BrokerArchiveRow[] = [];
+		const poller = new DepositArchivePoller({
+			brokers: poolWith(exchange),
+			archiver: fakeArchiver(sink),
+		});
+
+		await poller.pollAllOnce();
+		await poller.pollAllOnce();
+
+		expect(sinceValues[1]).toBe(depositTimestamp);
+		expect(sink).toHaveLength(1);
+		expect(sink[0]?.row.status).toBe("credited_not_withdrawable");
+	});
+
 	test("logs once and cleanly skips an account without fetchDeposits", async () => {
 		const info = spyOn(log, "info").mockImplementation(() => {});
 		try {


### PR DESCRIPTION
Binance deposit raw status `6` means credited but not yet withdrawable. ccxt maps both raw `6` and raw `1` (fully withdrawable) to `'ok'`, which the poller treats as terminal. Three things followed:

1. The cursor advanced past the deposit.
2. Binance filters deposit history by `insertTime`, which does not change when the status flips, so the `6 → 1` transition was never re-fetched.
3. The archive row carried ccxt's `'ok'` for both states, so even a re-observation would have written an identical row — the transition was invisible in the typed `status` column either way.

This already happened in production: a real deposit was archived at raw status 6 as `'ok'`, and its unlock is permanently unrecoverable. A deposit that is visible in balances but cannot yet be withdrawn is not equivalent to settled funds, yet the archive recorded both states identically.

## Change

- A Binance deposit at raw status `6` is archived as `credited_not_withdrawable` (raw status read from the payload, not the ccxt mapping; accepts string or numeric form). Everything else keeps its current ccxt-derived status, and other venues are untouched.
- That status is non-terminal for the cursor — treated like `pending` — so the watermark holds at the locked deposit and the later unlock is re-fetched.
- Rows are emitted **on status change only**: a per-target map of external id to last archived status means a deposit is enqueued when first seen or when its status changes, never on every poll. Entries are pruned once the deposit falls behind the advanced cursor.

The emit-on-change rule is what makes holding the cursor safe — without it, a locked deposit would be re-archived every 60 seconds. It also removes a pre-existing instance of the same problem: pending deposits were being re-archived on every poll.

A `6 → 1` flip now intentionally produces two rows with distinct statuses. That is compatible with the read-time dedupe contract documented in the poller, whose key includes status.

Accepted edge, unchanged in spirit from today's behavior: a deposit that stays locked indefinitely pins the cursor, as a full result window already does.

## Tests

```
bun test test/deposit-archive-poller.test.ts     9 pass, 0 fail, 59 expect()
bun test                                       489 pass, 0 fail, 1222 expect()
bunx tsc                                       clean
bunx biome check <changed files>               clean
```

New cases cover raw `6 → 1` producing two rows with distinct statuses and advancing the cursor only after unlock, and repeated raw `6` producing no additional row.

## Effect on downstream PnL

An earlier revision of this description claimed this change must wait for a consumer-side view fix to be deployed first. That was wrong, and it is retracted.

The locked-phase row carries a status other than `ok`, and the downstream flow view already filters on `status = 'ok'` — verified against the deployed view definition. Combined with emit-on-change, exactly one `ok` row per deposit reaches that view, so this change introduces no duplicate and needs no deploy ordering.

What it does change is *when* a locked deposit registers as an inflow: at unlock rather than at credit. That is the intended correction — venue free balance steps up at unlock, not at credit — but it moves the deposit rather than adding to it.

