### PR TITLE
release: cex-broker 0.2.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.39",
+	"version": "0.2.40",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Supersedes 0.2.39, which was tagged but never published: its publish run failed on a shallow checkout, so the npm package and broker image never went out. Only the archive-forwarder and market-data-collector images exist at 0.2.39 — treat that version as dangling and do not reuse it.

0.2.40 carries everything 0.2.39 would have, plus:
- the publish job now checks out full history, so the archive baseline test can resolve its parent commit;
- a production broker that requested market-data archival without a resolvable capture identity refuses to start instead of running healthy while archiving nothing.

Version bump only.