### PR TITLE
fix(archive): index Binance internal transfer venue ids

### DIFF
--- a/src/handlers/execute-action/internal-transfer.ts
+++ b/src/handlers/execute-action/internal-transfer.ts
@@ -9,7 +9,7 @@ import {
 } from "../../helpers";
 import {
 	archiveTransferEventInBackground,
-	normalizeCcxtTransactionForArchive,
+	extractBinanceInternalTransferId,
 } from "../../helpers/broker-execution-archive";
 import { mapCcxtErrorToGrpcStatus } from "../../helpers/grpc/status";
 import { log } from "../../helpers/logger";
@@ -113,7 +113,6 @@ export async function handleInternalTransfer(
 			transferPayload.amount,
 		);
 		// account_selector is the source; the destination is kept in payload_json.
-		const normalized = normalizeCcxtTransactionForArchive(result);
 		archiveTransferEventInBackground(brokerArchiver, {
 			exchange: normalizedCex,
 			accountSelector: fromSelector,
@@ -121,10 +120,10 @@ export async function handleInternalTransfer(
 			transfer: {
 				eventKind: "internal_transfer",
 				lifecycleAction: "submit_internal_transfer",
-				status: normalized.status ?? "ok",
-				amount: normalized.amount ?? String(transferPayload.amount),
+				status: "ok",
+				amount: String(transferPayload.amount),
 				network: "internal",
-				externalId: normalized.externalId,
+				externalId: extractBinanceInternalTransferId(result),
 				payload: { from: fromSelector, to: toSelector, result },
 			},
 		});

--- a/src/helpers/broker-execution-archive/index.ts
+++ b/src/helpers/broker-execution-archive/index.ts
@@ -20,6 +20,7 @@ export {
 	buildOrderEventArchiveRow,
 	buildSubscribeStreamArchiveRow,
 	buildTransferEventArchiveRow,
+	extractBinanceInternalTransferId,
 	type FillArchiveFields,
 	type NormalizedCcxtBalance,
 	type NormalizedCcxtTransfer,

--- a/src/helpers/broker-execution-archive/rows.ts
+++ b/src/helpers/broker-execution-archive/rows.ts
@@ -372,6 +372,15 @@ function quantityString(...values: unknown[]): string | undefined {
 	return firstString(...values);
 }
 
+// Binance's implicit internal-transfer methods return raw SAPI responses, not
+// ccxt unified transactions, and use a different id key for universal transfers.
+export function extractBinanceInternalTransferId(
+	response: unknown,
+): string | undefined {
+	const record = asRecord(response);
+	return firstString(record?.txnId, record?.tranId);
+}
+
 export type TransferArchiveFields = {
 	eventKind: TransferEventKind;
 	lifecycleAction: TransferLifecycleAction;

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -14,6 +14,7 @@ import type { LogRecord } from "@opentelemetry/api-logs";
 import type { Exchange } from "@usherlabs/ccxt";
 import { MAX_ARCHIVE_BODY_BYTES } from "../services/archive-forwarder/limits";
 import type { ExecuteActionContext } from "../src/handlers/execute-action/context";
+import { handleInternalTransfer } from "../src/handlers/execute-action/internal-transfer";
 import { handleOrders } from "../src/handlers/execute-action/orders";
 import { handleTreasuryCall } from "../src/handlers/execute-action/treasury-call";
 import { handleWithdraw } from "../src/handlers/execute-action/withdraw";
@@ -972,6 +973,123 @@ describe("withdraw submission archive", () => {
 				error_summary: "venue rejected withdrawal",
 			});
 			expect(rows[2]?.row.client_withdrawal_id).toBe("");
+		} finally {
+			await archiver.close();
+			await forwarder.close();
+		}
+	});
+});
+
+describe("internal transfer submission archive", () => {
+	test("indexes Binance venue ids for every internal transfer direction", async () => {
+		const forwarder = await startForwarderServer();
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: forwarder.url,
+			deadLetterPath: createDeadLetterPath(),
+			deploymentId: "test-deploy",
+			batchSize: 100,
+			flushIntervalMs: 60_000,
+		});
+		const exchangeBase = {
+			loadMarkets: async () => {},
+			currency: (code: string) => ({ id: code }),
+			currencyToPrecision: (_code: string, amount: number) => String(amount),
+		};
+		const primaryExchange = {
+			...exchangeBase,
+			sapiPostSubAccountUniversalTransfer: async () => ({
+				tranId: "primary-to-sub-id",
+			}),
+		} as unknown as Exchange;
+		const secondaryExchange = {
+			...exchangeBase,
+			sapiPostSubAccountTransferSubToMaster: async () => ({
+				txnId: "sub-to-master-id",
+			}),
+			sapiPostSubAccountTransferSubToSub: async () => ({
+				txnId: "sub-to-sub-id",
+			}),
+		} as unknown as Exchange;
+		const brokers = {
+			binance: {
+				primary: { exchange: primaryExchange, label: "primary" as const },
+				secondaryBrokers: [
+					{
+						exchange: secondaryExchange,
+						label: "secondary:1" as const,
+						index: 1,
+					},
+					{
+						exchange: secondaryExchange,
+						label: "secondary:2" as const,
+						index: 2,
+						email: "secondary-2@example.com",
+					},
+				],
+			},
+		};
+		const context = (fromAccount: string, toAccount: string) =>
+			({
+				call: {
+					request: {
+						payload: { amount: "10", fromAccount, toAccount },
+					},
+				},
+				wrappedCallback: () => {},
+				brokers,
+				metadata: {},
+				normalizedCex: "binance",
+				cex: "binance",
+				symbol: "USDC",
+				broker: primaryExchange,
+				verity: { proof: "" },
+				useVerity: false,
+				verityProverUrl: "",
+				brokerArchiver: archiver,
+			}) as unknown as ExecuteActionContext;
+
+		try {
+			await handleInternalTransfer(context("secondary:1", "primary"));
+			await handleInternalTransfer(context("secondary:1", "secondary:2"));
+			await handleInternalTransfer(context("primary", "secondary:2"));
+			await Promise.resolve();
+			await archiver.flush();
+
+			const rows = forwarder.requests.flatMap(
+				(request) => request.body.rows ?? [],
+			) as Array<{ row: Record<string, unknown> }>;
+			expect(rows).toHaveLength(3);
+			expect(
+				rows.map(({ row }) => ({
+					from: row.account_selector,
+					to: (JSON.parse(String(row.payload_json)) as { to: string }).to,
+					externalId: row.external_id,
+					status: row.status,
+					amount: row.amount,
+				})),
+			).toEqual([
+				{
+					from: "secondary:1",
+					to: "primary",
+					externalId: "sub-to-master-id",
+					status: "ok",
+					amount: "10",
+				},
+				{
+					from: "secondary:1",
+					to: "secondary:2",
+					externalId: "sub-to-sub-id",
+					status: "ok",
+					amount: "10",
+				},
+				{
+					from: "primary",
+					to: "secondary:2",
+					externalId: "primary-to-sub-id",
+					status: "ok",
+					amount: "10",
+				},
+			]);
 		} finally {
 			await archiver.close();
 			await forwarder.close();


### PR DESCRIPTION
Every `submit_internal_transfer` row in `broker_execution.transfer_events` has an empty `external_id` (491 rows on full production history), so those movements cannot be named, pointed at, or followed.

The venue does return an identifier and we already persist it — production `payload_json` on those rows reads `{"from":"secondary:1","to":"primary","result":{"txnId":"396024517510"}}`. It was simply never extracted into the indexed column.

## Cause

`transferBinanceInternal` returns the **raw Binance SAPI response**, not a ccxt unified transaction:

- `sapiPostSubAccountTransferSubToMaster` → `{ txnId }`
- `sapiPostSubAccountTransferSubToSub` → `{ txnId }`
- `sapiPostSubAccountUniversalTransfer` → `{ tranId }`

The handler passed that through `normalizeCcxtTransactionForArchive`, which looks for `id` / `info.id` / `txid` / `info.txId`. None exist on those shapes, so `externalId` came back `undefined` and the row builder wrote `""`.

## Change

A dedicated `extractBinanceInternalTransferId` handles the raw response, keeping `normalizeCcxtTransactionForArchive` scoped to ccxt unified transactions rather than widening it with keys that never appear on the withdraw/deposit paths it also serves. It goes through the existing `firstString` helper, which coerces finite numbers — `tranId` is documented as an integer, so a string-only extraction would have silently dropped the primary→sub direction.

`status` and `amount` are now written directly instead of via a `?? ` fallback on the normalizer. This is not a behaviour change: successful Binance responses carry neither field, so the normalizer always returned `undefined` there and the fallback was dead code that implied the venue might supply them.

## Scope

No caller-generated transfer id — the venue id suffices. No deposit↔withdrawal pairing, and no amount- or time-based matching of movements. No schema change; `external_id` already exists on the table. The 491 historical rows are not backfilled here; their ids remain recoverable from `payload_json`.

## Verification

New test covers all three transfer directions end to end through the handler and archiver, asserting the indexed `external_id` per direction.

```
$ bun test test/broker-execution-archive.test.ts
42 pass, 0 fail, 215 expect() calls

$ bun test
497 pass, 0 fail, 1243 expect() calls across 43 files
```

TypeScript and Biome checks pass.

Acceptance after release: new `submit_internal_transfer` rows carry a non-empty `external_id`.
