### PR TITLE
test: bound the ClickHouse availability probe and report why it failed

### DIFF
--- a/test/clickhouse-schema.integration.test.ts
+++ b/test/clickhouse-schema.integration.test.ts
@@ -40,7 +40,17 @@ function requireClient(): ClickHouseClient {
 	return client;
 }
 
-async function probeClickHouse(): Promise<boolean> {
+// An unreachable host normally refuses the connection immediately, but a
+// half-started server can accept the socket and never answer. Without a
+// deadline the probe would block beforeAll indefinitely and the file would be
+// reported as a wall of per-test timeouts naming neither ClickHouse nor the
+// URL. The deadline turns that into a definite unavailable verdict, and the
+// reason is carried so the required-service failure says what went wrong.
+const PROBE_TIMEOUT_MS = 10_000;
+
+type ProbeResult = { available: true } | { available: false; reason: string };
+
+async function probeClickHouse(): Promise<ProbeResult> {
 	const probe = createClient({
 		url: CLICKHOUSE_URL,
 		username: CLICKHOUSE_USERNAME,
@@ -50,11 +60,20 @@ async function probeClickHouse(): Promise<boolean> {
 		const result = await probe.query({
 			query: "SELECT 1 AS ok",
 			format: "JSONEachRow",
+			abort_signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
 		});
 		const rows = (await result.json()) as Array<{ ok: number }>;
-		return rows[0]?.ok === 1;
-	} catch {
-		return false;
+		return rows[0]?.ok === 1
+			? { available: true }
+			: { available: false, reason: "probe query did not return SELECT 1" };
+	} catch (error) {
+		const reason =
+			error instanceof Error && error.name === "TimeoutError"
+				? `probe did not answer within ${PROBE_TIMEOUT_MS}ms`
+				: error instanceof Error
+					? error.message
+					: String(error);
+		return { available: false, reason };
 	} finally {
 		await probe.close();
 	}
@@ -133,11 +152,12 @@ async function cleanupTestRows(): Promise<void> {
 
 describe("ClickHouse market_data schema integration", () => {
 	beforeAll(async () => {
-		clickhouseAvailable = await probeClickHouse();
-		if (!clickhouseAvailable) {
+		const probe = await probeClickHouse();
+		clickhouseAvailable = probe.available;
+		if (!probe.available) {
 			if (process.env.CLICKHOUSE_REQUIRED === "1") {
 				throw new Error(
-					`Required ClickHouse integration service is unavailable at ${CLICKHOUSE_URL}`,
+					`Required ClickHouse integration service is unavailable at ${CLICKHOUSE_URL}: ${probe.reason}`,
 				);
 			}
 			return;


### PR DESCRIPTION
## Problem

`test/clickhouse-schema.integration.test.ts` decides whether ClickHouse is reachable with a single probe query that has **no deadline**.

An unreachable host normally refuses the connection immediately, so this usually resolves fast. But a half-started server can accept the socket and never answer. In that case the probe blocks the suite's `beforeAll` indefinitely, and the file surfaces as a wall of per-test timeouts that name neither ClickHouse nor the URL that was tried — the reader has to guess that the database was the problem at all.

## Change

The probe now carries an explicit 10s deadline via `AbortSignal.timeout`, so an unanswered connection resolves to a definite "unavailable" verdict instead of hanging.

It also returns *why* it failed, and the required-service error repeats that reason next to the URL. A CI failure now distinguishes "the service refused the connection" from "it timed out" from "it answered incorrectly":

```
Required ClickHouse integration service is unavailable at http://localhost:8123: ECONNREFUSED
```

Nothing else changes. With ClickHouse reachable, all twelve tests run exactly as before. With it absent and `CLICKHOUSE_REQUIRED` unset, the suite still skips rather than failing, so a developer without a local ClickHouse is unaffected.

## Scope — what this does NOT do

**This does not fix the intermittent timeouts occasionally seen in this file on CI.** Those are a separate, unrelated failure: a ClickHouse HTTP request occasionally never receives its response, and the client's own 30s `request_timeout` is not enforced in this runtime, so the request hangs and whichever test owns it dies at the default per-test timeout. That is being tracked separately.

This PR is deliberately not an attempt at that. It hardens a *different* path — service genuinely unreachable — which today would hang rather than fail cleanly. It is worth doing on its own merits, and it is not evidence that the intermittent failure is addressed.

## Verification

Run against a real `clickhouse-server:24.8`, on a fresh instance:

| Condition | Result |
|---|---|
| ClickHouse present, service required | 12 pass / 0 fail, three consecutive runs |
| ClickHouse absent, service required | fails in ~250ms with the URL and `ECONNREFUSED` |
| ClickHouse absent, not required (developer with no docker) | skips, suite green |

`tsc --noEmit` clean, `biome lint` clean. One file, 27 insertions / 7 deletions.
