### PR TITLE
fix: admit Maker orchestrator strategy archive batches

### DIFF
--- a/openspec/specs/strategy-runtime-archive-ingestion/spec.md
+++ b/openspec/specs/strategy-runtime-archive-ingestion/spec.md
@@ -5,16 +5,26 @@ TBD - created by archiving change maker-archive-forwarder-conformance. Update Pu
 ## Requirements
 ### Requirement: Strategy runtime requests use a closed envelope contract
 
-The archive forwarder MUST accept a strategy runtime request only when its non-empty envelope source is `hb_runtime`, its deployment id is non-empty, it contains between one and 1000 rows, and every row targets an approved strategy runtime table.
+The archive forwarder MUST accept a strategy runtime request only when its non-empty envelope source belongs to exactly the admitted producer set `{hb_runtime, maker_orchestrator}`, its deployment id is non-empty, it contains between one and 1000 rows, and every row targets an approved strategy runtime table.
 
 The approved table set SHALL be exactly `strategy_data.policy_evaluation_events`, `strategy_data.strategy_policy_snapshots`, `strategy_data.market_identity`, `strategy_data.symbol_mapping`, and `strategy_data.inventory_settlement_events`.
+
+Conforming batches from either admitted producer MUST enter the same durable strategy-spool ownership path and return HTTP 202 without direct synchronous ClickHouse insertion.
 
 #### Scenario: All five strategy tables are submitted
 - **WHEN** one `hb_runtime` envelope contains conforming rows for all five approved tables
 - **THEN** the request MUST pass strategy contract validation
 
+#### Scenario: Maker orchestrator strategy rows are submitted
+- **WHEN** one `maker_orchestrator` envelope contains conforming rows for an approved strategy table
+- **THEN** the request MUST pass strategy contract validation
+
+#### Scenario: Either admitted producer transfers durable ownership
+- **WHEN** a conforming `hb_runtime` or `maker_orchestrator` strategy envelope is submitted
+- **THEN** the forwarder MUST durably admit it to the strategy spool and return HTTP 202 without direct ClickHouse insertion
+
 #### Scenario: Strategy and non-strategy rows are mixed
-- **WHEN** an `hb_runtime` envelope contains an approved strategy table and any non-strategy table
+- **WHEN** an envelope from either admitted producer contains an approved strategy table and any non-strategy table
 - **THEN** the entire request MUST be rejected with HTTP 400 before durable admission or ClickHouse insertion
 
 #### Scenario: Strategy table uses another source
@@ -53,10 +63,10 @@ Version `2` rows MUST contain non-empty `producer_id`, `producer_run_id`, `strea
 
 ### Requirement: Envelope and row provenance agree
 
-When a strategy row supplies `source` or `deployment_id`, its value MUST equal the corresponding envelope value. Credentials and broker configuration MUST NOT supply or override these Maker identities.
+When a strategy row supplies `source` or `deployment_id`, its value MUST equal the corresponding envelope value. Credentials and broker configuration MUST NOT supply or override these producer identities.
 
-#### Scenario: Row source differs from envelope
-- **WHEN** a row declares a source other than the envelope source
+#### Scenario: Row source differs across admitted producers
+- **WHEN** an `hb_runtime` envelope contains a row declaring `maker_orchestrator`, or a `maker_orchestrator` envelope contains a row declaring `hb_runtime`
 - **THEN** the entire request MUST be rejected before admission
 
 #### Scenario: Row deployment differs from envelope
@@ -91,9 +101,8 @@ The CEX Broker contract fixture MUST equal the pinned Maker `archive_forwarder_e
 
 ### Requirement: Non-strategy archive behavior remains compatible
 
-Requests that contain no strategy table and do not use `hb_runtime` MUST retain the existing direct ClickHouse insertion and synchronous success/failure contract.
+Requests that contain no strategy table and do not use either admitted strategy producer MUST retain the existing direct ClickHouse insertion and synchronous success/failure contract.
 
 #### Scenario: Broker market rows are submitted
 - **WHEN** a valid `broker_read` or `broker_write` request contains only supported non-strategy rows
 - **THEN** the forwarder MUST insert them through the existing direct path and MUST NOT consume strategy spool quota
-

--- a/services/archive-forwarder/strategy-contract.ts
+++ b/services/archive-forwarder/strategy-contract.ts
@@ -1,6 +1,9 @@
 import type { ArchiveBatchRequest, ArchiveRow } from "./types";
 
-export const STRATEGY_ARCHIVE_SOURCE = "hb_runtime";
+export const STRATEGY_ARCHIVE_SOURCES: ReadonlySet<string> = new Set([
+	"hb_runtime",
+	"maker_orchestrator",
+]);
 
 export const STRATEGY_ARCHIVE_TABLES = [
 	"strategy_data.policy_evaluation_events",
@@ -58,7 +61,7 @@ export function classifyStrategyArchiveBatch(
 		isStrategyArchiveTable(entryTable(entry)),
 	);
 
-	if (source === STRATEGY_ARCHIVE_SOURCE) {
+	if (typeof source === "string" && STRATEGY_ARCHIVE_SOURCES.has(source)) {
 		return rows.length > 0 && rows.every((entry) =>
 			isStrategyArchiveTable(entryTable(entry)),
 		)

--- a/test/archive-forwarder-strategy-contract.test.ts
+++ b/test/archive-forwarder-strategy-contract.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
+	STRATEGY_ARCHIVE_SOURCES,
 	classifyStrategyArchiveBatch,
 	validateStrategyArchiveBatch,
 } from "../services/archive-forwarder/strategy-contract";
 import fixture from "./fixtures/archive_forwarder_envelope.json";
+import makerOrchestratorFixture from "./fixtures/maker_orchestrator_archive_envelope.json";
 
 const PINNED_MAKER_FIXTURE_SHA256 =
 	"5c9fd679a5a05ebce5f5158f4cc376360f24a34d9a07edeee43e94e564db3ee7";
@@ -52,6 +54,38 @@ describe("Maker strategy archive contract", () => {
 	test("accepts one v2 row for every approved strategy table", () => {
 		const rows = strategyTables.map((table, index) => v2Row(table, index + 1));
 		expect(validateStrategyArchiveBatch(batch(rows))).toEqual({ ok: true });
+	});
+
+	test("classifies both admitted strategy producers", () => {
+		expect(STRATEGY_ARCHIVE_SOURCES).toEqual(
+			new Set(["hb_runtime", "maker_orchestrator"]),
+		);
+		expect(classifyStrategyArchiveBatch(fixture)).toBe("strategy");
+		expect(classifyStrategyArchiveBatch(makerOrchestratorFixture)).toBe(
+			"strategy",
+		);
+		expect(validateStrategyArchiveBatch(makerOrchestratorFixture)).toEqual({
+			ok: true,
+		});
+	});
+
+	test("rejects an unknown producer carrying strategy rows", () => {
+		expect(
+			classifyStrategyArchiveBatch({
+				...makerOrchestratorFixture,
+				source: "unknown_runtime",
+			}),
+		).toBe("invalid_strategy_source");
+	});
+
+	test("rejects cross-producer row and envelope provenance", () => {
+		const hbEnvelopeWithMakerRow = structuredClone(fixture);
+		hbEnvelopeWithMakerRow.rows[0].row.source = "maker_orchestrator";
+		expect(validateStrategyArchiveBatch(hbEnvelopeWithMakerRow).ok).toBe(false);
+
+		const makerEnvelopeWithHbRow = structuredClone(makerOrchestratorFixture);
+		makerEnvelopeWithHbRow.rows[0].row.source = "hb_runtime";
+		expect(validateStrategyArchiveBatch(makerEnvelopeWithHbRow).ok).toBe(false);
 	});
 
 	test.each([
@@ -104,7 +138,7 @@ describe("Maker strategy archive contract", () => {
 		expect(validateStrategyArchiveBatch(batch([])).ok).toBe(false);
 	});
 
-	test("rejects mixed tables, mixed sources, and row provenance mismatch", () => {
+	test("rejects mixed tables and row deployment mismatch", () => {
 		const strategy = v2Row("strategy_data.policy_evaluation_events", 1);
 		expect(
 			validateStrategyArchiveBatch(
@@ -114,13 +148,6 @@ describe("Maker strategy archive contract", () => {
 				]),
 			).ok,
 		).toBe(false);
-		expect(
-			classifyStrategyArchiveBatch({
-				source: "broker_write",
-				deployment_id: "maker-a",
-				rows: [strategy],
-			}),
-		).toBe("invalid_strategy_source");
 		strategy.row.deployment_id = "maker-b";
 		expect(validateStrategyArchiveBatch(batch([strategy])).ok).toBe(false);
 	});

--- a/test/archive-forwarder-strategy-contract.test.ts
+++ b/test/archive-forwarder-strategy-contract.test.ts
@@ -69,14 +69,17 @@ describe("Maker strategy archive contract", () => {
 		});
 	});
 
-	test("rejects an unknown producer carrying strategy rows", () => {
-		expect(
-			classifyStrategyArchiveBatch({
-				...makerOrchestratorFixture,
-				source: "unknown_runtime",
-			}),
-		).toBe("invalid_strategy_source");
-	});
+	test.each(["unknown_runtime", "broker_read", "broker_write"])(
+		"rejects %s carrying strategy rows",
+		(source) => {
+			expect(
+				classifyStrategyArchiveBatch({
+					...makerOrchestratorFixture,
+					source,
+				}),
+			).toBe("invalid_strategy_source");
+		},
+	);
 
 	test("rejects cross-producer row and envelope provenance", () => {
 		const hbEnvelopeWithMakerRow = structuredClone(fixture);

--- a/test/archive-forwarder-strategy-contract.test.ts
+++ b/test/archive-forwarder-strategy-contract.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
-	STRATEGY_ARCHIVE_SOURCES,
 	classifyStrategyArchiveBatch,
+	STRATEGY_ARCHIVE_SOURCES,
 	validateStrategyArchiveBatch,
 } from "../services/archive-forwarder/strategy-contract";
 import fixture from "./fixtures/archive_forwarder_envelope.json";
@@ -69,17 +69,18 @@ describe("Maker strategy archive contract", () => {
 		});
 	});
 
-	test.each(["unknown_runtime", "broker_read", "broker_write"])(
-		"rejects %s carrying strategy rows",
-		(source) => {
-			expect(
-				classifyStrategyArchiveBatch({
-					...makerOrchestratorFixture,
-					source,
-				}),
-			).toBe("invalid_strategy_source");
-		},
-	);
+	test.each([
+		"unknown_runtime",
+		"broker_read",
+		"broker_write",
+	])("rejects %s carrying strategy rows", (source) => {
+		expect(
+			classifyStrategyArchiveBatch({
+				...makerOrchestratorFixture,
+				source,
+			}),
+		).toBe("invalid_strategy_source");
+	});
 
 	test("rejects cross-producer row and envelope provenance", () => {
 		const hbEnvelopeWithMakerRow = structuredClone(fixture);

--- a/test/archive-forwarder-strategy-request.test.ts
+++ b/test/archive-forwarder-strategy-request.test.ts
@@ -6,6 +6,7 @@ import {
 	type ArchiveMetricsRecorder,
 } from "../services/archive-forwarder/telemetry";
 import fixture from "./fixtures/archive_forwarder_envelope.json";
+import makerOrchestratorFixture from "./fixtures/maker_orchestrator_archive_envelope.json";
 
 const noopRecorder: ArchiveMetricsRecorder = {
 	recordCounter: () => {},
@@ -37,6 +38,29 @@ describe("strategy durable HTTP admission", () => {
 		expect(spool.stats()).toMatchObject({
 			queuedBatches: 1,
 			queuedWork: fixture.rows.length,
+		});
+		spool.close();
+	});
+
+	test("durably admits Maker orchestrator rows without waiting for ClickHouse", async () => {
+		const spool = new StrategyArchiveSpool({ path: ":memory:" });
+		let insertCalled = false;
+		const response = await handleArchiveRequest(
+			post(makerOrchestratorFixture),
+			{
+				inserter: async () => {
+					insertCalled = true;
+					throw new Error("ClickHouse is down");
+				},
+				spool,
+				telemetry: new ArchiveForwarderTelemetry(noopRecorder),
+			},
+		);
+		expect(response.status).toBe(202);
+		expect(insertCalled).toBe(false);
+		expect(spool.stats()).toMatchObject({
+			queuedBatches: 1,
+			queuedWork: makerOrchestratorFixture.rows.length,
 		});
 		spool.close();
 	});

--- a/test/fixtures/maker_orchestrator_archive_envelope.json
+++ b/test/fixtures/maker_orchestrator_archive_envelope.json
@@ -1,0 +1,35 @@
+{
+  "source": "maker_orchestrator",
+  "deployment_id": "maker-deployment",
+  "rows": [
+    {
+      "table": "strategy_data.inventory_settlement_events",
+      "row": {
+        "source": "maker_orchestrator",
+        "deployment_id": "maker-deployment",
+        "schema_version": "2",
+        "producer_id": "maker_orchestrator:maker-deployment:orchestrator",
+        "producer_run_id": "run-1",
+        "controller_id": "orchestrator",
+        "controller_type": "maker_orchestrator",
+        "connector_name": "",
+        "exchange": "",
+        "trading_pair": "",
+        "market_id": "pool-1",
+        "run_id": "run-1",
+        "seq": 1,
+        "stream_name": "maker_runtime_state",
+        "stream_seq": 1,
+        "archive_event_id": "run-1:maker_runtime_state:1",
+        "event_time_ms": 1719999999997,
+        "emitted_at_ms": 1720000000000,
+        "event_kind": "orchestrator_retained_state",
+        "token": "ARB",
+        "account": "wallet",
+        "reservation_id": "reservation-1",
+        "workflow_state": "published",
+        "payload_json": "{\"pool_id\":\"pool-1\"}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

The archive forwarder admits exactly one strategy producer. `strategy-contract.ts` defined
`STRATEGY_ARCHIVE_SOURCE = "hb_runtime"`, so any strategy-table batch whose envelope source
is `maker_orchestrator` classified as `invalid_strategy_source` and was refused with HTTP 400
before spooling or storage.

The Maker orchestrator is a real, distinct producer: it stamps `maker_orchestrator` as the
envelope source, row source, controller type, and producer id. Since the archive-forwarder
rollout on 2026-08-03, its strategy rows have been rejected outright — production Maker
archive rows stopped at the rollout boundary, with roughly 3,142 archive POST failures
observed over ~23 hours.

Runtime decisions are fire-and-forget, so trading behavior is unaffected; what breaks is
replay completeness and operational evidence — retained state and deltas, settlement checks
and status, shared-funding lineage, transfer lifecycle, and Maker market-health snapshots.

## Change

Widen the strategy producer admission set to exactly `{hb_runtime, maker_orchestrator}`.

`STRATEGY_ARCHIVE_SOURCE` is replaced by a single canonical `STRATEGY_ARCHIVE_SOURCES` set;
no consumer hard-codes a producer string. `request.ts` needed no change, because the
classification value it branches on is unchanged — both producers therefore reach the same
durable strategy-spool path and the same 202 ownership contract.

The producer identity is deliberately preserved rather than normalized. Relabeling Maker rows
as `hb_runtime` would have made replay provenance false, which is worse than the rejection it
would have papered over.

Everything else in the gate remains fail-closed and untouched:

- unknown sources carrying strategy rows are still rejected;
- an admitted source mixing strategy and non-strategy tables is still rejected;
- row/envelope source equality still holds per producer, so an `hb_runtime` envelope cannot
  carry a `maker_orchestrator` row, or vice versa;
- deployment-id equality, envelope identity, row-count bounds, and the v2 `schema_version`
  rules are unchanged;
- non-strategy `broker_read` / `broker_write` traffic still takes the direct synchronous
  insert path;
- the five approved `strategy_data.*` tables are unchanged.

`openspec/specs/strategy-runtime-archive-ingestion/spec.md` is updated to describe the
two-producer admission set, since it previously mandated hb_runtime-only and would otherwise
contradict the code.

## Tests

New `maker_orchestrator` fixture built from the Maker orchestrator's actual serialized wire
shape (`stream_name`, `event_kind`, and `schema_version` verified against the producer's
own wire-contract test) rather than a synthesized guess. The existing shared
`archive_forwarder_envelope.json` is deliberately left untouched — it is byte-pinned here and
mirrored by a parity test on the Maker side.

Added coverage:

- a request/spool test proving a `maker_orchestrator` envelope reaches durable admission
  (202, no ClickHouse insert, one queued batch);
- classification of both admitted producers;
- rejection of `unknown_runtime`, `broker_read`, and `broker_write` carrying strategy rows;
- rejection of cross-producer row/envelope provenance in both directions.

The defect-focused test was demonstrated failing on the unfixed parent (`expected 202,
received 400`) before the fix was accepted.

Verification:

- `bun test test/archive-forwarder-strategy-contract.test.ts test/archive-forwarder-strategy-request.test.ts` — 24 pass, 0 fail
- full suite — 601 pass, 0 fail
- `biome check` over `test/` and `services/archive-forwarder/` — clean
- `tsc --noEmit` — clean

## Notes for review

- Branched from `develop`. #108 independently refactors the same constant into a source array
  while adding `maker_replay` and splitting the classification enum, so whichever lands second
  will need a small conflict resolution on those lines. The resolution is mechanical either
  way: on top of #108 this reduces to one additional entry in its source set.
- Scope is the admission contract only. Image publication, deployment, and live ClickHouse
  readback are tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Strategy archive submissions are now accepted from both `hb_runtime` and `maker_orchestrator`.
  - Accepted submissions receive HTTP 202 after durable queuing, without waiting for synchronous database insertion.
  - Provenance validation now rejects mismatches between envelope producers and row sources.
  - Other archive requests retain their existing synchronous processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->