### PR TITLE
feat(archive): add forwarder OpenTelemetry metrics

### DIFF
--- a/services/archive-forwarder/Dockerfile
+++ b/services/archive-forwarder/Dockerfile
@@ -18,6 +18,7 @@ RUN bun install --frozen-lockfile
 # Forwarder source and the SQL files its schema initializer applies at startup
 # (schema.ts resolves ../../schema/clickhouse relative to this directory).
 COPY services/archive-forwarder ./services/archive-forwarder
+COPY src/helpers/otel.ts src/helpers/logger.ts ./src/helpers/
 COPY schema/clickhouse ./schema/clickhouse
 
 ENV ARCHIVE_FORWARDER_PORT=8090

--- a/services/archive-forwarder/index.ts
+++ b/services/archive-forwarder/index.ts
@@ -1,15 +1,10 @@
 import { createClient } from "@clickhouse/client";
-import { isArchiveRequestAuthorized } from "./auth";
 import { loadForwarderConfig } from "./config";
 import { createClickHouseInserter } from "./insert";
 import { pingClickHouse } from "./health";
-import {
-	MAX_ARCHIVE_ROWS,
-	isArchiveBodyTooLarge,
-	readBoundedArchiveBody,
-} from "./limits";
-import { handleArchiveBatch, parseArchiveBatchRequest } from "./router";
+import { handleArchiveRequest } from "./request";
 import { ensureArchiveSchema } from "./schema";
+import { createArchiveForwarderTelemetry } from "./telemetry";
 
 const config = loadForwarderConfig();
 const clickhouse = createClient({
@@ -25,6 +20,7 @@ const clickhouse = createClient({
 	clickhouse_settings: { date_time_input_format: "best_effort" },
 });
 const inserter = createClickHouseInserter(clickhouse);
+const telemetry = createArchiveForwarderTelemetry();
 
 try {
 	await ensureArchiveSchema(clickhouse);
@@ -49,97 +45,11 @@ const server = Bun.serve({
 		}
 
 		if (request.method === "POST" && url.pathname === "/archive") {
-			if (!isArchiveRequestAuthorized(request, config.authToken)) {
-				return Response.json({ error: "Unauthorized" }, { status: 401 });
-			}
-
-			if (isArchiveBodyTooLarge(request.headers.get("content-length"))) {
-				return Response.json({ error: "Request body too large" }, { status: 413 });
-			}
-
-			let bodyText: string;
-			const bodyRead = await readBoundedArchiveBody(request);
-			if (!bodyRead.ok) {
-				return Response.json(
-					{
-						error:
-							bodyRead.status === 413
-								? "Request body too large"
-								: "Failed to read request body",
-					},
-					{ status: bodyRead.status },
-				);
-			}
-			bodyText = bodyRead.text;
-
-			let body: unknown;
-			try {
-				body = JSON.parse(bodyText);
-			} catch {
-				return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-			}
-
-			const parsed = parseArchiveBatchRequest(body);
-			if (!parsed.ok) {
-				return Response.json(
-					{ error: "Invalid archive batch payload" },
-					{ status: 400 },
-				);
-			}
-
-			if (parsed.rejectedRowCount > 0) {
-				// Name the offending tables: an unknown table (e.g. a forgotten
-				// SUPPORTED_TABLES entry for a new archive table) would otherwise reject
-				// the whole batch with only a count, hiding which table is at fault.
-				console.warn(
-					`Rejected ${parsed.rejectedRowCount}/${parsed.inputRowCount} archive row(s) from ${parsed.batch.source}; tables: ${parsed.rejectedTables.join(", ")}`,
-				);
-				return Response.json(
-					{
-						error: "Malformed archive rows in batch",
-						rejected: parsed.rejectedRowCount,
-						inputRows: parsed.inputRowCount,
-						rejectedTables: parsed.rejectedTables,
-					},
-					{ status: 400 },
-				);
-			}
-
-			if (parsed.batch.rows.length > MAX_ARCHIVE_ROWS) {
-				return Response.json(
-					{
-						error: "Too many archive rows in batch",
-						maxRows: MAX_ARCHIVE_ROWS,
-						received: parsed.batch.rows.length,
-					},
-					{ status: 413 },
-				);
-			}
-
-			try {
-				const result = await handleArchiveBatch(inserter, parsed.batch);
-				if (result.skipped > 0) {
-					console.warn(
-						`Skipped ${result.skipped} unsupported archive row(s) from ${parsed.batch.source}`,
-					);
-				}
-				if (result.failed > 0) {
-					console.warn(
-						`Failed ${result.failed} archive row(s) from ${parsed.batch.source}: ${result.failedTables.join(", ")}`,
-					);
-					return Response.json(
-						{ error: "Archive insert failed", ...result },
-						{ status: 500 },
-					);
-				}
-				return Response.json({ ok: true, ...result });
-			} catch (error) {
-				console.error("Archive insert failed:", error);
-				return Response.json(
-					{ error: "Archive insert failed" },
-					{ status: 500 },
-				);
-			}
+			return handleArchiveRequest(request, {
+				authToken: config.authToken,
+				inserter,
+				telemetry,
+			});
 		}
 
 		return Response.json({ error: "Not found" }, { status: 404 });

--- a/services/archive-forwarder/insert.ts
+++ b/services/archive-forwarder/insert.ts
@@ -1,4 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import type { ArchiveForwarderTelemetry } from "./telemetry";
 import type { ArchiveRow, ArchiveBatchResult, SupportedTable } from "./types";
 import { isSupportedTable } from "./types";
 
@@ -29,6 +30,7 @@ export function countSkippedRows(rows: ArchiveRow[]): number {
 export async function insertArchiveRows(
 	inserter: RowInserter,
 	rows: ArchiveRow[],
+	telemetry?: ArchiveForwarderTelemetry,
 ): Promise<ArchiveBatchResult> {
 	const grouped = groupRowsByTable(rows);
 	const byTable: Record<string, number> = {};
@@ -44,9 +46,11 @@ export async function insertArchiveRows(
 			await inserter(table, tableRows);
 			byTable[table] = tableRows.length;
 			inserted += tableRows.length;
+			telemetry?.recordRowsInserted(table, tableRows.length);
 		} catch (error) {
 			failedTables.push(table);
 			failed += tableRows.length;
+			telemetry?.recordInsertFailure(table, error);
 			console.error(`Archive insert failed for ${table}:`, error);
 		}
 	}

--- a/services/archive-forwarder/request.ts
+++ b/services/archive-forwarder/request.ts
@@ -1,0 +1,115 @@
+import { isArchiveRequestAuthorized } from "./auth";
+import type { RowInserter } from "./insert";
+import {
+	MAX_ARCHIVE_ROWS,
+	isArchiveBodyTooLarge,
+	readBoundedArchiveBody,
+} from "./limits";
+import { handleArchiveBatch, parseArchiveBatchRequest } from "./router";
+import type { ArchiveForwarderTelemetry } from "./telemetry";
+
+export type ArchiveRequestDependencies = {
+	authToken?: string;
+	inserter: RowInserter;
+	telemetry: ArchiveForwarderTelemetry;
+};
+
+export async function handleArchiveRequest(
+	request: Request,
+	dependencies: ArchiveRequestDependencies,
+): Promise<Response> {
+	if (!isArchiveRequestAuthorized(request, dependencies.authToken)) {
+		return Response.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	if (isArchiveBodyTooLarge(request.headers.get("content-length"))) {
+		return Response.json({ error: "Request body too large" }, { status: 413 });
+	}
+
+	const bodyRead = await readBoundedArchiveBody(request);
+	if (!bodyRead.ok) {
+		return Response.json(
+			{
+				error:
+					bodyRead.status === 413
+						? "Request body too large"
+						: "Failed to read request body",
+			},
+			{ status: bodyRead.status },
+		);
+	}
+
+	let body: unknown;
+	try {
+		body = JSON.parse(bodyRead.text);
+	} catch {
+		return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+	}
+
+	const parsed = parseArchiveBatchRequest(body);
+	if (!parsed.ok) {
+		return Response.json(
+			{ error: "Invalid archive batch payload" },
+			{ status: 400 },
+		);
+	}
+
+	if (parsed.rejectedRowCount > 0) {
+		dependencies.telemetry.recordRejectedRows(parsed.rejectedRowsByTable);
+		// Name the offending tables: an unknown table (e.g. a forgotten
+		// SUPPORTED_TABLES entry for a new archive table) would otherwise reject
+		// the whole batch with only a count, hiding which table is at fault.
+		console.warn(
+			`Rejected ${parsed.rejectedRowCount}/${parsed.inputRowCount} archive row(s) from ${parsed.batch.source}; tables: ${parsed.rejectedTables.join(", ")}`,
+		);
+		return Response.json(
+			{
+				error: "Malformed archive rows in batch",
+				rejected: parsed.rejectedRowCount,
+				inputRows: parsed.inputRowCount,
+				rejectedTables: parsed.rejectedTables,
+			},
+			{ status: 400 },
+		);
+	}
+
+	if (parsed.batch.rows.length > MAX_ARCHIVE_ROWS) {
+		return Response.json(
+			{
+				error: "Too many archive rows in batch",
+				maxRows: MAX_ARCHIVE_ROWS,
+				received: parsed.batch.rows.length,
+			},
+			{ status: 413 },
+		);
+	}
+
+	try {
+		const result = await handleArchiveBatch(
+			dependencies.inserter,
+			parsed.batch,
+			dependencies.telemetry,
+		);
+		if (result.skipped > 0) {
+			console.warn(
+				`Skipped ${result.skipped} unsupported archive row(s) from ${parsed.batch.source}`,
+			);
+		}
+		if (result.failed > 0) {
+			console.warn(
+				`Failed ${result.failed} archive row(s) from ${parsed.batch.source}: ${result.failedTables.join(", ")}`,
+			);
+			return Response.json(
+				{ error: "Archive insert failed", ...result },
+				{ status: 500 },
+			);
+		}
+		return Response.json({ ok: true, ...result });
+	} catch (error) {
+		console.error("Archive insert failed:", error);
+		return Response.json(
+			{ error: "Archive insert failed" },
+			{ status: 500 },
+		);
+	}
+}

--- a/services/archive-forwarder/router.ts
+++ b/services/archive-forwarder/router.ts
@@ -1,6 +1,7 @@
 import type { ArchiveBatchRequest, ArchiveBatchResult } from "./types";
 import { isSupportedTable } from "./types";
 import { insertArchiveRows, type RowInserter } from "./insert";
+import type { ArchiveForwarderTelemetry } from "./telemetry";
 
 export type ParsedArchiveBatch =
 	| {
@@ -12,6 +13,7 @@ export type ParsedArchiveBatch =
 			// so the caller can name them in a WARN instead of dropping silently.
 			// A rejected row with no string `table` contributes "(malformed)".
 			rejectedTables: string[];
+			rejectedRowsByTable: Record<string, number>;
 	  }
 	| { ok: false };
 
@@ -49,7 +51,7 @@ export function parseArchiveBatchRequest(body: unknown): ParsedArchiveBatch {
 	}
 	const inputRowCount = record.rows.length;
 	const rows = record.rows.filter(isValidArchiveRow);
-	const rejectedTables = collectRejectedTables(record.rows);
+	const rejectedRowsByTable = countRejectedRowsByTable(record.rows);
 	return {
 		ok: true,
 		batch: {
@@ -59,20 +61,22 @@ export function parseArchiveBatchRequest(body: unknown): ParsedArchiveBatch {
 		},
 		inputRowCount,
 		rejectedRowCount: inputRowCount - rows.length,
-		rejectedTables,
+		rejectedTables: Object.keys(rejectedRowsByTable),
+		rejectedRowsByTable,
 	};
 }
 
-function collectRejectedTables(rows: unknown[]): string[] {
-	const tables = new Set<string>();
+function countRejectedRowsByTable(rows: unknown[]): Record<string, number> {
+	const counts = new Map<string, number>();
 	for (const entry of rows) {
 		if (isValidArchiveRow(entry)) {
 			continue;
 		}
 		const table = (entry as { table?: unknown } | null)?.table;
-		tables.add(typeof table === "string" ? table : "(malformed)");
+		const label = typeof table === "string" ? table : "(malformed)";
+		counts.set(label, (counts.get(label) ?? 0) + 1);
 	}
-	return [...tables];
+	return Object.fromEntries(counts);
 }
 
 /** @deprecated Use parseArchiveBatchRequest returning ParsedArchiveBatch */
@@ -89,6 +93,11 @@ export function parseArchiveBatchRequestLegacy(
 export async function handleArchiveBatch(
 	inserter: RowInserter,
 	request: ArchiveBatchRequest,
+	telemetry?: ArchiveForwarderTelemetry,
 ): Promise<ArchiveBatchResult> {
-	return insertArchiveRows(inserter, request.rows);
+	const result = await insertArchiveRows(inserter, request.rows, telemetry);
+	if (result.failed === 0) {
+		telemetry?.recordSuccessfulFlush();
+	}
+	return result;
 }

--- a/services/archive-forwarder/router.ts
+++ b/services/archive-forwarder/router.ts
@@ -1,5 +1,5 @@
 import type { ArchiveBatchRequest, ArchiveBatchResult } from "./types";
-import { isSupportedTable } from "./types";
+import { isSupportedTable, MALFORMED_TABLE_LABEL } from "./types";
 import { insertArchiveRows, type RowInserter } from "./insert";
 import type { ArchiveForwarderTelemetry } from "./telemetry";
 
@@ -73,7 +73,8 @@ function countRejectedRowsByTable(rows: unknown[]): Record<string, number> {
 			continue;
 		}
 		const table = (entry as { table?: unknown } | null)?.table;
-		const label = typeof table === "string" ? table : "(malformed)";
+		const label =
+			typeof table === "string" ? table : MALFORMED_TABLE_LABEL;
 		counts.set(label, (counts.get(label) ?? 0) + 1);
 	}
 	return Object.fromEntries(counts);
@@ -96,7 +97,12 @@ export async function handleArchiveBatch(
 	telemetry?: ArchiveForwarderTelemetry,
 ): Promise<ArchiveBatchResult> {
 	const result = await insertArchiveRows(inserter, request.rows, telemetry);
-	if (result.failed === 0) {
+	// Requires rows to have actually landed. `failed === 0` is also true for an
+	// empty batch, and an empty POST advancing this gauge would keep a staleness
+	// alert green while nothing reaches ClickHouse — the precise failure this
+	// heartbeat exists to catch, since its whole job is separating "quiet" from
+	// "dead".
+	if (result.failed === 0 && result.inserted > 0) {
 		telemetry?.recordSuccessfulFlush();
 	}
 	return result;

--- a/services/archive-forwarder/telemetry.ts
+++ b/services/archive-forwarder/telemetry.ts
@@ -2,6 +2,11 @@ import {
 	createOtelMetricsFromEnv,
 	type OtelMetrics,
 } from "../../src/helpers/otel";
+import {
+	isSupportedTable,
+	MALFORMED_TABLE_LABEL,
+	UNSUPPORTED_TABLE_LABEL,
+} from "./types";
 
 export const ARCHIVE_FORWARDER_METRICS = {
 	rowsInserted: "archive_forwarder_rows_inserted_total",
@@ -29,8 +34,29 @@ export class ArchiveForwarderTelemetry {
 		);
 	}
 
+	/**
+	 * Rejected rows are precisely the rows whose table is unknown, so their names
+	 * come straight from the request payload. Every distinct label value becomes a
+	 * permanent series in the metrics SDK, so emitting them verbatim lets any client
+	 * grow our memory without bound — and a metrics pipeline that can be exhausted
+	 * by traffic is worse than no metrics.
+	 *
+	 * Labels are therefore bounded to the supported-table set plus two fixed
+	 * buckets. The bound lives here, at the metric boundary, rather than at the one
+	 * current call site, so a future caller cannot reintroduce the problem. The raw
+	 * names are still reported and logged per request, where they are bounded by the
+	 * batch and are what an operator actually needs for diagnosis.
+	 */
 	public recordRejectedRows(rowsByTable: Readonly<Record<string, number>>): void {
+		const bounded = new Map<string, number>();
 		for (const [table, count] of Object.entries(rowsByTable)) {
+			const label =
+				table === MALFORMED_TABLE_LABEL || isSupportedTable(table)
+					? table
+					: UNSUPPORTED_TABLE_LABEL;
+			bounded.set(label, (bounded.get(label) ?? 0) + count);
+		}
+		for (const [table, count] of bounded) {
 			this.bestEffort(() =>
 				this.metrics.recordCounter(
 					ARCHIVE_FORWARDER_METRICS.rowsRejected,

--- a/services/archive-forwarder/telemetry.ts
+++ b/services/archive-forwarder/telemetry.ts
@@ -1,0 +1,106 @@
+import {
+	createOtelMetricsFromEnv,
+	type OtelMetrics,
+} from "../../src/helpers/otel";
+
+export const ARCHIVE_FORWARDER_METRICS = {
+	rowsInserted: "archive_forwarder_rows_inserted_total",
+	rowsRejected: "archive_forwarder_rows_rejected_total",
+	insertFailures: "archive_forwarder_insert_failures_total",
+	lastSuccessfulFlush:
+		"archive_forwarder_last_successful_flush_timestamp_seconds",
+} as const;
+
+export type ArchiveMetricsRecorder = Pick<
+	OtelMetrics,
+	"recordCounter" | "setObservableGauge"
+>;
+
+export class ArchiveForwarderTelemetry {
+	constructor(private readonly metrics: ArchiveMetricsRecorder) {}
+
+	public recordRowsInserted(table: string, count: number): void {
+		this.bestEffort(() =>
+			this.metrics.recordCounter(
+				ARCHIVE_FORWARDER_METRICS.rowsInserted,
+				count,
+				{ table },
+			),
+		);
+	}
+
+	public recordRejectedRows(rowsByTable: Readonly<Record<string, number>>): void {
+		for (const [table, count] of Object.entries(rowsByTable)) {
+			this.bestEffort(() =>
+				this.metrics.recordCounter(
+					ARCHIVE_FORWARDER_METRICS.rowsRejected,
+					count,
+					{ table },
+				),
+			);
+		}
+	}
+
+	public recordInsertFailure(table: string, error: unknown): void {
+		this.bestEffort(() =>
+			this.metrics.recordCounter(
+				ARCHIVE_FORWARDER_METRICS.insertFailures,
+				1,
+				{ table, error_class: classifyInsertError(error) },
+			),
+		);
+	}
+
+	public recordSuccessfulFlush(completedAt: Date = new Date()): void {
+		this.bestEffort(() =>
+			this.metrics.setObservableGauge(
+				ARCHIVE_FORWARDER_METRICS.lastSuccessfulFlush,
+				Math.floor(completedAt.getTime() / 1_000),
+				{},
+			),
+		);
+	}
+
+	private bestEffort(action: () => void | Promise<void>): void {
+		try {
+			const result = action();
+			if (result instanceof Promise) {
+				void result.catch(() => {});
+			}
+		} catch {
+			// Metrics must never affect archive request handling or insertion.
+		}
+	}
+}
+
+export function createArchiveForwarderTelemetry(): ArchiveForwarderTelemetry {
+	return new ArchiveForwarderTelemetry(
+		createOtelMetricsFromEnv({
+			defaultServiceName: "archive-forwarder",
+			allowLegacyBrokerConfig: false,
+		}),
+	);
+}
+
+export function classifyInsertError(error: unknown): string {
+	const message =
+		error instanceof Error
+			? `${error.name} ${error.message}`.toLowerCase()
+			: String(error).toLowerCase();
+
+	if (/timeout|timed out|abort/.test(message)) return "timeout";
+	if (/econn|connection|network|socket|fetch failed/.test(message)) {
+		return "connection";
+	}
+	if (/unauthorized|forbidden|authentication|credential/.test(message)) {
+		return "authentication";
+	}
+	if (
+		/unknown (table|column)|does not exist|doesn't exist|table missing/.test(
+			message,
+		)
+	) {
+		return "schema";
+	}
+	return "unknown";
+}

--- a/services/archive-forwarder/types.ts
+++ b/services/archive-forwarder/types.ts
@@ -39,3 +39,13 @@ export type SupportedTable = (typeof SUPPORTED_TABLES)[number];
 export function isSupportedTable(table: string): table is SupportedTable {
 	return (SUPPORTED_TABLES as readonly string[]).includes(table);
 }
+
+/** Rejected row carrying no usable `table` field. */
+export const MALFORMED_TABLE_LABEL = "(malformed)";
+
+/**
+ * Rejected row naming a table we do not support. The name is client-controlled,
+ * so it is collapsed to this fixed bucket before reaching a metric label; the raw
+ * name stays in the response and the log line, where it is bounded per request.
+ */
+export const UNSUPPORTED_TABLE_LABEL = "(unsupported)";

--- a/src/helpers/otel.ts
+++ b/src/helpers/otel.ts
@@ -1,4 +1,8 @@
-import { metrics } from "@opentelemetry/api";
+import {
+	type Attributes,
+	metrics,
+	type ObservableGauge,
+} from "@opentelemetry/api";
 import { type LogRecord, logs } from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
@@ -40,6 +44,13 @@ export interface MetricData {
 	value: number;
 	labels: string;
 	service: string;
+}
+
+export interface OtelMetricsEnvOptions {
+	/** Service name used when OTEL_SERVICE_NAME is not configured. */
+	defaultServiceName?: string;
+	/** Whether broker-specific legacy collector host variables are accepted. */
+	allowLegacyBrokerConfig?: boolean;
 }
 
 const DEFAULT_SERVICE = "cex-broker";
@@ -140,6 +151,13 @@ export class OtelMetrics extends BaseOtelSignal<MeterProviderType> {
 	private readonly histograms = new Map<
 		string,
 		ReturnType<ReturnType<MeterProviderType["getMeter"]>["createHistogram"]>
+	>();
+	private readonly observableGauges = new Map<
+		string,
+		{
+			instrument: ObservableGauge;
+			observations: Map<string, { value: number; attributes: Attributes }>;
+		}
 	>();
 
 	constructor(config?: OtelConfig) {
@@ -264,6 +282,47 @@ export class OtelMetrics extends BaseOtelSignal<MeterProviderType> {
 			hist.record(value, toAttributes(labels, service));
 		} catch (error) {
 			log.error("Failed to record gauge:", error);
+		}
+	}
+
+	/**
+	 * Set a gauge value that is observed on every export. This is suitable for
+	 * staleness signals where a quiet live process must keep exporting its last value.
+	 */
+	public async setObservableGauge(
+		metricName: string,
+		value: number,
+		labels: Record<string, string | number>,
+		service: string = this.getServiceName(),
+	): Promise<void> {
+		const provider = this.getProvider();
+		if (!this.isOtelEnabled() || !provider) return;
+		try {
+			let state = this.observableGauges.get(metricName);
+			if (!state) {
+				const observations = new Map<
+					string,
+					{ value: number; attributes: Attributes }
+				>();
+				const instrument = provider
+					.getMeter("cex-broker-metrics", "1.0.0")
+					.createObservableGauge(metricName, { description: metricName });
+				instrument.addCallback((result) => {
+					for (const observation of observations.values()) {
+						result.observe(observation.value, observation.attributes);
+					}
+				});
+				state = { instrument, observations };
+				this.observableGauges.set(metricName, state);
+			}
+
+			const attributes = toAttributes(labels, service);
+			state.observations.set(stableAttributeKey(attributes), {
+				value,
+				attributes,
+			});
+		} catch (error) {
+			log.error("Failed to set observable gauge:", error);
 		}
 	}
 
@@ -420,30 +479,48 @@ function getOtelProtocolFromEnv(): "http" | "https" {
 	return (protocol as "http" | "https") || "http";
 }
 
-export function createOtelMetricsFromEnv(): OtelMetrics {
+export function createOtelMetricsFromEnv(
+	options: OtelMetricsEnvOptions = {},
+): OtelMetrics {
 	const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
-	const host = getOtelHostFromEnv();
+	const serviceName =
+		process.env.OTEL_SERVICE_NAME ||
+		options.defaultServiceName ||
+		DEFAULT_SERVICE;
 
 	if (otlpEndpoint) {
 		return new OtelMetrics({
-			otlpEndpoint: otlpEndpoint.replace(/\/v1\/metrics\/?$/, ""),
-			serviceName: process.env.OTEL_SERVICE_NAME || DEFAULT_SERVICE,
+			otlpEndpoint,
+			serviceName,
 		});
 	}
 
-	if (!host) {
-		return new OtelMetrics();
+	if (options.allowLegacyBrokerConfig === false) {
+		return new OtelMetrics({ serviceName });
 	}
+
+	const host = getOtelHostFromEnv();
+	if (!host) return new OtelMetrics({ serviceName });
 
 	const port = getOtelPortFromEnv();
 	const config: OtelConfig = {
 		host,
 		port: port ?? DEFAULT_OTLP_PORT,
 		protocol: getOtelProtocolFromEnv(),
-		serviceName: process.env.OTEL_SERVICE_NAME || DEFAULT_SERVICE,
+		serviceName,
 	};
 
 	return new OtelMetrics(config);
+}
+
+function stableAttributeKey(
+	attributes: Record<string, string | number>,
+): string {
+	return JSON.stringify(
+		Object.entries(attributes).sort(([left], [right]) =>
+			left.localeCompare(right),
+		),
+	);
 }
 
 export function createOtelLogsFromEnv(): OtelLogs {

--- a/test/archive-forwarder-telemetry.test.ts
+++ b/test/archive-forwarder-telemetry.test.ts
@@ -90,6 +90,20 @@ describe("archive forwarder telemetry", () => {
 		expect(gauges[0]?.value).toBeGreaterThan(0);
 	});
 
+	test("an empty batch does not advance the successful-flush heartbeat", async () => {
+		const { telemetry, gauges } = createCapturingTelemetry();
+		const response = await handleArchiveRequest(archiveRequest([]), {
+			inserter: async () => {},
+			telemetry,
+		});
+
+		expect(response.status).toBe(200);
+		// A batch that inserts nothing must not look like a successful flush: a
+		// staleness alert built on this gauge would stay green while no data reaches
+		// ClickHouse, which is exactly the condition it exists to detect.
+		expect(gauges).toHaveLength(0);
+	});
+
 	test("records every rejected row by table, including malformed rows", async () => {
 		const { telemetry, counters } = createCapturingTelemetry();
 		let insertCalled = false;
@@ -109,12 +123,14 @@ describe("archive forwarder telemetry", () => {
 
 		expect(response.status).toBe(400);
 		expect(insertCalled).toBe(false);
+		// Unknown table names are client-controlled, so they are bucketed rather than
+		// used verbatim as a label. The raw name stays in the response and the log.
 		expect(counters).toEqual(
 			expect.arrayContaining([
 				{
 					name: ARCHIVE_FORWARDER_METRICS.rowsRejected,
 					value: 2,
-					labels: { table: "strategy_data.unknown" },
+					labels: { table: "(unsupported)" },
 				},
 				{
 					name: ARCHIVE_FORWARDER_METRICS.rowsRejected,
@@ -123,6 +139,33 @@ describe("archive forwarder telemetry", () => {
 				},
 			]),
 		);
+	});
+
+	test("bounds rejected-row label cardinality no matter how many table names a client invents", async () => {
+		const { telemetry, counters } = createCapturingTelemetry();
+		const response = await handleArchiveRequest(
+			archiveRequest(
+				Array.from({ length: 50 }, (_, index) => ({
+					table: `strategy_data.attacker_${index}`,
+					row: {},
+				})),
+			),
+			{ inserter: async () => {}, telemetry },
+		);
+
+		expect(response.status).toBe(400);
+		const rejected = counters.filter(
+			(entry) => entry.name === ARCHIVE_FORWARDER_METRICS.rowsRejected,
+		);
+		// One series, not fifty: each distinct label value would otherwise persist in
+		// the metrics SDK, letting a client grow our memory without bound.
+		expect(rejected).toEqual([
+			{
+				name: ARCHIVE_FORWARDER_METRICS.rowsRejected,
+				value: 50,
+				labels: { table: "(unsupported)" },
+			},
+		]);
 	});
 
 	test("records insert failures by table and coarse error class", async () => {

--- a/test/archive-forwarder-telemetry.test.ts
+++ b/test/archive-forwarder-telemetry.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { handleArchiveRequest } from "../services/archive-forwarder/request";
+import {
+	ARCHIVE_FORWARDER_METRICS,
+	ArchiveForwarderTelemetry,
+	type ArchiveMetricsRecorder,
+	createArchiveForwarderTelemetry,
+} from "../services/archive-forwarder/telemetry";
+
+type CounterRecord = {
+	name: string;
+	value: number;
+	labels: Record<string, string | number>;
+};
+
+type GaugeRecord = CounterRecord;
+
+function createCapturingTelemetry(): {
+	telemetry: ArchiveForwarderTelemetry;
+	counters: CounterRecord[];
+	gauges: GaugeRecord[];
+} {
+	const counters: CounterRecord[] = [];
+	const gauges: GaugeRecord[] = [];
+	const recorder: ArchiveMetricsRecorder = {
+		recordCounter: async (name, value, labels) => {
+			counters.push({ name, value, labels });
+		},
+		setObservableGauge: async (name, value, labels) => {
+			gauges.push({ name, value, labels });
+		},
+	};
+	return {
+		telemetry: new ArchiveForwarderTelemetry(recorder),
+		counters,
+		gauges,
+	};
+}
+
+function archiveRequest(rows: unknown[]): Request {
+	return new Request("http://localhost/archive", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			source: "broker_write",
+			deployment_id: "deploy-a",
+			rows,
+		}),
+	});
+}
+
+describe("archive forwarder telemetry", () => {
+	const originalEnv = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+	});
+
+	test("records inserted rows by table and updates the successful-flush heartbeat", async () => {
+		const { telemetry, counters, gauges } = createCapturingTelemetry();
+		const response = await handleArchiveRequest(
+			archiveRequest([
+				{ table: "market_data.candles", row: { open_time_ms: 1 } },
+				{ table: "market_data.candles", row: { open_time_ms: 2 } },
+				{
+					table: "broker_execution.order_events",
+					row: { order_id: "order-1" },
+				},
+			]),
+			{ inserter: async () => {}, telemetry },
+		);
+
+		expect(response.status).toBe(200);
+		expect(counters).toEqual(
+			expect.arrayContaining([
+				{
+					name: ARCHIVE_FORWARDER_METRICS.rowsInserted,
+					value: 2,
+					labels: { table: "market_data.candles" },
+				},
+				{
+					name: ARCHIVE_FORWARDER_METRICS.rowsInserted,
+					value: 1,
+					labels: { table: "broker_execution.order_events" },
+				},
+			]),
+		);
+		expect(gauges).toHaveLength(1);
+		expect(gauges[0]?.name).toBe(ARCHIVE_FORWARDER_METRICS.lastSuccessfulFlush);
+		expect(gauges[0]?.value).toBeGreaterThan(0);
+	});
+
+	test("records every rejected row by table, including malformed rows", async () => {
+		const { telemetry, counters } = createCapturingTelemetry();
+		let insertCalled = false;
+		const response = await handleArchiveRequest(
+			archiveRequest([
+				{ table: "strategy_data.unknown", row: {} },
+				{ table: "strategy_data.unknown", row: {} },
+				{ table: 42, row: {} },
+			]),
+			{
+				inserter: async () => {
+					insertCalled = true;
+				},
+				telemetry,
+			},
+		);
+
+		expect(response.status).toBe(400);
+		expect(insertCalled).toBe(false);
+		expect(counters).toEqual(
+			expect.arrayContaining([
+				{
+					name: ARCHIVE_FORWARDER_METRICS.rowsRejected,
+					value: 2,
+					labels: { table: "strategy_data.unknown" },
+				},
+				{
+					name: ARCHIVE_FORWARDER_METRICS.rowsRejected,
+					value: 1,
+					labels: { table: "(malformed)" },
+				},
+			]),
+		);
+	});
+
+	test("records insert failures by table and coarse error class", async () => {
+		const { telemetry, counters, gauges } = createCapturingTelemetry();
+		const response = await handleArchiveRequest(
+			archiveRequest([
+				{ table: "market_data.cex_trades", row: { trade_id: "trade-1" } },
+			]),
+			{
+				inserter: async () => {
+					throw new Error("unknown table market_data.cex_trades");
+				},
+				telemetry,
+			},
+		);
+
+		expect(response.status).toBe(500);
+		expect(counters).toContainEqual({
+			name: ARCHIVE_FORWARDER_METRICS.insertFailures,
+			value: 1,
+			labels: {
+				table: "market_data.cex_trades",
+				error_class: "schema",
+			},
+		});
+		expect(gauges).toHaveLength(0);
+	});
+
+	test("keeps a successful request independent of throwing telemetry", async () => {
+		const throwingRecorder: ArchiveMetricsRecorder = {
+			recordCounter: async () => {
+				throw new Error("exporter failed");
+			},
+			setObservableGauge: () => {
+				throw new Error("exporter failed");
+			},
+		};
+		const insertedTables: string[] = [];
+		const response = await handleArchiveRequest(
+			archiveRequest([
+				{ table: "market_data.candles", row: { open_time_ms: 1 } },
+			]),
+			{
+				inserter: async (table) => {
+					insertedTables.push(table);
+				},
+				telemetry: new ArchiveForwarderTelemetry(throwingRecorder),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(insertedTables).toEqual(["market_data.candles"]);
+	});
+
+	test("keeps telemetry optional when no OTLP endpoint is configured", async () => {
+		delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+		delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+		const response = await handleArchiveRequest(
+			archiveRequest([
+				{ table: "market_data.candles", row: { open_time_ms: 1 } },
+			]),
+			{
+				inserter: async () => {},
+				telemetry: createArchiveForwarderTelemetry(),
+			},
+		);
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/test/archive-forwarder.test.ts
+++ b/test/archive-forwarder.test.ts
@@ -111,6 +111,10 @@ describe("archive forwarder batch parsing", () => {
 		expect(parsed.rejectedTables).toEqual(
 			expect.arrayContaining(["broker_execution.mystery_table", "(malformed)"]),
 		);
+		expect(parsed.rejectedRowsByTable).toEqual({
+			"broker_execution.mystery_table": 1,
+			"(malformed)": 1,
+		});
 	});
 
 	test("parseArchiveBatchRequest accepts broker_execution and strategy_data, rejects unknown tables", () => {

--- a/test/otel.test.ts
+++ b/test/otel.test.ts
@@ -404,6 +404,7 @@ describe("OtelMetrics", () => {
 			await metrics.recordHistogram("integration_histogram", 10, {
 				test: "true",
 			});
+			await metrics.setObservableGauge("integration_heartbeat", 123, {});
 
 			await new Promise((r) => setTimeout(r, 5500));
 


### PR DESCRIPTION
The archive plane feeds the tables most working dashboards read, and it has had **no liveness signal anywhere**. If the forwarder shed rows or failed to flush, nothing observed it.

## What it emits

- `archive_forwarder_rows_inserted_total{table}`
- `archive_forwarder_rows_rejected_total{table}` — including the `(malformed)` bucket
- `archive_forwarder_insert_failures_total{table,error_class}`
- `archive_forwarder_last_successful_flush_timestamp_seconds`

The rejection counter is the one worth having. An unknown table is the failure mode that produces a poison pill — a 400 plus infinite requeue on the producer side — and today that condition is completely invisible. The router already computed rejected counts and table names and discarded them; this wires up what existed rather than inventing new bookkeeping.

The heartbeat gauge is what separates "quiet" from "dead". A counter that only moves on activity cannot tell you the service is alive on a quiet market — the same reasoning that makes archived order events unusable as a broker liveness signal.

## Telemetry cannot break the data path

That was the hard requirement, and it is enforced rather than intended: the recorder swallows synchronous throws *and* attaches a catch to returned promises, so a rejected export cannot surface as an unhandled rejection either. With no endpoint configured the service behaves exactly as it does today — OTel is not required to boot, and no new configuration is mandatory.

Two of the tests exist specifically for this: a request succeeds while telemetry throws, and telemetry stays optional when no endpoint is set. Those are the cases that matter operationally.

## Shape

The existing OTel helper was generalized to take a service-specific default rather than copied, so there is one metrics bootstrap in this repo, not two. Default service name is `archive-forwarder`, overridable, so it stays separable from the broker instances reporting to the same collector.

No change to the wire contract, accepted payloads, HTTP status codes, or ClickHouse insert behaviour. Additive instrumentation only, and no ClickHouse exporter — metrics go to the collector, the archive tables remain a separate plane.

## Tests

`bun test` — 421 pass, 0 fail, across 36 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operational metrics for archived rows, rejected rows, insertion failures, and successful processing heartbeats.
  * Added per-table reporting for rejected archive rows.
  * Improved support for configurable OpenTelemetry metric export.

* **Bug Fixes**
  * Archive requests now consistently enforce authorization, payload limits, validation, and structured error handling.
  * Telemetry failures no longer interrupt successful archive processing.

* **Tests**
  * Added coverage for telemetry, rejection tracking, insertion failures, and metric delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->