### PR TITLE
chore: pin bun to an exact version above the known-bad range

### DIFF
--- a/.github/workflows/archive-live-smoke.yml
+++ b/.github/workflows/archive-live-smoke.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.12
+          # Pinned, not floating: bun <= 1.3.9 can drop the terminating chunk of
+          # an empty chunked HTTP response, which hangs a ClickHouse read
+          # forever. request_timeout cannot rescue it — the client implements
+          # that with socket.setTimeout, which Bun's node:http client ignores.
+          # Measured at ~1% of query bursts on 1.3.9 and zero on 1.3.12 and
+          # later, so keep this at 1.3.12 or above.
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.12
+          # Pinned, not floating: bun <= 1.3.9 can drop the terminating chunk of
+          # an empty chunked HTTP response, which hangs a ClickHouse read
+          # forever. request_timeout cannot rescue it — the client implements
+          # that with socket.setTimeout, which Bun's node:http client ignores.
+          # Measured at ~1% of query bursts on 1.3.9 and zero on 1.3.12 and
+          # later, so keep this at 1.3.12 or above.
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,13 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.9
+          # Pinned, not floating: bun <= 1.3.9 can drop the terminating chunk of
+          # an empty chunked HTTP response, which hangs a ClickHouse read
+          # forever. request_timeout cannot rescue it — the client implements
+          # that with socket.setTimeout, which Bun's node:http client ignores.
+          # Measured at ~1% of query bursts on 1.3.9 and zero on 1.3.12 and
+          # later, so keep this at 1.3.12 or above.
+          bun-version: 1.3.14
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@v4

--- a/.sandbox/Dockerfile
+++ b/.sandbox/Dockerfile
@@ -1,4 +1,10 @@
-FROM oven/bun:1.3
+# Pinned to an exact patch, not the floating 1.3 tag: bun <= 1.3.9 can drop the
+# terminating chunk of an empty chunked HTTP response, which hangs a ClickHouse
+# read forever. request_timeout cannot rescue it — the client implements that
+# with socket.setTimeout, which Bun's node:http client ignores. Measured at ~1%
+# of query bursts on 1.3.9 and zero on 1.3.12 and later, so keep this at 1.3.12
+# or above.
+FROM oven/bun:1.3.14
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM oven/bun:1.3
+# Pinned to an exact patch, not the floating 1.3 tag: bun <= 1.3.9 can drop the
+# terminating chunk of an empty chunked HTTP response, which hangs a ClickHouse
+# read forever. request_timeout cannot rescue it — the client implements that
+# with socket.setTimeout, which Bun's node:http client ignores. Measured at ~1%
+# of query bursts on 1.3.9 and zero on 1.3.12 and later, so keep this at 1.3.12
+# or above.
+FROM oven/bun:1.3.14
 
 WORKDIR /app
 

--- a/docker/clickhouse-research.compose.yml
+++ b/docker/clickhouse-research.compose.yml
@@ -20,7 +20,10 @@ services:
   # host `bun install`. For a standalone prod image build
   # services/archive-forwarder/Dockerfile instead (self-contained, no mount).
   archive-forwarder:
-    image: oven/bun:1.2
+    # Same bun floor as the production images: bun <= 1.3.9 can drop the
+    # terminating chunk of an empty chunked HTTP response and hang a ClickHouse
+    # read forever, and this runs the real forwarder against ClickHouse.
+    image: oven/bun:1.3.14
     container_name: cex-broker-archive-forwarder
     working_dir: /app
     command: ["bun", "run", "services/archive-forwarder/index.ts"]

--- a/services/archive-forwarder/Dockerfile
+++ b/services/archive-forwarder/Dockerfile
@@ -5,7 +5,14 @@
 #
 # Build from the repository ROOT so the schema/ directory is in the build context:
 #   docker build -f services/archive-forwarder/Dockerfile -t cex-broker-archive-forwarder .
-FROM oven/bun:1.3
+# Pinned to an exact patch, not the floating 1.3 tag: bun <= 1.3.9 can drop the
+# terminating chunk of an empty chunked HTTP response, which hangs a ClickHouse
+# read forever. request_timeout cannot rescue it — the client implements that
+# with socket.setTimeout, which Bun's node:http client ignores. This service
+# reads and writes ClickHouse continuously, so it is the most exposed. Measured
+# at ~1% of query bursts on 1.3.9 and zero on 1.3.12 and later, so keep this at
+# 1.3.12 or above.
+FROM oven/bun:1.3.14
 
 WORKDIR /app
 

--- a/services/ohlcv-collector/Dockerfile
+++ b/services/ohlcv-collector/Dockerfile
@@ -9,7 +9,13 @@
 # Set CEX_BROKER_URL=host:port and mount the canonical feed configuration named
 # by CEX_BROKER_MARKET_DATA_COLLECTOR_CONFIG. The legacy OHLCV array variable is
 # retained for compatibility.
-FROM oven/bun:1.3
+# Pinned to an exact patch, not the floating 1.3 tag: bun <= 1.3.9 can drop the
+# terminating chunk of an empty chunked HTTP response, which hangs a ClickHouse
+# read forever. request_timeout cannot rescue it — the client implements that
+# with socket.setTimeout, which Bun's node:http client ignores. Measured at ~1%
+# of query bursts on 1.3.9 and zero on 1.3.12 and later, so keep this at 1.3.12
+# or above.
+FROM oven/bun:1.3.14
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

Bun's `node:http` client occasionally drops the terminating chunk of an empty chunked HTTP response. When that happens a ClickHouse read never completes — and the client's `request_timeout` cannot rescue it, because `@clickhouse/client` implements that timeout with `socket.setTimeout`, which Bun's `node:http` client ignores. The call hangs forever instead of failing.

This is what had been intermittently hanging the ClickHouse schema integration tests in CI at bun's 5000ms per-test timeout. The response arrives fine — ClickHouse logs `QueryStart` and `QueryFinish` for the query in ~26ms with no exception — and then the body stream simply never ends.

Measured against a real `clickhouse-server:24.8`, firing bursts of zero-row queries through `@clickhouse/client`:

| bun | hangs |
|---|---|
| 1.3.0 | 6 / 400 bursts |
| 1.3.9 | 12 / 1200 bursts (~1%) |
| 1.3.12 | 0 / 2000 bursts (16000 queries) |
| 1.3.14 | 0 / 2000 bursts (16000 queries) |
| node 22 (control) | 0 / 800 bursts |

## What was wrong

CI already ran 1.3.12 and was therefore already unaffected — but nothing recorded that the pin was load-bearing, and every other pin had drifted away from it:

- `publish.yml` was still on 1.3.9
- `Dockerfile`, `services/archive-forwarder/Dockerfile`, `services/ohlcv-collector/Dockerfile` and `.sandbox/Dockerfile` used the floating `oven/bun:1.3` tag
- `docker/clickhouse-research.compose.yml` ran the real archive forwarder on bun 1.2

So the bun version of the service that reads and writes ClickHouse continuously was decided by image build date rather than by anything in the repo.

## What this does

Pins every workflow and image to **1.3.14** and states the constraint at each pin site, since it is invisible from the code.

1.3.14 rather than the 1.3.12 floor because it is the newest 1.3.x and is what the floating tag resolves to today — so no image is downgraded — and it was measured to be clean at the same sample size as 1.3.12 before being chosen.

## Verification

- 30 consecutive runs of the ClickHouse schema integration suite on 1.3.14 against a persistent ClickHouse instance: 30 pass, 0 fail
- `oven/bun:1.3.14` pulls and runs (`bun --version` → 1.3.14), so no image build can break on a missing tag
- Every touched YAML file parses
- `bun run check`, `bun run check:server-lines`, `bun run typecheck:sidecar` all pass; the pre-commit and pre-push hooks ran `bun format` and the full suite (668 tests) green

Not verifiable locally: that the workflows themselves run green end to end and that the images build. Both changes are a version string plus a comment.

## Note for review

`.sandbox/Dockerfile` and `docker/clickhouse-research.compose.yml` are included beyond the CI and production images. The research compose file runs `services/archive-forwarder/index.ts` against ClickHouse on bun 1.2 — the exact exposed code path — so leaving it out would have made the alignment incomplete. Happy to drop either if you'd rather keep this to the shipped artifacts.