### PR TITLE
release: cex-broker 0.2.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.35",
+	"version": "0.2.36",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Version bump for release. Carries two changes since v0.2.35:

**Archive forwarder OpenTelemetry metrics** (#95). The archive plane feeds the tables most dashboards read and has had no liveness signal anywhere — if the forwarder shed rows or failed to flush, nothing observed it. Adds rows inserted/rejected by table, insert failures by error class, and a last-successful-flush heartbeat. Rejected-table labels are bounded so a client cannot grow metric cardinality without limit, and the heartbeat only advances when rows actually land, so a staleness alert cannot read green on empty batches. Telemetry cannot fail or delay the insert path, and with no endpoint configured behaviour is unchanged.

**Locked deposit status transitions preserved** (#94).

Tagging this release publishes the npm package, the broker image and the forwarder image. Only the forwarder image is needed for the observability rollout; the others come along with the tag as usual.
