### PR TITLE
feat: supervise configured user data streams

### DIFF
--- a/src/handlers/subscribe/handler.ts
+++ b/src/handlers/subscribe/handler.ts
@@ -2,14 +2,14 @@ import * as grpc from "@grpc/grpc-js";
 import type { Exchange } from "@usherlabs/ccxt";
 import { authenticateRequest } from "../../helpers/auth";
 import {
+	normalizeBinanceExecutionReport,
+	normalizeBinanceSpotBalanceEvent,
+} from "../../helpers/binance-user-data-normalization";
+import {
 	BinanceSpotUserDataStream,
 	isBinanceBalanceUserDataEvent,
 	isBinanceOrderUserDataEvent,
 } from "../../helpers/binance-user-data-stream";
-import {
-	normalizeBinanceExecutionReport,
-	normalizeBinanceSpotBalanceEvent,
-} from "../../helpers/binance-user-data-normalization";
 import {
 	type BrokerPoolEntry,
 	createBroker,
@@ -46,6 +46,10 @@ import {
 } from "../../helpers/order-book";
 import type { OtelMetrics } from "../../helpers/otel";
 import { getErrorMessage } from "../../helpers/shared/errors";
+import type {
+	UserDataStreamSupervisor,
+	UserDataSubscription,
+} from "../../helpers/user-data-stream-supervisor";
 import type { SubscribeRequest, SubscribeResponse } from "../types";
 import { SubscribeBrokerLifecycle } from "./broker-lifecycle";
 
@@ -55,6 +59,7 @@ export type SubscribeDeps = {
 	otelMetrics?: OtelMetrics;
 	brokerArchiver?: BrokerExecutionArchiver;
 	brokerLifecycle?: SubscribeBrokerLifecycle;
+	userDataStreamSupervisor?: UserDataStreamSupervisor;
 };
 
 type SubscribeCall = grpc.ServerWritableStream<
@@ -179,16 +184,22 @@ async function streamBinanceUserData(
 		deploymentId: string;
 		assetType: BrokerMarketType;
 	},
+	userDataSource?: UserDataSubscription,
+	knownMarketId?: string | null,
 ): Promise<void> {
-	const userDataStream = new BinanceSpotUserDataStream(broker);
-	call.once("close", () => userDataStream.close());
-	call.once("cancelled", () => userDataStream.close());
-	call.once("error", () => userDataStream.close());
+	const userDataStream =
+		userDataSource ?? new BinanceSpotUserDataStream(broker);
+	if (!userDataSource) {
+		call.once("close", () => userDataStream.close());
+		call.once("cancelled", () => userDataStream.close());
+		call.once("error", () => userDataStream.close());
+	}
 
 	const marketId =
-		subscriptionType === SubscriptionType.ORDERS
+		knownMarketId ??
+		(subscriptionType === SubscriptionType.ORDERS
 			? await getBinanceMarketId(broker, symbol)
-			: null;
+			: null);
 
 	try {
 		for await (const message of userDataStream) {
@@ -319,7 +330,13 @@ async function runCcxtSubscribeLoop(
 }
 
 export function createSubscribeHandler(deps: SubscribeDeps) {
-	const { brokers, whitelistIps, otelMetrics, brokerArchiver } = deps;
+	const {
+		brokers,
+		whitelistIps,
+		otelMetrics,
+		brokerArchiver,
+		userDataStreamSupervisor,
+	} = deps;
 	const brokerLifecycle =
 		deps.brokerLifecycle ?? new SubscribeBrokerLifecycle();
 	return async (call: SubscribeCall) => {
@@ -485,6 +502,33 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 					});
 					return;
 				}
+				const marketId =
+					subscriptionType === SubscriptionType.ORDERS
+						? await getBinanceMarketId(accountBroker, resolvedSymbol)
+						: undefined;
+				let userDataSource: UserDataSubscription | undefined;
+				if (selectedBrokerAccount) {
+					if (!userDataStreamSupervisor) {
+						await writeSubscribeError(call, isStreamClosed, {
+							data: JSON.stringify({
+								error: "Configured account user-data supervisor is unavailable",
+							}),
+							timestamp: Date.now(),
+							symbol: resolvedSymbol,
+							type: subscriptionType,
+						});
+						return;
+					}
+					userDataSource = userDataStreamSupervisor.subscribe({
+						exchange: normalizedCex,
+						accountSelector: selectedBrokerAccount.label,
+						kind:
+							subscriptionType === SubscriptionType.BALANCE
+								? "balance"
+								: "orders",
+						marketId,
+					});
+				}
 				await streamBinanceUserData(
 					call,
 					accountBroker,
@@ -492,6 +536,8 @@ export function createSubscribeHandler(deps: SubscribeDeps) {
 					subscriptionType,
 					isStreamClosed,
 					streamArchiveContext,
+					userDataSource,
+					marketId,
 				);
 				return;
 			}

--- a/src/helpers/binance-user-data-stream.ts
+++ b/src/helpers/binance-user-data-stream.ts
@@ -11,6 +11,23 @@ export type BinanceUserDataEvent = {
 	event: Record<string, unknown>;
 };
 
+export type BinanceUserDataStreamFailureKind =
+	| "auth_failed"
+	| "transport_error"
+	| "remote_closed"
+	| "protocol_error"
+	| "backpressure";
+
+export type BinanceUserDataStreamObserver = {
+	onConnected?: () => void;
+	onAuthenticated?: () => void;
+	onEvent?: (event: BinanceUserDataEvent) => void;
+	onFailure?: (failure: {
+		kind: BinanceUserDataStreamFailureKind;
+		reason: string;
+	}) => void;
+};
+
 type BinanceUserDataMessage =
 	| {
 			id?: string | null;
@@ -39,6 +56,7 @@ type WebSocketFactory = (url: string) => WebSocketLike;
 
 type BinanceSpotUserDataStreamOptions = {
 	maxBufferedEvents?: number;
+	observer?: BinanceUserDataStreamObserver;
 };
 
 let createWebSocket: WebSocketFactory = (url) =>
@@ -240,6 +258,7 @@ export class BinanceSpotUserDataStream
 	private readonly requestId =
 		`user-data-${Date.now()}-${userDataRequestCounter++}`;
 	private readonly maxBufferedEvents: number;
+	private readonly observer?: BinanceUserDataStreamObserver;
 	private readonly queue: BinanceUserDataEvent[] = [];
 	private readonly waiters: Array<{
 		resolve: (event: BinanceUserDataEvent | null) => void;
@@ -256,15 +275,22 @@ export class BinanceSpotUserDataStream
 		this.maxBufferedEvents =
 			options.maxBufferedEvents ??
 			DEFAULT_BINANCE_USER_DATA_MAX_BUFFERED_EVENTS;
+		this.observer = options.observer;
 		this.secretValues = [
 			getOptionalExchangeString(exchange, "apiKey"),
 			getOptionalExchangeString(exchange, "secret"),
 		].filter((value): value is string => value !== null);
 		this.ws = createWebSocket(getBinanceSpotWsApiUrl(exchange));
-		this.ws.on("open", () => this.subscribe());
+		this.ws.on("open", () => {
+			this.observer?.onConnected?.();
+			this.subscribe();
+		});
 		this.ws.on("message", (data) => this.handleMessage(data));
 		this.ws.on("error", (error) =>
-			this.fail(formatBinanceUserDataWebSocketError(error, this.secretValues)),
+			this.fail(
+				formatBinanceUserDataWebSocketError(error, this.secretValues),
+				"transport_error",
+			),
 		);
 		this.ws.on("close", (code, reason) => this.handleClose(code, reason));
 	}
@@ -299,6 +325,7 @@ export class BinanceSpotUserDataStream
 		}
 		this.fail(
 			formatBinanceUserDataWebSocketClose(code, reason, this.secretValues),
+			"remote_closed",
 		);
 	}
 
@@ -334,6 +361,7 @@ export class BinanceSpotUserDataStream
 				error instanceof Error
 					? error
 					: new Error("Invalid Binance user-data message"),
+				"protocol_error",
 			);
 			return;
 		}
@@ -346,10 +374,12 @@ export class BinanceSpotUserDataStream
 							message.error?.message ??
 							`Binance user-data subscription failed with status ${message.status}`,
 					),
+					"auth_failed",
 				);
 				return;
 			}
 			this.subscriptionId = message.result?.subscriptionId ?? null;
+			this.observer?.onAuthenticated?.();
 			return;
 		}
 
@@ -369,6 +399,7 @@ export class BinanceSpotUserDataStream
 						? `${errorMessage} (code ${errorCode})`
 						: errorMessage,
 				),
+				"protocol_error",
 			);
 			return;
 		}
@@ -387,6 +418,7 @@ export class BinanceSpotUserDataStream
 		if (this.closed) {
 			return;
 		}
+		this.observer?.onEvent?.(event);
 
 		const waiter = this.waiters.shift();
 		if (waiter) {
@@ -398,6 +430,7 @@ export class BinanceSpotUserDataStream
 				new Error(
 					`Binance user-data stream buffered event limit exceeded (${this.maxBufferedEvents}); downstream consumer is not keeping up`,
 				),
+				"backpressure",
 			);
 			return;
 		}
@@ -420,11 +453,12 @@ export class BinanceSpotUserDataStream
 		});
 	}
 
-	private fail(error: Error): void {
+	private fail(error: Error, kind: BinanceUserDataStreamFailureKind): void {
 		if (this.closeError) {
 			return;
 		}
 		this.closeError = error;
+		this.observer?.onFailure?.({ kind, reason: error.message });
 		this.closed = true;
 		this.queue.length = 0;
 		this.flushWaiters();

--- a/src/helpers/stream-health-publisher.ts
+++ b/src/helpers/stream-health-publisher.ts
@@ -1,0 +1,459 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+	closeSync,
+	fsyncSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { dirname } from "node:path";
+
+const SOURCE = "broker_write";
+const TABLE = "broker_stream_health.snapshots";
+const PRODUCER_ID = "cex-broker-user-data";
+const STATE_VERSION = 1;
+const HEARTBEAT_MS = 30_000;
+const FORWARDER_TIMEOUT_MS = 3_000;
+const IDENTIFIER = /^[a-z0-9][a-z0-9:_-]{0,127}$/;
+
+export type StreamHealthState =
+	| "connecting"
+	| "connected"
+	| "disconnected"
+	| "error";
+export type StreamHealthFailureKind =
+	| "none"
+	| "auth_failed"
+	| "transport_error"
+	| "remote_closed"
+	| "protocol_error"
+	| "backpressure"
+	| "unsupported_connector"
+	| "shutdown";
+export type StreamHealthSnapshot = {
+	exchange: string;
+	accountSelector: string;
+	accountRole?: string;
+	streamKind: "user_data";
+	accountScope: "spot";
+	registryStatus: "active" | "retired";
+	retiredAt: string | null;
+	state: StreamHealthState;
+	stateChangedAt: string;
+	lastConnectedAt: string | null;
+	lastAuthenticatedAt: string | null;
+	lastReceivedAt: string | null;
+	connectAttemptCount: string;
+	reconnectCount: string;
+	errorCount: string;
+	lastFailureKind: StreamHealthFailureKind;
+	lastFailureReason: string;
+	trafficMode: "event_driven" | "continuous" | "unknown";
+	sourceWatermark: string | null;
+};
+type StateFile = {
+	version: typeof STATE_VERSION;
+	producerId: typeof PRODUCER_ID;
+	producerEpoch: string;
+	runId: string;
+	nextBatchSequence: string;
+	nextStreamSequences: Record<string, string>;
+	pendingBody?: string;
+};
+export type StreamHealthPublisherOptions = {
+	deploymentId: string;
+	statePath: string;
+	forwarderUrl: string;
+	forwarderAuthToken?: string;
+	heartbeatIntervalMs?: number;
+	forwarderTimeoutMs?: number;
+	post?: (body: string) => Promise<void>;
+};
+
+function identifier(value: string, name: string): string {
+	const normalized = value.trim().toLowerCase();
+	if (!IDENTIFIER.test(normalized)) {
+		throw new Error(`${name} must be a lower-case stream-health identifier`);
+	}
+	return normalized;
+}
+
+function counter(value: string): bigint {
+	if (!/^(0|[1-9]\d*)$/.test(value)) {
+		throw new Error("Invalid persisted stream-health counter");
+	}
+	return BigInt(value);
+}
+function next(value: string): string {
+	return (counter(value) + 1n).toString();
+}
+function key(snapshot: StreamHealthSnapshot): string {
+	return `exchange:${snapshot.exchange}|account:${snapshot.accountSelector}|stream:${snapshot.streamKind}|scope:${snapshot.accountScope}`;
+}
+function registryRevision(snapshots: readonly StreamHealthSnapshot[]): string {
+	const rows = snapshots
+		.map((snapshot) => ({
+			exchange: snapshot.exchange,
+			account_selector: snapshot.accountSelector,
+			account_role: snapshot.accountRole ?? null,
+			stream_kind: snapshot.streamKind,
+			account_scope: snapshot.accountScope,
+			registry_status: snapshot.registryStatus,
+		}))
+		.sort((left, right) =>
+			JSON.stringify(left).localeCompare(JSON.stringify(right)),
+		);
+	return createHash("sha256").update(JSON.stringify(rows)).digest("hex");
+}
+function validState(value: unknown): value is StateFile {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const state = value as Partial<StateFile>;
+	return (
+		state.version === STATE_VERSION &&
+		state.producerId === PRODUCER_ID &&
+		typeof state.producerEpoch === "string" &&
+		typeof state.runId === "string" &&
+		typeof state.nextBatchSequence === "string" &&
+		state.nextStreamSequences !== null &&
+		typeof state.nextStreamSequences === "object" &&
+		(state.pendingBody === undefined || typeof state.pendingBody === "string")
+	);
+}
+function forwarderPost(
+	url: URL,
+	body: string,
+	authToken: string | undefined,
+	timeoutMs: number,
+): Promise<void> {
+	const request = url.protocol === "http:" ? httpRequest : httpsRequest;
+	const headers: Record<string, string | number> = {
+		"content-type": "application/json",
+		"content-length": Buffer.byteLength(body),
+	};
+	if (authToken) headers.authorization = `Bearer ${authToken}`;
+	return new Promise((resolve, reject) => {
+		const req = request(
+			url,
+			{ method: "POST", headers, timeout: timeoutMs },
+			(res) => {
+				res.on("data", () => {});
+				res.on("end", () => {
+					const status = res.statusCode ?? 0;
+					if (status < 200 || status >= 300) {
+						reject(new Error(`Stream health forwarder returned ${status}`));
+						return;
+					}
+					resolve();
+				});
+			},
+		);
+		req.on("error", reject);
+		req.on("timeout", () =>
+			req.destroy(new Error("Stream health forwarder timed out")),
+		);
+		req.write(body);
+		req.end();
+	});
+}
+
+/** A whole health batch is persisted before POST so retries are exact replays. */
+export class StreamHealthPublisher {
+	readonly #deploymentId: string;
+	readonly #statePath: string;
+	readonly #heartbeatMs: number;
+	readonly #post: (body: string) => Promise<void>;
+	#state: StateFile;
+	#advanceRun: boolean;
+	#snapshots: readonly StreamHealthSnapshot[] = [];
+	#dirty = false;
+	#closed = false;
+	#pumping: Promise<void> | null = null;
+	#heartbeat: ReturnType<typeof setInterval> | null = null;
+	#retry: ReturnType<typeof setTimeout> | null = null;
+	#retryAttempt = 0;
+
+	constructor(options: StreamHealthPublisherOptions) {
+		this.#deploymentId = identifier(options.deploymentId, "deployment_id");
+		this.#statePath = options.statePath.trim();
+		if (!this.#statePath) {
+			throw new Error("CEX_BROKER_STREAM_HEALTH_STATE_PATH is required");
+		}
+		this.#heartbeatMs = options.heartbeatIntervalMs ?? HEARTBEAT_MS;
+		if (
+			!Number.isInteger(this.#heartbeatMs) ||
+			this.#heartbeatMs < 1 ||
+			this.#heartbeatMs > 60_000
+		) {
+			throw new Error(
+				"Stream health heartbeat interval must be between 1 and 60000ms",
+			);
+		}
+		let url: URL;
+		try {
+			url = new URL(options.forwarderUrl.trim());
+		} catch (error) {
+			throw new Error("CEX_BROKER_ARCHIVE_FORWARDER_URL must be valid", {
+				cause: error,
+			});
+		}
+		if (url.protocol !== "http:" && url.protocol !== "https:") {
+			throw new Error("CEX_BROKER_ARCHIVE_FORWARDER_URL must use HTTP(S)");
+		}
+		this.#post =
+			options.post ??
+			((body) =>
+				forwarderPost(
+					url,
+					body,
+					options.forwarderAuthToken,
+					options.forwarderTimeoutMs ?? FORWARDER_TIMEOUT_MS,
+				));
+		const loaded = this.#read();
+		this.#state = loaded ?? {
+			version: STATE_VERSION,
+			producerId: PRODUCER_ID,
+			producerEpoch: "1",
+			runId: randomUUID(),
+			nextBatchSequence: "1",
+			nextStreamSequences: {},
+		};
+		counter(this.#state.producerEpoch);
+		counter(this.#state.nextBatchSequence);
+		for (const value of Object.values(this.#state.nextStreamSequences))
+			counter(value);
+		this.#advanceRun = loaded !== null;
+		if (!loaded) this.#persist();
+	}
+
+	start(): void {
+		if (this.#closed || this.#heartbeat) return;
+		this.#heartbeat = setInterval(() => {
+			if (this.#snapshots.length > 0) {
+				this.#dirty = true;
+				this.#schedule();
+			}
+		}, this.#heartbeatMs);
+		this.#heartbeat.unref?.();
+		if (this.#state.pendingBody || this.#dirty) this.#schedule();
+	}
+
+	publish(snapshots: readonly StreamHealthSnapshot[]): void {
+		if (this.#closed) return;
+		this.#snapshots = snapshots.map((snapshot) => ({ ...snapshot }));
+		this.#dirty = true;
+		this.#schedule();
+	}
+
+	async close(
+		snapshots: readonly StreamHealthSnapshot[],
+		timeoutMs = FORWARDER_TIMEOUT_MS,
+	): Promise<void> {
+		if (this.#closed) return;
+		if (this.#heartbeat) clearInterval(this.#heartbeat);
+		this.#heartbeat = null;
+		if (this.#retry) clearTimeout(this.#retry);
+		this.#retry = null;
+		this.#snapshots = snapshots.map((snapshot) => ({ ...snapshot }));
+		this.#dirty = this.#snapshots.length > 0;
+		this.#schedule();
+		await Promise.race([
+			this.#waitForIdle(),
+			new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+		]);
+		this.#closed = true;
+		if (this.#retry) clearTimeout(this.#retry);
+		this.#retry = null;
+	}
+
+	#schedule(): void {
+		if (this.#closed || this.#pumping) return;
+		this.#pumping = this.#pump().finally(() => {
+			this.#pumping = null;
+			if (
+				!this.#closed &&
+				!this.#retry &&
+				(this.#state.pendingBody || this.#dirty)
+			)
+				this.#schedule();
+		});
+	}
+	async #pump(): Promise<void> {
+		if (this.#state.pendingBody && !(await this.#deliver())) return;
+		if (!this.#dirty || this.#snapshots.length === 0) return;
+		if (this.#advanceRun) {
+			this.#state.producerEpoch = next(this.#state.producerEpoch);
+			this.#state.runId = randomUUID();
+			this.#state.nextBatchSequence = "1";
+			this.#state.nextStreamSequences = {};
+			this.#advanceRun = false;
+			this.#persist();
+		}
+		this.#dirty = false;
+		this.#state.pendingBody = this.#body(this.#snapshots);
+		this.#persist();
+		await this.#deliver();
+	}
+	async #deliver(): Promise<boolean> {
+		const body = this.#state.pendingBody;
+		if (!body) return true;
+		try {
+			await this.#post(body);
+			this.#state.pendingBody = undefined;
+			this.#persist();
+			this.#retryAttempt = 0;
+			return true;
+		} catch {
+			this.#retryLater();
+			return false;
+		}
+	}
+	#body(snapshots: readonly StreamHealthSnapshot[]): string {
+		const ordered = [...snapshots].sort((left, right) =>
+			key(left).localeCompare(key(right)),
+		);
+		if (ordered.length === 0 || ordered.length > 1_000) {
+			throw new Error(
+				"Stream health requires between one and 1000 registry rows",
+			);
+		}
+		const batchSequence = this.#state.nextBatchSequence;
+		this.#state.nextBatchSequence = next(batchSequence);
+		const heartbeatAt = new Date().toISOString();
+		const active = ordered.filter(
+			(snapshot) => snapshot.registryStatus === "active",
+		).length;
+		const rows = ordered.map((snapshot) => {
+			const streamKey = key(snapshot);
+			const sequence = this.#state.nextStreamSequences[streamKey] ?? "1";
+			this.#state.nextStreamSequences[streamKey] = next(sequence);
+			return {
+				table: TABLE,
+				row: {
+					producer_id: PRODUCER_ID,
+					producer_epoch: this.#state.producerEpoch,
+					run_id: this.#state.runId,
+					batch_sequence: batchSequence,
+					batch_snapshot_count: String(ordered.length),
+					batch_active_stream_count: String(active),
+					registry_revision: registryRevision(ordered),
+					registry_status: snapshot.registryStatus,
+					retired_at: snapshot.retiredAt,
+					exchange: snapshot.exchange,
+					account_selector: snapshot.accountSelector,
+					account_role: snapshot.accountRole ?? null,
+					stream_kind: snapshot.streamKind,
+					account_scope: snapshot.accountScope,
+					sequence,
+					state: snapshot.state,
+					state_changed_at: snapshot.stateChangedAt,
+					last_connected_at: snapshot.lastConnectedAt,
+					last_authenticated_at: snapshot.lastAuthenticatedAt,
+					last_received_at: snapshot.lastReceivedAt,
+					heartbeat_at: heartbeatAt,
+					connect_attempt_count: snapshot.connectAttemptCount,
+					reconnect_count: snapshot.reconnectCount,
+					error_count: snapshot.errorCount,
+					last_failure_kind: snapshot.lastFailureKind,
+					last_failure_reason: snapshot.lastFailureReason,
+					traffic_mode: snapshot.trafficMode,
+					source_watermark: snapshot.sourceWatermark,
+				},
+			};
+		});
+		return JSON.stringify({
+			source: SOURCE,
+			deployment_id: this.#deploymentId,
+			rows,
+		});
+	}
+	#retryLater(): void {
+		if (this.#closed || this.#retry) return;
+		const delay = Math.min(1_000 * 2 ** this.#retryAttempt, 30_000);
+		this.#retryAttempt += 1;
+		this.#retry = setTimeout(() => {
+			this.#retry = null;
+			this.#schedule();
+		}, delay);
+		this.#retry.unref?.();
+	}
+	async #waitForIdle(): Promise<void> {
+		while (this.#pumping) await this.#pumping;
+	}
+	#read(): StateFile | null {
+		try {
+			const parsed = JSON.parse(
+				readFileSync(this.#statePath, "utf8"),
+			) as unknown;
+			if (!validState(parsed)) throw new Error("invalid state shape");
+			return parsed;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw new Error("Stream health state cannot be read", { cause: error });
+		}
+	}
+	#persist(): void {
+		const parent = dirname(this.#statePath);
+		try {
+			if (!statSync(parent).isDirectory())
+				throw new Error("state parent is not a directory");
+		} catch (error) {
+			throw new Error("Stream health state directory is unavailable", {
+				cause: error,
+			});
+		}
+		const temporary = `${this.#statePath}.${process.pid}.${randomUUID()}.tmp`;
+		let fd: number | undefined;
+		try {
+			fd = openSync(temporary, "wx", 0o600);
+			writeFileSync(fd, JSON.stringify(this.#state));
+			fsyncSync(fd);
+			closeSync(fd);
+			fd = undefined;
+			renameSync(temporary, this.#statePath);
+			const parentFd = openSync(parent, "r");
+			try {
+				fsyncSync(parentFd);
+			} finally {
+				closeSync(parentFd);
+			}
+		} catch (error) {
+			if (fd !== undefined) closeSync(fd);
+			try {
+				unlinkSync(temporary);
+			} catch {}
+			throw new Error("Stream health state cannot be persisted", {
+				cause: error,
+			});
+		}
+	}
+}
+
+export function streamHealthPublisherConfigFromEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): StreamHealthPublisherOptions {
+	if (env.CEX_BROKER_ARCHIVE_ENABLED !== "true") {
+		throw new Error(
+			"Configured account user streams require CEX_BROKER_ARCHIVE_ENABLED=true",
+		);
+	}
+	const deploymentId = env.CEX_BROKER_DEPLOYMENT_ID?.trim();
+	const forwarderUrl = env.CEX_BROKER_ARCHIVE_FORWARDER_URL?.trim();
+	const statePath = env.CEX_BROKER_STREAM_HEALTH_STATE_PATH?.trim();
+	if (!deploymentId || !forwarderUrl || !statePath) {
+		throw new Error(
+			"Configured account user streams require deployment, forwarder, and persistent state configuration",
+		);
+	}
+	return {
+		deploymentId,
+		forwarderUrl,
+		statePath,
+		forwarderAuthToken:
+			env.CEX_BROKER_ARCHIVE_FORWARDER_TOKEN?.trim() || undefined,
+	};
+}

--- a/src/helpers/user-data-stream-supervisor.ts
+++ b/src/helpers/user-data-stream-supervisor.ts
@@ -1,0 +1,366 @@
+import type { Exchange } from "@usherlabs/ccxt";
+import {
+	BinanceSpotUserDataStream,
+	type BinanceUserDataEvent,
+	type BinanceUserDataStreamFailureKind,
+	isBinanceBalanceUserDataEvent,
+	isBinanceOrderUserDataEvent,
+} from "./binance-user-data-stream";
+import type { BrokerAccount, BrokerPoolEntry } from "./broker";
+import { redactSecretLiterals } from "./broker-execution-archive/redact";
+import type {
+	StreamHealthFailureKind,
+	StreamHealthPublisher,
+	StreamHealthSnapshot,
+} from "./stream-health-publisher";
+
+const MAX_SUBSCRIBER_EVENTS = 16;
+
+export type UserDataSubscriptionKind = "balance" | "orders";
+export type UserDataSubscription = AsyncIterable<BinanceUserDataEvent> & {
+	close(): void;
+};
+export type UserDataStreamSupervisorOptions = {
+	brokers: Record<string, BrokerPoolEntry>;
+	publisher: StreamHealthPublisher;
+};
+
+type UserDataSubscriptionOptions = {
+	exchange: string;
+	accountSelector: string;
+	kind: UserDataSubscriptionKind;
+	marketId?: string;
+};
+
+function now(): string {
+	return new Date().toISOString();
+}
+
+function retryDelay(attempt: number): number {
+	return Math.min(1_000 * 2 ** attempt, 30_000);
+}
+
+function safeFailureReason(exchange: Exchange, reason: string): string {
+	const secrets = [exchange.apiKey, exchange.secret].filter(
+		(value): value is string => typeof value === "string" && value.length > 0,
+	);
+	return redactSecretLiterals(reason, secrets)
+		.replace(/\s+/g, " ")
+		.trim()
+		.slice(0, 256);
+}
+
+class Subscriber implements UserDataSubscription {
+	readonly #queue: BinanceUserDataEvent[] = [];
+	readonly #waiters: Array<{
+		resolve: (event: BinanceUserDataEvent | null) => void;
+		reject: (error: Error) => void;
+	}> = [];
+	#closed = false;
+	#error: Error | null = null;
+
+	constructor(
+		readonly kind: UserDataSubscriptionKind,
+		readonly marketId: string | undefined,
+		private readonly onClose: () => void,
+	) {}
+
+	push(message: BinanceUserDataEvent): void {
+		if (this.#closed || !this.#matches(message.event)) return;
+		const waiter = this.#waiters.shift();
+		if (waiter) {
+			waiter.resolve(message);
+			return;
+		}
+		if (this.#queue.length >= MAX_SUBSCRIBER_EVENTS) {
+			this.#fail(
+				new Error("Configured account user-data subscriber fell behind"),
+			);
+			return;
+		}
+		this.#queue.push(message);
+	}
+
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#queue.length = 0;
+		this.onClose();
+		for (const waiter of this.#waiters.splice(0)) waiter.resolve(null);
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterator<BinanceUserDataEvent> {
+		while (true) {
+			const event = await this.#next();
+			if (!event) return;
+			yield event;
+		}
+	}
+
+	#matches(event: Record<string, unknown>): boolean {
+		if (this.kind === "balance") return isBinanceBalanceUserDataEvent(event);
+		if (!isBinanceOrderUserDataEvent(event)) return false;
+		return !this.marketId || event.s === this.marketId;
+	}
+
+	#next(): Promise<BinanceUserDataEvent | null> {
+		const event = this.#queue.shift();
+		if (event) return Promise.resolve(event);
+		if (this.#error) return Promise.reject(this.#error);
+		if (this.#closed) return Promise.resolve(null);
+		return new Promise((resolve, reject) =>
+			this.#waiters.push({ resolve, reject }),
+		);
+	}
+
+	#fail(error: Error): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#error = error;
+		this.#queue.length = 0;
+		this.onClose();
+		for (const waiter of this.#waiters.splice(0)) waiter.reject(error);
+	}
+}
+
+class AccountWorker {
+	readonly #subscribers = new Set<Subscriber>();
+	#snapshot: StreamHealthSnapshot;
+	#stopping = false;
+	#stream: BinanceSpotUserDataStream | null = null;
+	#retryTimer: ReturnType<typeof setTimeout> | null = null;
+	#retryResolve: (() => void) | null = null;
+	#run: Promise<void> | null = null;
+	#failureObserved = false;
+	#attempts = 0;
+
+	constructor(
+		private readonly exchangeName: string,
+		private readonly account: BrokerAccount,
+		private readonly onChange: () => void,
+	) {
+		const timestamp = now();
+		this.#snapshot = {
+			exchange: exchangeName,
+			accountSelector: account.label,
+			accountRole: account.role,
+			streamKind: "user_data",
+			accountScope: "spot",
+			registryStatus: "active",
+			retiredAt: null,
+			state: "connecting",
+			stateChangedAt: timestamp,
+			lastConnectedAt: null,
+			lastAuthenticatedAt: null,
+			lastReceivedAt: null,
+			connectAttemptCount: "0",
+			reconnectCount: "0",
+			errorCount: "0",
+			lastFailureKind: "none",
+			lastFailureReason: "",
+			trafficMode: "event_driven",
+			sourceWatermark: null,
+		};
+	}
+
+	start(): void {
+		if (this.exchangeName !== "binance") {
+			this.#fail(
+				"unsupported_connector",
+				"Configured exchange has no user-data supervisor",
+			);
+			return;
+		}
+		this.#run = this.#connectLoop();
+	}
+
+	subscribe(
+		options: Omit<UserDataSubscriptionOptions, "exchange" | "accountSelector">,
+	): UserDataSubscription {
+		if (this.#stopping)
+			throw new Error("Configured account user-data supervisor is stopping");
+		const subscriber = new Subscriber(options.kind, options.marketId, () => {
+			this.#subscribers.delete(subscriber);
+		});
+		this.#subscribers.add(subscriber);
+		return subscriber;
+	}
+
+	snapshot(): StreamHealthSnapshot {
+		return { ...this.#snapshot };
+	}
+
+	async stop(): Promise<void> {
+		this.#stopping = true;
+		if (this.#retryTimer) clearTimeout(this.#retryTimer);
+		this.#retryTimer = null;
+		this.#retryResolve?.();
+		this.#retryResolve = null;
+		this.#stream?.close();
+		await this.#run;
+		this.#transition("disconnected", "shutdown", "Broker shutdown");
+		for (const subscriber of [...this.#subscribers]) subscriber.close();
+	}
+
+	#transition(
+		state: StreamHealthSnapshot["state"],
+		failureKind?: StreamHealthFailureKind,
+		failureReason?: string,
+	): void {
+		const timestamp = now();
+		if (this.#snapshot.state !== state) {
+			this.#snapshot.state = state;
+			this.#snapshot.stateChangedAt = timestamp;
+		}
+		if (failureKind) {
+			this.#snapshot.lastFailureKind = failureKind;
+			this.#snapshot.lastFailureReason = failureReason ?? "";
+		}
+		this.onChange();
+	}
+
+	#connected(): void {
+		this.#snapshot.lastConnectedAt = now();
+		this.#transition("connected");
+	}
+
+	#authenticated(): void {
+		this.#snapshot.lastAuthenticatedAt = now();
+		this.onChange();
+	}
+
+	#received(message: BinanceUserDataEvent): void {
+		this.#snapshot.lastReceivedAt = now();
+		const eventTimestamp = message.event.E;
+		this.#snapshot.sourceWatermark =
+			typeof eventTimestamp === "number" || typeof eventTimestamp === "string"
+				? String(eventTimestamp).slice(0, 512)
+				: null;
+		for (const subscriber of this.#subscribers) subscriber.push(message);
+		this.onChange();
+	}
+
+	#fail(kind: StreamHealthFailureKind, reason: string): void {
+		this.#failureObserved = true;
+		this.#snapshot.errorCount = (
+			BigInt(this.#snapshot.errorCount) + 1n
+		).toString();
+		this.#transition(
+			"error",
+			kind,
+			safeFailureReason(this.account.exchange, reason),
+		);
+	}
+
+	async #connectLoop(): Promise<void> {
+		while (!this.#stopping) {
+			if (this.#attempts > 0) {
+				this.#snapshot.reconnectCount = (
+					BigInt(this.#snapshot.reconnectCount) + 1n
+				).toString();
+			}
+			this.#attempts += 1;
+			this.#snapshot.connectAttemptCount = String(this.#attempts);
+			this.#failureObserved = false;
+			this.#transition("connecting");
+			const stream = new BinanceSpotUserDataStream(this.account.exchange, {
+				observer: {
+					onConnected: () => this.#connected(),
+					onAuthenticated: () => this.#authenticated(),
+					onEvent: (message) => this.#received(message),
+					onFailure: (failure) => this.#handleStreamFailure(failure),
+				},
+			});
+			this.#stream = stream;
+			try {
+				for await (const _event of stream) {
+					// Observer delivery fans out before this drain advances the socket queue.
+				}
+			} catch (error) {
+				if (!this.#stopping && !this.#failureObserved) {
+					this.#fail(
+						"transport_error",
+						error instanceof Error ? error.message : "User-data stream failed",
+					);
+				}
+			} finally {
+				stream.close();
+				if (this.#stream === stream) this.#stream = null;
+			}
+			if (!this.#stopping) await this.#waitForRetry();
+		}
+	}
+
+	#handleStreamFailure(failure: {
+		kind: BinanceUserDataStreamFailureKind;
+		reason: string;
+	}): void {
+		this.#fail(failure.kind, failure.reason);
+	}
+
+	#waitForRetry(): Promise<void> {
+		return new Promise((resolve) => {
+			const delay = retryDelay(Math.max(this.#attempts - 1, 0));
+			this.#retryResolve = resolve;
+			this.#retryTimer = setTimeout(() => {
+				this.#retryTimer = null;
+				this.#retryResolve = null;
+				resolve();
+			}, delay);
+			this.#retryTimer.unref?.();
+		});
+	}
+}
+
+/** Owns one physical authenticated venue stream for each configured account. */
+export class UserDataStreamSupervisor {
+	readonly #workers = new Map<string, AccountWorker>();
+	#started = false;
+
+	constructor(private readonly options: UserDataStreamSupervisorOptions) {
+		for (const [exchange, pool] of Object.entries(options.brokers)) {
+			for (const account of [pool.primary, ...pool.secondaryBrokers]) {
+				const normalizedExchange = exchange.trim().toLowerCase();
+				const worker = new AccountWorker(normalizedExchange, account, () =>
+					this.#publish(),
+				);
+				this.#workers.set(`${normalizedExchange}|${account.label}`, worker);
+			}
+		}
+		if (this.#workers.size === 0) {
+			throw new Error(
+				"User-data supervisor requires at least one configured account",
+			);
+		}
+	}
+
+	start(): void {
+		if (this.#started) return;
+		this.#started = true;
+		this.options.publisher.start();
+		for (const worker of this.#workers.values()) worker.start();
+		this.#publish();
+	}
+
+	subscribe(options: UserDataSubscriptionOptions): UserDataSubscription {
+		const exchange = options.exchange.trim().toLowerCase();
+		const worker = this.#workers.get(`${exchange}|${options.accountSelector}`);
+		if (!worker)
+			throw new Error("Configured account user-data stream is unavailable");
+		return worker.subscribe({ kind: options.kind, marketId: options.marketId });
+	}
+
+	async close(): Promise<void> {
+		for (const worker of this.#workers.values()) await worker.stop();
+		await this.options.publisher.close(this.#snapshots());
+	}
+
+	#snapshots(): StreamHealthSnapshot[] {
+		return [...this.#workers.values()].map((worker) => worker.snapshot());
+	}
+
+	#publish(): void {
+		if (!this.#started) return;
+		this.options.publisher.publish(this.#snapshots());
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,11 @@ import {
 	OtelLogs,
 	OtelMetrics,
 } from "./helpers/otel";
+import {
+	StreamHealthPublisher,
+	streamHealthPublisherConfigFromEnv,
+} from "./helpers/stream-health-publisher";
+import { UserDataStreamSupervisor } from "./helpers/user-data-stream-supervisor";
 import { getServer } from "./server";
 import {
 	type BrokerCredentials,
@@ -67,6 +72,7 @@ export default class CEXBroker {
 	private fillArchivePoller?: FillArchivePoller;
 	private depositArchivePoller?: DepositArchivePoller;
 	private accountBalanceArchivePoller?: AccountBalanceArchivePoller;
+	private userDataStreamSupervisor?: UserDataStreamSupervisor;
 
 	/**
 	 * Loads environment variables prefixed with CEX_BROKER_
@@ -302,6 +308,10 @@ export default class CEXBroker {
 		if (this.server) {
 			await this.server.forceShutdown();
 		}
+		if (this.userDataStreamSupervisor) {
+			await this.userDataStreamSupervisor.close();
+			this.userDataStreamSupervisor = undefined;
+		}
 		if (this.brokerArchiver) {
 			await this.brokerArchiver.close();
 		}
@@ -344,6 +354,19 @@ export default class CEXBroker {
 		if (this.otelMetrics?.isOtelEnabled()) {
 			await this.otelMetrics.initialize();
 		}
+		if (
+			!this.userDataStreamSupervisor &&
+			Object.keys(this.brokers).length > 0
+		) {
+			const publisher = new StreamHealthPublisher(
+				streamHealthPublisherConfigFromEnv(),
+			);
+			this.userDataStreamSupervisor = new UserDataStreamSupervisor({
+				brokers: this.brokers,
+				publisher,
+			});
+			this.userDataStreamSupervisor.start();
+		}
 
 		this.server = getServer(
 			this.policy,
@@ -356,6 +379,7 @@ export default class CEXBroker {
 			this.orderActivityTracker,
 			this.withdrawalObservationTracker,
 			undefined,
+			this.userDataStreamSupervisor,
 		);
 
 		this.server.bindAsync(

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import type {
 } from "./helpers/broker-execution-archive";
 import type { OrderActivityTracker } from "./helpers/order-activity-tracker";
 import type { OtelMetrics } from "./helpers/otel";
+import type { UserDataStreamSupervisor } from "./helpers/user-data-stream-supervisor";
 import { CEX_BROKER_PACKAGE_DEFINITION } from "./proto-package-definition";
 import type { PolicyConfig } from "./types";
 
@@ -34,6 +35,7 @@ export function getServer(
 	orderActivityTracker?: OrderActivityTracker,
 	withdrawalObservationTracker?: WithdrawalObservationTracker,
 	subscribeBrokerLifecycle?: SubscribeBrokerLifecycle,
+	userDataStreamSupervisor?: UserDataStreamSupervisor,
 ) {
 	const server = new grpc.Server();
 
@@ -55,6 +57,7 @@ export function getServer(
 			otelMetrics,
 			brokerArchiver,
 			brokerLifecycle: subscribeBrokerLifecycle,
+			userDataStreamSupervisor,
 		}),
 	});
 	return server;

--- a/test/stream-health-publisher.test.ts
+++ b/test/stream-health-publisher.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Exchange } from "@usherlabs/ccxt";
+import { validateStreamHealthArchiveBatch } from "../services/archive-forwarder/stream-health-contract";
+import {
+	StreamHealthPublisher,
+	type StreamHealthSnapshot,
+	streamHealthPublisherConfigFromEnv,
+} from "../src/helpers/stream-health-publisher";
+import { UserDataStreamSupervisor } from "../src/helpers/user-data-stream-supervisor";
+
+const directories: string[] = [];
+
+afterEach(() => {
+	for (const directory of directories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function statePath(): string {
+	const directory = mkdtempSync(join(tmpdir(), "cex-broker-stream-health-"));
+	directories.push(directory);
+	return join(directory, "state.json");
+}
+
+function snapshot(
+	overrides: Partial<StreamHealthSnapshot> = {},
+): StreamHealthSnapshot {
+	return {
+		exchange: "binance",
+		accountSelector: "primary",
+		streamKind: "user_data",
+		accountScope: "spot",
+		registryStatus: "active",
+		retiredAt: null,
+		state: "connected",
+		stateChangedAt: "2026-08-03T20:00:00.000Z",
+		lastConnectedAt: "2026-08-03T20:00:00.000Z",
+		lastAuthenticatedAt: "2026-08-03T20:00:01.000Z",
+		lastReceivedAt: null,
+		connectAttemptCount: "1",
+		reconnectCount: "0",
+		errorCount: "0",
+		lastFailureKind: "none",
+		lastFailureReason: "",
+		trafficMode: "event_driven",
+		sourceWatermark: null,
+		...overrides,
+	};
+}
+
+describe("stream health publisher", () => {
+	test("publishes a complete quiet connected socket row accepted by the stream health contract", async () => {
+		const sent: string[] = [];
+		const publisher = new StreamHealthPublisher({
+			deploymentId: "test-deployment",
+			statePath: statePath(),
+			forwarderUrl: "http://127.0.0.1:1/archive",
+			post: async (body) => sent.push(body),
+		});
+		publisher.start();
+		publisher.publish([snapshot()]);
+		await publisher.close([snapshot()]);
+		expect(sent.length).toBeGreaterThanOrEqual(1);
+		const body = JSON.parse(sent[0] ?? "{}") as Record<string, unknown>;
+		const validation = validateStreamHealthArchiveBatch(body);
+		expect(validation.ok).toBe(true);
+		const row = (body.rows as Array<{ row: Record<string, unknown> }>)[0]?.row;
+		expect(row?.stream_kind).toBe("user_data");
+		expect(row?.last_received_at).toBeNull();
+	});
+
+	test("retries one byte-identical pending batch before a fresh current snapshot", async () => {
+		const path = statePath();
+		const attempts: string[] = [];
+		let reachable = false;
+		const publisher = new StreamHealthPublisher({
+			deploymentId: "test-deployment",
+			statePath: path,
+			forwarderUrl: "http://127.0.0.1:1/archive",
+			post: async (body) => {
+				attempts.push(body);
+				if (!reachable) throw new Error("forwarder unavailable");
+			},
+		});
+		publisher.start();
+		publisher.publish([snapshot()]);
+		await Bun.sleep(10);
+		const pending = JSON.parse(readFileSync(path, "utf8")) as {
+			pendingBody?: string;
+		};
+		expect(pending.pendingBody).toBeDefined();
+		reachable = true;
+		await publisher.close([
+			snapshot({
+				errorCount: "1",
+				lastFailureKind: "transport_error",
+				lastFailureReason: "offline",
+			}),
+		]);
+		expect(attempts[1]).toBe(attempts[0]);
+		expect(attempts[0]).toBe(pending.pendingBody);
+		expect(attempts.at(-1)).not.toBe(pending.pendingBody);
+	});
+
+	test("drains persisted old-run work before atomically advancing the run", async () => {
+		const path = statePath();
+		const pendingPublisher = new StreamHealthPublisher({
+			deploymentId: "test-deployment",
+			statePath: path,
+			forwarderUrl: "http://127.0.0.1:1/archive",
+			post: async () => {
+				throw new Error("forwarder unavailable");
+			},
+		});
+		pendingPublisher.start();
+		pendingPublisher.publish([snapshot()]);
+		await Bun.sleep(10);
+		const oldPending = (
+			JSON.parse(readFileSync(path, "utf8")) as { pendingBody: string }
+		).pendingBody;
+		const sent: string[] = [];
+		const restarted = new StreamHealthPublisher({
+			deploymentId: "test-deployment",
+			statePath: path,
+			forwarderUrl: "http://127.0.0.1:1/archive",
+			post: async (body) => sent.push(body),
+		});
+		restarted.start();
+		restarted.publish([
+			snapshot({ lastReceivedAt: "2026-08-03T20:00:02.000Z" }),
+		]);
+		await restarted.close([
+			snapshot({ lastReceivedAt: "2026-08-03T20:00:02.000Z" }),
+		]);
+		expect(sent[0]).toBe(oldPending);
+		const oldRow = (
+			JSON.parse(oldPending).rows[0] as { row: Record<string, unknown> }
+		).row;
+		const newRow = (
+			JSON.parse(sent.at(-1) ?? "{}").rows[0] as {
+				row: Record<string, unknown>;
+			}
+		).row;
+		expect(newRow.producer_epoch).not.toBe(oldRow.producer_epoch);
+		expect(newRow.run_id).not.toBe(oldRow.run_id);
+	});
+
+	test("requires archive and persistent state configuration for configured streams", () => {
+		expect(() => streamHealthPublisherConfigFromEnv({})).toThrow(
+			"CEX_BROKER_ARCHIVE_ENABLED",
+		);
+		expect(() =>
+			streamHealthPublisherConfigFromEnv({
+				CEX_BROKER_ARCHIVE_ENABLED: "true",
+			}),
+		).toThrow("deployment, forwarder, and persistent state");
+	});
+
+	test("keeps an unsupported configured connector in the complete health batch", async () => {
+		const sent: string[] = [];
+		const supervisor = new UserDataStreamSupervisor({
+			brokers: {
+				bybit: {
+					primary: { exchange: {} as Exchange, label: "primary" },
+					secondaryBrokers: [],
+				},
+			},
+			publisher: new StreamHealthPublisher({
+				deploymentId: "test-deployment",
+				statePath: statePath(),
+				forwarderUrl: "http://127.0.0.1:1/archive",
+				post: async (body) => sent.push(body),
+			}),
+		});
+		supervisor.start();
+		await Bun.sleep(10);
+		await supervisor.close();
+		const first = JSON.parse(sent[0] ?? "{}") as {
+			rows?: Array<{ row?: Record<string, unknown> }>;
+		};
+		expect(first.rows?.[0]?.row).toMatchObject({
+			exchange: "bybit",
+			state: "error",
+			last_failure_kind: "unsupported_connector",
+		});
+	});
+});

--- a/test/subscribe-user-stream.test.ts
+++ b/test/subscribe-user-stream.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import type { Exchange } from "@usherlabs/ccxt";
-import type { BrokerExecutionArchiver } from "../src/helpers/broker-execution-archive";
-import type { BrokerArchiveRow } from "../src/helpers/broker-execution-archive/types";
 import {
 	BinanceSpotUserDataStream,
 	setBinanceUserDataWebSocketFactoryForTests,
 } from "../src/helpers/binance-user-data-stream";
 import type { BrokerPoolEntry } from "../src/helpers/broker";
+import type { BrokerExecutionArchiver } from "../src/helpers/broker-execution-archive";
+import type { BrokerArchiveRow } from "../src/helpers/broker-execution-archive/types";
 import { SubscriptionType } from "../src/helpers/constants";
+import { StreamHealthPublisher } from "../src/helpers/stream-health-publisher";
+import { UserDataStreamSupervisor } from "../src/helpers/user-data-stream-supervisor";
 import { PROTO_LOADER_OPTIONS } from "../src/proto-loader-options";
 import { getServer } from "../src/server";
 import type { PolicyConfig } from "../src/types";
@@ -44,6 +49,7 @@ const testPolicy: PolicyConfig = {
 	deposit: {},
 	order: { rule: { markets: [], limits: [] } },
 };
+let configuredSubscriptionCount = 0;
 
 class FakeWebSocket {
 	static instances: FakeWebSocket[] = [];
@@ -283,15 +289,23 @@ function bindServer(server: grpc.Server) {
 	});
 }
 
-async function waitForSocket(): Promise<FakeWebSocket> {
-	for (let attempt = 0; attempt < 20; attempt += 1) {
-		const socket = FakeWebSocket.instances.at(-1);
-		if (socket?.sent.length) {
-			return socket;
-		}
-		await new Promise((resolve) => setTimeout(resolve, 0));
-	}
-	throw new Error("Fake Binance WebSocket was not opened");
+async function waitForSocket(apiKey?: string): Promise<FakeWebSocket> {
+	let socket: FakeWebSocket | undefined;
+	await waitFor(() => {
+		socket = apiKey
+			? FakeWebSocket.instances.find((candidate) => {
+					const request = JSON.parse(candidate.sent[0] ?? "{}") as {
+						params?: { apiKey?: string };
+					};
+					return request.params?.apiKey === apiKey;
+				})
+			: FakeWebSocket.instances.at(-1);
+		return Boolean(
+			socket?.sent.length && (!apiKey || configuredSubscriptionCount > 0),
+		);
+	});
+	if (!socket) throw new Error("Fake Binance WebSocket was not opened");
+	return socket;
 }
 
 async function waitFor(
@@ -335,23 +349,20 @@ function subscribeOnce(
 	});
 }
 
-function getSubscribeError(response: { data: string }): string {
-	const payload = JSON.parse(response.data) as { error?: unknown };
-	expect(typeof payload.error).toBe("string");
-	return payload.error as string;
-}
-
 describe("Binance Subscribe user-data streams", () => {
 	const originalWebSocket = globalThis.WebSocket;
 	let resetWebSocketFactory: (() => void) | undefined;
 	let server: grpc.Server | undefined;
 	let client: InstanceType<typeof grpcObj.cex_broker.cex_service> | undefined;
+	let supervisor: UserDataStreamSupervisor | undefined;
+	let supervisorStateDirectory: string | undefined;
 
 	beforeEach(() => {
 		resetWebSocketFactory = setBinanceUserDataWebSocketFactoryForTests(
 			(url) => new FakeWebSocket(url),
 		);
 		(globalThis as { WebSocket?: typeof WebSocket }).WebSocket = undefined;
+		configuredSubscriptionCount = 0;
 	});
 
 	afterEach(async () => {
@@ -363,8 +374,15 @@ describe("Binance Subscribe user-data streams", () => {
 		if (server) {
 			await server.forceShutdown();
 		}
+		await supervisor?.close();
+		if (supervisorStateDirectory) {
+			rmSync(supervisorStateDirectory, { recursive: true, force: true });
+		}
 		server = undefined;
 		client = undefined;
+		supervisor = undefined;
+		supervisorStateDirectory = undefined;
+		configuredSubscriptionCount = 0;
 	});
 
 	async function startClient(
@@ -372,14 +390,37 @@ describe("Binance Subscribe user-data streams", () => {
 		secondaryExchange: Exchange,
 		brokerArchiver?: BrokerExecutionArchiver,
 	) {
+		const brokers = createBinancePool(primaryExchange, secondaryExchange);
+		supervisorStateDirectory = mkdtempSync(
+			join(tmpdir(), "cex-broker-user-data-supervisor-"),
+		);
+		supervisor = new UserDataStreamSupervisor({
+			brokers,
+			publisher: new StreamHealthPublisher({
+				deploymentId: "test-deployment",
+				statePath: join(supervisorStateDirectory, "state.json"),
+				forwarderUrl: "http://127.0.0.1:1/archive",
+				post: async () => {},
+			}),
+		});
+		const subscribe = supervisor.subscribe.bind(supervisor);
+		supervisor.subscribe = (options) => {
+			configuredSubscriptionCount += 1;
+			return subscribe(options);
+		};
+		supervisor.start();
 		server = getServer(
 			testPolicy,
-			createBinancePool(primaryExchange, secondaryExchange),
+			brokers,
 			["*"],
 			false,
 			"",
 			undefined,
 			brokerArchiver,
+			undefined,
+			undefined,
+			undefined,
+			supervisor,
 		);
 		const port = await bindServer(server);
 		client = new grpcObj.cex_broker.cex_service(
@@ -514,7 +555,7 @@ describe("Binance Subscribe user-data streams", () => {
 			symbol: "BTC/USDT",
 			type: SubscriptionType.BALANCE,
 		});
-		const socket = await waitForSocket();
+		const socket = await waitForSocket("primary-key");
 		const subscribeRequest = JSON.parse(socket.sent[0] ?? "{}") as {
 			method?: string;
 			params?: { apiKey?: string };
@@ -571,6 +612,61 @@ describe("Binance Subscribe user-data streams", () => {
 		}
 	});
 
+	test("fans configured balance and order subscribers out from one account socket", async () => {
+		const primary = createBinanceExchange("primary-key", "primary-secret");
+		const secondary = createBinanceExchange(
+			"secondary-key",
+			"secondary-secret",
+		);
+		const subscribeClient = await startClient(
+			primary.exchange,
+			secondary.exchange,
+		);
+		const balance = subscribeOnce(subscribeClient, {
+			cex: "binance",
+			symbol: "BTC/USDT",
+			type: SubscriptionType.BALANCE,
+		});
+		const orders = subscribeOnce(subscribeClient, {
+			cex: "binance",
+			symbol: "BTC/USDT",
+			type: SubscriptionType.ORDERS,
+		});
+		const socket = await waitForSocket("primary-key");
+		expect(
+			FakeWebSocket.instances.filter((candidate) => {
+				const request = JSON.parse(candidate.sent[0] ?? "{}") as {
+					params?: { apiKey?: string };
+				};
+				return request.params?.apiKey === "primary-key";
+			}),
+		).toHaveLength(1);
+		socket.emitEvent({
+			e: "outboundAccountPosition",
+			E: 1_700_000_000_000,
+			B: [{ a: "BTC", f: "1", l: "0" }],
+		});
+		expect((await balance).type).toBe("BALANCE");
+		socket.emitEvent({
+			e: "executionReport",
+			E: 1_700_000_000_001,
+			s: "BTCUSDT",
+			i: 1,
+			c: "client-1",
+			X: "NEW",
+			q: "1",
+			z: "0",
+			p: "100",
+			Z: "0",
+			O: 1_700_000_000_000,
+			T: 1_700_000_000_001,
+			t: -1,
+			n: "0",
+			N: null,
+		});
+		expect((await orders).type).toBe("ORDERS");
+	});
+
 	test("refreshes the authoritative primary balance for balanceUpdate", async () => {
 		const authoritativeBalance = {
 			free: { BTC: 2.5, USDT: 10 },
@@ -593,7 +689,7 @@ describe("Binance Subscribe user-data streams", () => {
 			type: SubscriptionType.BALANCE,
 		});
 
-		const socket = await waitForSocket();
+		const socket = await waitForSocket("primary-key");
 		socket.emitEvent({
 			e: "balanceUpdate",
 			E: 1_700_000_000_000,
@@ -637,7 +733,7 @@ describe("Binance Subscribe user-data streams", () => {
 			metadata,
 		);
 
-		const socket = await waitForSocket();
+		const socket = await waitForSocket("secondary-key");
 		socket.emitEvent({
 			e: "externalLockUpdate",
 			E: 1_700_000_000_010,
@@ -674,7 +770,7 @@ describe("Binance Subscribe user-data streams", () => {
 			},
 			metadata,
 		);
-		const socket = await waitForSocket();
+		const socket = await waitForSocket("secondary-key");
 		const subscribeRequest = JSON.parse(socket.sent[0] ?? "{}") as {
 			method?: string;
 			params?: { apiKey?: string };
@@ -743,7 +839,7 @@ describe("Binance Subscribe user-data streams", () => {
 			symbol: "BTC/USDT",
 			type: SubscriptionType.ORDERS,
 		});
-		const socket = await waitForSocket();
+		const socket = await waitForSocket("primary-key");
 		const listStatus = {
 			e: "listStatus",
 			E: 1_700_000_000_100,
@@ -798,7 +894,7 @@ describe("Binance Subscribe user-data streams", () => {
 		}
 	});
 
-	test("surfaces ws error event diagnostics without leaking signed params", async () => {
+	test("keeps configured subscribers registered across a ws error", async () => {
 		expect(globalThis.WebSocket).toBeUndefined();
 		const primary = createBinanceExchange("primary-key", "primary-secret");
 		const secondary = createBinanceExchange(
@@ -810,12 +906,13 @@ describe("Binance Subscribe user-data streams", () => {
 			secondary.exchange,
 		);
 
-		const responsePromise = subscribeOnce(subscribeClient, {
+		const stream = subscribeClient.Subscribe({
 			cex: "binance",
 			symbol: "BTC/USDT",
 			type: SubscriptionType.BALANCE,
 		});
-		const socket = await waitForSocket();
+		stream.on("error", () => {});
+		const socket = await waitForSocket("primary-key");
 		socket.emitError({
 			error: new Error(
 				"proxy refused event.error apiKey=primary-key secret=primary-secret signature=deadbeef",
@@ -823,19 +920,14 @@ describe("Binance Subscribe user-data streams", () => {
 			message: "fallback transport message",
 		});
 
-		const error = getSubscribeError(await responsePromise);
-		expect(error).toContain(
-			"Binance user-data WebSocket error: proxy refused event.error",
-		);
-		expect(error).toContain("apiKey=[redacted]");
-		expect(error).toContain("secret=[redacted]");
-		expect(error).toContain("signature=[redacted]");
-		expect(error).not.toContain("primary-key");
-		expect(error).not.toContain("primary-secret");
-		expect(error).not.toContain("deadbeef");
+		await waitFor(() => FakeWebSocket.instances.length >= 3);
+		expect(
+			FakeWebSocket.instances.filter((candidate) => candidate.closed),
+		).toHaveLength(1);
+		stream.cancel();
 	});
 
-	test("surfaces ws error message diagnostics without leaking secrets", async () => {
+	test("keeps configured subscribers registered across an error message", async () => {
 		expect(globalThis.WebSocket).toBeUndefined();
 		const primary = createBinanceExchange("primary-key", "primary-secret");
 		const secondary = createBinanceExchange(
@@ -847,30 +939,23 @@ describe("Binance Subscribe user-data streams", () => {
 			secondary.exchange,
 		);
 
-		const responsePromise = subscribeOnce(subscribeClient, {
+		const stream = subscribeClient.Subscribe({
 			cex: "binance",
 			symbol: "BTC/USDT",
 			type: SubscriptionType.BALANCE,
 		});
-		const socket = await waitForSocket();
+		stream.on("error", () => {});
+		const socket = await waitForSocket("primary-key");
 		socket.emitError({
 			message:
 				"transport refused event.message apiKey=primary-key secret=primary-secret signature=feedface",
 		});
 
-		const error = getSubscribeError(await responsePromise);
-		expect(error).toContain(
-			"Binance user-data WebSocket error: transport refused event.message",
-		);
-		expect(error).toContain("apiKey=[redacted]");
-		expect(error).toContain("secret=[redacted]");
-		expect(error).toContain("signature=[redacted]");
-		expect(error).not.toContain("primary-key");
-		expect(error).not.toContain("primary-secret");
-		expect(error).not.toContain("feedface");
+		await waitFor(() => FakeWebSocket.instances.length >= 3);
+		stream.cancel();
 	});
 
-	test("surfaces abnormal ws close code and reason without leaking secrets", async () => {
+	test("keeps configured subscribers registered across a remote close", async () => {
 		expect(globalThis.WebSocket).toBeUndefined();
 		const primary = createBinanceExchange("primary-key", "primary-secret");
 		const secondary = createBinanceExchange(
@@ -882,12 +967,13 @@ describe("Binance Subscribe user-data streams", () => {
 			secondary.exchange,
 		);
 
-		const responsePromise = subscribeOnce(subscribeClient, {
+		const stream = subscribeClient.Subscribe({
 			cex: "binance",
 			symbol: "BTC/USDT",
 			type: SubscriptionType.BALANCE,
 		});
-		const socket = await waitForSocket();
+		stream.on("error", () => {});
+		const socket = await waitForSocket("primary-key");
 		socket.emitClose(
 			1011,
 			Buffer.from(
@@ -895,15 +981,7 @@ describe("Binance Subscribe user-data streams", () => {
 			),
 		);
 
-		const error = getSubscribeError(await responsePromise);
-		expect(error).toContain("Binance user-data WebSocket closed unexpectedly");
-		expect(error).toContain("code=1011");
-		expect(error).toContain("reason=upstream closed");
-		expect(error).toContain("apiKey=[redacted]");
-		expect(error).toContain("secret=[redacted]");
-		expect(error).toContain("signature=[redacted]");
-		expect(error).not.toContain("primary-key");
-		expect(error).not.toContain("primary-secret");
-		expect(error).not.toContain("abc123");
+		await waitFor(() => FakeWebSocket.instances.length >= 3);
+		stream.cancel();
 	});
 });


### PR DESCRIPTION
## Summary

- supervise one Binance user-data socket per configured account and fan events to balance and order subscribers
- publish durable complete configured-account stream-health snapshots with bounded retry and replay
- keep supplied API credentials scoped to their individual requests

## Verification

- `bun test`
- `bunx biome check` on the changed files
- `bunx tsc --noEmit`