### PR TITLE
fix(archive-forwarder): bound every ClickHouse request with an explicit deadline

### DIFF
--- a/services/archive-forwarder/clickhouse-deadline.ts
+++ b/services/archive-forwarder/clickhouse-deadline.ts
@@ -1,0 +1,17 @@
+// @clickhouse/client documents a `request_timeout` (30s by default), but that
+// timeout is not enforced under Bun: a request whose response never arrives
+// stays open indefinitely instead of failing. Verified against a frozen
+// ClickHouse — an unanswered request was still pending after 100s, while the
+// same request carrying an abort signal failed at its deadline, and the
+// connection pool served later requests normally once the server recovered.
+//
+// The forwarder therefore attaches an explicit deadline to every ClickHouse
+// request. This enforces the client's own documented timeout rather than
+// introducing a new one, so a healthy server behaves exactly as before; what
+// changes is that a lost response becomes a failure the caller can see and
+// count instead of a permanently stalled request.
+export const CLICKHOUSE_REQUEST_TIMEOUT_MS = 30_000;
+
+export function clickHouseRequestDeadline(): AbortSignal {
+	return AbortSignal.timeout(CLICKHOUSE_REQUEST_TIMEOUT_MS);
+}

--- a/services/archive-forwarder/health.ts
+++ b/services/archive-forwarder/health.ts
@@ -1,4 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import { clickHouseRequestDeadline } from "./clickhouse-deadline";
 import type { StrategySpoolStats } from "./strategy-spool";
 
 export type ForwarderHealthInput = {
@@ -33,6 +34,7 @@ export async function pingClickHouse(
 		const result = await client.query({
 			query: "SELECT 1 AS ok",
 			format: "JSONEachRow",
+			abort_signal: clickHouseRequestDeadline(),
 		});
 		const rows = (await result.json()) as Array<{ ok: number }>;
 		return rows[0]?.ok === 1;

--- a/services/archive-forwarder/insert.ts
+++ b/services/archive-forwarder/insert.ts
@@ -1,4 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client";
+import { clickHouseRequestDeadline } from "./clickhouse-deadline";
 import type { ArchiveForwarderTelemetry } from "./telemetry";
 import type { ArchiveRow, ArchiveBatchResult, SupportedTable } from "./types";
 import { isSupportedTable } from "./types";
@@ -73,6 +74,7 @@ export function createClickHouseInserter(
 			table,
 			values: rows,
 			format: "JSONEachRow",
+			abort_signal: clickHouseRequestDeadline(),
 			...(options?.deduplicationToken
 				? {
 						clickhouse_settings: {

--- a/services/archive-forwarder/schema.ts
+++ b/services/archive-forwarder/schema.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import path from "path";
+import { clickHouseRequestDeadline } from "./clickhouse-deadline";
 
 function stripSqlComments(sql: string): string {
 	return sql.replace(/--[^\n]*/g, "");
@@ -73,7 +74,10 @@ async function applySchemaFile(
 	const sql = await Bun.file(schemaPath).text();
 	for (const statement of splitSqlStatements(sql)) {
 		try {
-			await client.command({ query: statement });
+			await client.command({
+				query: statement,
+				abort_signal: clickHouseRequestDeadline(),
+			});
 		} catch (error) {
 			if (isIdempotentSchemaError(error)) {
 				continue;

--- a/services/archive-forwarder/stream-health-contract.ts
+++ b/services/archive-forwarder/stream-health-contract.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { ClickHouseClient } from "@clickhouse/client";
+import { clickHouseRequestDeadline } from "./clickhouse-deadline";
 import type { RowInserter } from "./insert";
 import type { ArchiveBatchRequest, ArchiveRow } from "./types";
 
@@ -759,6 +760,7 @@ export function createClickHouseStreamHealthReplayStore(
 					"SELECT snapshot_id, payload_sha256, payload_json FROM broker_stream_health.snapshots WHERE snapshot_id IN ({snapshot_ids:Array(String)})",
 				query_params: { snapshot_ids: [...snapshotIds] },
 				format: "JSONEachRow",
+				abort_signal: clickHouseRequestDeadline(),
 			});
 			const rows = (await result.json()) as Array<{
 				snapshot_id: string;
@@ -785,6 +787,7 @@ export function createClickHouseStreamHealthReplayStore(
 					incoming_payload_json: conflict.incomingPayloadJson,
 				})),
 				format: "JSONEachRow",
+				abort_signal: clickHouseRequestDeadline(),
 			});
 		},
 	};


### PR DESCRIPTION
## Problem

The ClickHouse client documents a `request_timeout` — 30s by default — but that timeout **is not enforced in this runtime**. A request whose response never arrives stays open indefinitely instead of failing.

Measured against a deliberately frozen ClickHouse: an unanswered insert was still pending after **100 seconds**, and only ended when the process was killed.

The archive forwarder made every ClickHouse call that way — no deadline on the row inserts, the startup schema statements, the health ping, or the stream-health snapshot reads and conflict writes.

Why that matters here specifically: the batch loop is deliberately written to record a failure and carry on when an insert *fails*. But a request that never returns never reaches that path. The forwarder would simply stop draining — no error, no counter, no alarm. This service is the record of where funds moved, so a silent stall is the worst shape the failure could take.

## Change

Every ClickHouse request now carries an explicit abort deadline, which this runtime does honour.

The value is the client's **own documented 30s**, so this enforces the existing contract rather than inventing a policy — a healthy server behaves exactly as it did before, and there is no new tuning knob to get wrong. What changes is that a lost response becomes an ordinary, visible failure instead of a permanent stall: it lands on the failure path that already exists, is counted as `insert_failures` with `error_class="timeout"` by the existing classifier, and the loop moves on to the next table.

**No retry is introduced.** A lost response is surfaced, not papered over.

## Verification

Demonstrated against a real ClickHouse frozen mid-request, driving the actual `createClickHouseInserter` → `insertArchiveRows` path rather than reasoning about it. Same code path, with and without the change:

| | Result |
|---|---|
| Before | still hanging when killed at **100s** — the request never completed |
| After | batch fails at **30011ms**, reports the failed table, records `error_class="timeout"` |

Two follow-on properties were checked rather than assumed:

- **The pool is not left wedged.** After an aborted request, once the server recovered, subsequent queries succeeded normally (8ms, 7ms). An abort leaves nothing poisoned behind.
- **Healthy behaviour is unchanged.** Full suite green against a live ClickHouse: 603 passing, 0 failing. `tsc --noEmit`, `biome format` and `biome lint` all clean.

## Scope

Five ClickHouse call sites in the archive forwarder, one new 17-line module holding the deadline and the reason for it. Nothing else in the service is touched. The SQLite spool calls are unaffected — they are not ClickHouse requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout to ClickHouse requests.
  * Prevented health checks, inserts, schema operations, and replay-store requests from hanging indefinitely.
  * Improved service responsiveness when ClickHouse is slow or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->