### PR TITLE
release: cex-broker 0.2.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Publishes the Binance user-data subscription normalization from #101 as `@usherlabs/cex-broker` 0.2.38.

The release provides canonical balance snapshots for Binance balance events, canonical order frames for execution reports, and preserves venue-native archive payloads.

Verification: the merged develop CI run completed successfully, including tests, lint, and the strict package build.

After merge, tag `v0.2.38` to publish the npm package and release images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.2.38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->