### PR TITLE
ci(publish): check out full history for the npm publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          # Full history: the archive baseline test resolves BASELINE_COMMIT^ and
+          # diffs it against its parent, which a shallow clone cannot satisfy.
+          fetch-depth: 0
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
The 0.2.39 tag run failed in publish-npm on `archive E2E immutable baseline > baseline commit changes only canonical OpenSpec artifacts`.

The test resolves `BASELINE_COMMIT^` and diffs it against its parent. `ci.yml` already checks out with `fetch-depth: 0`, so it passes there; the publish job checked out shallow, where that parent does not exist. The test shipped in this release, so the publish workflow had never had to satisfy it. Nothing about the released content is at fault.

The archive-forwarder and market-data-collector images published successfully; the npm package and the broker image did not (publish-docker needs publish-npm).

After merge, 0.2.39 goes out via the workflow_dispatch recovery path this workflow already documents — a re-run of the tag would execute the old workflow file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package publishing workflow to ensure complete repository history is available during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->