### PR TITLE
fix(archive): correlate withdrawal observations with their submission

### DIFF
--- a/src/helpers/broker-execution-archive/capture.ts
+++ b/src/helpers/broker-execution-archive/capture.ts
@@ -176,6 +176,7 @@ export function archiveWithdrawalObservationsInBackground(
 					address: normalized.address,
 					network: normalized.network,
 					externalId: normalized.externalId,
+					clientWithdrawalId: normalized.clientWithdrawalId,
 					txid: normalized.txid,
 					resultIndex,
 					feeAmount: normalized.feeAmount,

--- a/src/helpers/broker-execution-archive/rows.ts
+++ b/src/helpers/broker-execution-archive/rows.ts
@@ -430,6 +430,7 @@ export function buildTransferEventArchiveRow(input: {
 // payload_json regardless, so this only needs the columns we index/filter on.
 export type NormalizedCcxtTransfer = {
 	externalId?: string;
+	clientWithdrawalId?: string;
 	txid?: string;
 	address?: string;
 	network?: string;
@@ -449,6 +450,12 @@ export function normalizeCcxtTransactionForArchive(
 	const fee = asRecord(record?.fee);
 	return compactUndefined({
 		externalId: firstString(record?.id, info?.id, record?.txid, info?.txId),
+		// The caller's withdrawal id, echoed back by the venue on withdrawal
+		// history records. Without it an observation carries only the venue id and
+		// a submission only the client id, so the two halves of one movement have
+		// no shared key and the lifecycle cannot be joined (amounts differ by the
+		// withdrawal fee, so they are not a fallback).
+		clientWithdrawalId: firstString(info?.withdrawOrderId),
 		txid: firstString(record?.txid, info?.txId, info?.txid, info?.tx_hash),
 		address: firstString(record?.address, record?.addressTo, info?.address),
 		network: firstString(record?.network, info?.network),

--- a/test/treasury-discovery-rpc.test.ts
+++ b/test/treasury-discovery-rpc.test.ts
@@ -190,7 +190,11 @@ describe("Treasury discovery and transfer observation RPC", () => {
 				network: "ARBITRUM",
 				fee: { cost: 0, currency: "USDC" },
 				datetime: "2026-07-01T00:00:00.000Z",
-				info: { amount: "12.50000000", completeTime: "" },
+				info: {
+					amount: "12.50000000",
+					completeTime: "",
+					withdrawOrderId: "lane-withdrawal-1",
+				},
 			},
 			{
 				id: "wd-2",
@@ -256,6 +260,9 @@ describe("Treasury discovery and transfer observation RPC", () => {
 					account_selector: "primary",
 					asset_symbol: "USDC",
 					external_id: "wd-1",
+					// The submission that opened this movement is keyed on the same
+					// client id, so the observation is joinable back to it.
+					client_withdrawal_id: "lane-withdrawal-1",
 					txid: "tx-1",
 					status: "pending",
 					amount: "12.50000000",
@@ -273,6 +280,9 @@ describe("Treasury discovery and transfer observation RPC", () => {
 			expect(initialRows[1]?.row).toMatchObject({
 				asset_symbol: "ETH",
 				external_id: "wd-2",
+				// A venue record with no echoed client id stays empty rather than
+				// borrowing one from a neighbouring observation.
+				client_withdrawal_id: "",
 				txid: "tx-2",
 				fee_amount: "0.005",
 				fee_currency: "ETH",


### PR DESCRIPTION
## Problem

A withdrawal's two halves in `broker_execution.transfer_events` share no key, so a movement cannot be followed end to end.

| lifecycle_action | rows | client_withdrawal_id | external_id |
|---|---|---|---|
| `submit_withdrawal` | 504 | 19 | 0 |
| `observe_withdrawal` | 1576 | **0** | 1573 |

A submission carries only the caller's id; the observations that terminate it carry only the venue id. Amount matching is not a fallback — the two differ by the withdrawal fee, and heuristic correlation is how movement evidence gets mis-attributed.

Any surface that follows a movement end to end is structurally blind as a result: it can report that submissions happened and that completions happened, but never that a given withdrawal completed.

## Fix

Binance echoes the caller's `withdrawOrderId` back on withdrawal-history records. This extracts it in `normalizeCcxtTransactionForArchive` and carries it onto `observe_withdrawal` rows as `client_withdrawal_id`, making the lifecycle joinable at the producer.

Exact key only — no heuristic or positional fallback. A venue record with no echoed id stays empty rather than borrowing one from a neighbouring observation. No schema change: the column and its idempotent `ADD COLUMN` migration already exist.

## Evidence

Verified against full production history before writing the fix. The echo is present on `observe_withdrawal` rows in exactly the cases where the originating submission carried a client id (285 of 1576 rows — every observation descending from the 19 client-keyed submissions). Two independent worked pairs join on the echoed id.

The reverse approach — stamping the venue id back onto the submission — was ruled out: the withdraw response carries no venue id in all 504 submissions, and the code already attempts that extraction.

## Verification

`bun test`: 496 pass, 0 fail. `bunx tsc --noEmit`: clean. Both re-run on a second machine at the same commit.

The added assertion is load-bearing: reverting the source change while keeping the test fails it with `client_withdrawal_id: ""` against the expected value.

## Not covered

- 485 historical submissions carry no identifier of any kind and stay unjoinable. This is a closed era — all current callers pass `withdrawOrderId`.
- `submit_internal_transfer` (491 rows) and `observe_deposit` (12 rows) have the same gap and need their own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Withdrawal records now include the client-provided withdrawal identifier when supported by the venue.

* **Bug Fixes**
  * Improved withdrawal observation matching and display of client withdrawal IDs.
  * Records without an echoed client identifier continue to show an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->