### PR TITLE
fix(ohlcv-collector): detect silent OHLCV stream death via cadence deadline and exit for restart

### DIFF
--- a/services/ohlcv-collector/collector.ts
+++ b/services/ohlcv-collector/collector.ts
@@ -25,6 +25,8 @@ export type MarketDataCollectorOptions = {
 	subscriptions: MarketDataSubscription[];
 	metrics?: CollectorMetrics;
 	retry?: Partial<RetryPolicy>;
+	/** Test override for the OHLCV message-gap deadline; production derives it from the timeframe. */
+	ohlcvStaleDeadlineMs?: number;
 };
 
 type CollectorSubscription = MarketDataSubscription;
@@ -46,6 +48,7 @@ type RetryPolicy = {
 type StreamResult =
 	| { reason: "aborted" }
 	| { reason: "end" | "close" }
+	| { reason: "stale"; deadlineMs: number }
 	| { reason: "error"; error: grpc.ServiceError };
 
 const DEFAULT_RETRY_POLICY: RetryPolicy = {
@@ -55,6 +58,45 @@ const DEFAULT_RETRY_POLICY: RetryPolicy = {
 	random: Math.random,
 };
 const BACKOFF_RESET_AFTER_MS = 60_000;
+
+// Liveness invariant: OHLCV is a cadence-bearing market-data feed — the broker
+// forwards at least one candle update per timeframe (a bar closes every
+// timeframe even on a quiet market), so an OHLCV stream that stays silent for
+// several timeframes is a dead upstream (e.g. an exchange WebSocket that died
+// without a close event), never legitimate quiet. That expected cadence is the
+// only thing that licenses a message-gap deadline here. Event-driven feeds
+// (ORDERBOOK/TICKER/TRADES) and all user-data streams have no guaranteed
+// cadence and MUST NOT get per-message timeouts — silence there can be real.
+const OHLCV_STALE_TIMEFRAME_MULTIPLIER = 5;
+const OHLCV_STALE_MIN_DEADLINE_MS = 90_000;
+
+const TIMEFRAME_UNIT_MS: Record<string, number> = {
+	s: 1_000,
+	m: 60_000,
+	h: 3_600_000,
+	d: 86_400_000,
+	w: 604_800_000,
+	M: 2_592_000_000,
+};
+
+function timeframeToMs(timeframe: string): number {
+	const match = /^(\d+)([smhdwM])$/.exec(timeframe);
+	if (!match) {
+		throw new Error(
+			`Unsupported OHLCV timeframe "${timeframe}"; expected <number><s|m|h|d|w|M>`,
+		);
+	}
+	return Number(match[1]) * TIMEFRAME_UNIT_MS[match[2]];
+}
+
+export class OhlcvStreamStaleError extends Error {
+	constructor(subscription: MarketDataSubscription, deadlineMs: number) {
+		super(
+			`OHLCV stream ${subscription.exchange}:${subscription.symbol} delivered no frames for ${deadlineMs}ms; upstream is dead`,
+		);
+		this.name = "OhlcvStreamStaleError";
+	}
+}
 
 const grpcObject = grpc.loadPackageDefinition(
 	CEX_BROKER_PACKAGE_DEFINITION,
@@ -117,12 +159,21 @@ export class MarketDataCollector {
 	readonly #metrics?: CollectorMetrics;
 	readonly #retry: RetryPolicy;
 	readonly #health = new Map<string, CollectorFeedHealth>();
+	readonly #ohlcvStaleDeadlineMs?: number;
 	#started = false;
 
 	constructor(options: MarketDataCollectorOptions) {
 		this.#subscriptions = options.subscriptions;
 		this.#metrics = options.metrics;
 		this.#retry = { ...DEFAULT_RETRY_POLICY, ...options.retry };
+		this.#ohlcvStaleDeadlineMs = options.ohlcvStaleDeadlineMs;
+		// Fail at construction on an unparseable timeframe: a config typo must be
+		// a boot error, not a subscription that silently runs without liveness.
+		for (const subscription of options.subscriptions) {
+			if (subscription.feed === "OHLCV") {
+				this.#staleDeadlineMs(subscription);
+			}
+		}
 		this.#client = new grpcObject.cex_broker.cex_service(
 			options.brokerUrl,
 			grpc.credentials.createInsecure(),
@@ -137,6 +188,19 @@ export class MarketDataCollector {
 
 	#healthKey(subscription: CollectorSubscription): string {
 		return `${subscription.exchange}:${subscription.symbol}:${subscription.feed}`;
+	}
+
+	#staleDeadlineMs(
+		subscription: Extract<CollectorSubscription, { feed: "OHLCV" }>,
+	): number {
+		return (
+			this.#ohlcvStaleDeadlineMs ??
+			Math.max(
+				timeframeToMs(subscription.timeframe) *
+					OHLCV_STALE_TIMEFRAME_MULTIPLIER,
+				OHLCV_STALE_MIN_DEADLINE_MS,
+			)
+		);
 	}
 
 	#updateHealth(
@@ -181,6 +245,14 @@ export class MarketDataCollector {
 				await this.#supervise(subscription, signal);
 				return;
 			} catch (error) {
+				// Deliberately fatal: a stale OHLCV stream means the upstream died
+				// without a close event, and an in-process resubscribe can silently
+				// reattach to the same wedged channel. Crash so the process exits
+				// nonzero and the container supervisor restarts it with fresh state —
+				// the remedy proven to restore candles within a minute.
+				if (error instanceof OhlcvStreamStaleError) {
+					throw error;
+				}
 				log.error("OHLCV collector pair supervisor failed; restarting", {
 					...pairLabels(subscription),
 					error,
@@ -244,6 +316,20 @@ export class MarketDataCollector {
 				break;
 			}
 
+			if (result.reason === "stale") {
+				this.#updateHealth(subscription, { state: "stopped" });
+				void this.#metrics?.recordCounter(
+					"cex_ohlcv_collector_stale_streams_total",
+					1,
+					labels,
+				);
+				log.error(
+					"OHLCV stream delivered no frames within the cadence deadline; exiting so the container restarts",
+					{ ...labels, deadline_ms: result.deadlineMs },
+				);
+				throw new OhlcvStreamStaleError(subscription, result.deadlineMs);
+			}
+
 			if (Date.now() - openedAt >= BACKOFF_RESET_AFTER_MS) {
 				consecutiveFailures = 0;
 			}
@@ -273,13 +359,32 @@ export class MarketDataCollector {
 		return new Promise((resolve) => {
 			let settled = false;
 			let stream: grpc.ClientReadableStream<SubscribeResponse>;
+			let staleTimer: ReturnType<typeof setTimeout> | undefined;
+			const staleDeadlineMs =
+				subscription.feed === "OHLCV"
+					? this.#staleDeadlineMs(subscription)
+					: undefined;
 			const settle = (result: StreamResult) => {
 				if (settled) {
 					return;
 				}
 				settled = true;
+				clearTimeout(staleTimer);
 				signal.removeEventListener("abort", onAbort);
 				resolve(result);
+			};
+			// Message-gap deadline, re-armed on every frame. Only cadence-bearing
+			// OHLCV streams get one — see the liveness invariant on
+			// OHLCV_STALE_TIMEFRAME_MULTIPLIER.
+			const armStaleDeadline = () => {
+				if (staleDeadlineMs === undefined || settled) {
+					return;
+				}
+				clearTimeout(staleTimer);
+				staleTimer = setTimeout(() => {
+					stream.cancel();
+					settle({ reason: "stale", deadlineMs: staleDeadlineMs });
+				}, staleDeadlineMs);
 			};
 			const onAbort = () => {
 				stream.cancel();
@@ -311,7 +416,12 @@ export class MarketDataCollector {
 				return;
 			}
 
+			armStaleDeadline();
+
 			stream.on("data", (response) => {
+				// Any frame proves the upstream is alive, whether or not it carries
+				// countable bars, so the deadline re-arms before payload inspection.
+				armStaleDeadline();
 				const frames =
 					subscription.feed === "OHLCV"
 						? countOhlcvBars(response.data)

--- a/test/ohlcv-collector.test.ts
+++ b/test/ohlcv-collector.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import * as grpc from "@grpc/grpc-js";
-import { MarketDataCollector } from "../services/ohlcv-collector/collector";
+import {
+	MarketDataCollector,
+	OhlcvStreamStaleError,
+} from "../services/ohlcv-collector/collector";
 import { CEX_BROKER_PACKAGE_DEFINITION } from "../src/proto-package-definition";
 
 type SubscribeRequest = {
@@ -292,5 +295,142 @@ describe("market-data collector supervision", () => {
 			await runPromise;
 			server.forceShutdown();
 		}
+	});
+
+	test("fails the run when an OHLCV stream goes silent past the cadence deadline", async () => {
+		const { server, port } = await startSubscribeServer((call) => {
+			// One bar, then silence: the upstream-dead case (WS death without a
+			// close event) — the stream stays open but never delivers again.
+			writeBar(call);
+		});
+		const metrics = new CapturingMetrics();
+		const abort = new AbortController();
+		const collector = new MarketDataCollector({
+			brokerUrl: `127.0.0.1:${port}`,
+			subscriptions: [
+				{
+					exchange: "binance",
+					symbol: "BTC/USDT",
+					feed: "OHLCV",
+					timeframe: "1m",
+				},
+			],
+			metrics,
+			ohlcvStaleDeadlineMs: 50,
+		});
+
+		try {
+			await expect(collector.run(abort.signal)).rejects.toBeInstanceOf(
+				OhlcvStreamStaleError,
+			);
+			expect(metrics.counters).toContainEqual({
+				name: "cex_ohlcv_collector_stale_streams_total",
+				value: 1,
+				labels: {
+					exchange: "binance",
+					feed: "OHLCV",
+					symbol: "BTC/USDT",
+					timeframe: "1m",
+				},
+			});
+		} finally {
+			abort.abort();
+			server.forceShutdown();
+		}
+	});
+
+	test("frames arriving within the deadline keep the OHLCV stream alive", async () => {
+		let stopWriting = false;
+		const { server, port } = await startSubscribeServer((call) => {
+			const interval = setInterval(() => {
+				if (stopWriting || call.cancelled) {
+					clearInterval(interval);
+					return;
+				}
+				writeBar(call);
+			}, 10);
+			call.once("cancelled", () => clearInterval(interval));
+		});
+		const metrics = new CapturingMetrics();
+		const abort = new AbortController();
+		const collector = new MarketDataCollector({
+			brokerUrl: `127.0.0.1:${port}`,
+			subscriptions: [
+				{
+					exchange: "binance",
+					symbol: "BTC/USDT",
+					feed: "OHLCV",
+					timeframe: "1m",
+				},
+			],
+			metrics,
+			ohlcvStaleDeadlineMs: 250,
+		});
+		const runPromise = collector.run(abort.signal);
+
+		try {
+			await waitFor(
+				() =>
+					metrics.counters.filter(
+						(counter) =>
+							counter.name === "cex_ohlcv_collector_bars_received_total",
+					).length >= 10,
+			);
+			expect(
+				collector.getHealthSnapshot()["binance:BTC/USDT:OHLCV"]?.state,
+			).toBe("healthy");
+		} finally {
+			stopWriting = true;
+			abort.abort();
+			await runPromise;
+			server.forceShutdown();
+		}
+	});
+
+	test("a silent event-driven feed stays subscribed through OHLCV-length silence", async () => {
+		// TRADES has no guaranteed cadence: a quiet market is legitimate silence,
+		// so the message-gap deadline must not apply to it.
+		let subscribed = false;
+		const { server, port } = await startSubscribeServer(() => {
+			subscribed = true;
+		});
+		const abort = new AbortController();
+		const collector = new MarketDataCollector({
+			brokerUrl: `127.0.0.1:${port}`,
+			subscriptions: [
+				{ exchange: "binance", symbol: "BTC/USDT", feed: "TRADES" },
+			],
+			ohlcvStaleDeadlineMs: 10,
+		});
+		const runPromise = collector.run(abort.signal);
+
+		try {
+			await waitFor(() => subscribed);
+			await Bun.sleep(100);
+			expect(
+				collector.getHealthSnapshot()["binance:BTC/USDT:TRADES"]?.state,
+			).toBe("connecting");
+		} finally {
+			abort.abort();
+			await runPromise;
+			server.forceShutdown();
+		}
+	});
+
+	test("rejects an unparseable OHLCV timeframe at construction", () => {
+		expect(
+			() =>
+				new MarketDataCollector({
+					brokerUrl: "127.0.0.1:1",
+					subscriptions: [
+						{
+							exchange: "binance",
+							symbol: "BTC/USDT",
+							feed: "OHLCV",
+							timeframe: "one-minute",
+						},
+					],
+				}),
+		).toThrow('Unsupported OHLCV timeframe "one-minute"');
 	});
 });


### PR DESCRIPTION
## Problem

The market-data collector only learns a subscription died through gRPC `error`/`end`/`close` events. When the upstream WebSocket dies **without** a close event, the stream stays open and silent: the supervisor blocks forever awaiting a stream result, no reconnect fires, no log line is emitted, and candles simply stop until someone restarts the container. This has bitten production twice (~16h after a restart each time), with zero error logs and a manual restart as the remedy.

## Fix

OHLCV is a cadence-bearing feed — at least one candle update arrives per timeframe, even on a quiet market — so a message-gap deadline is sound there:

- Each OHLCV stream arms a stale deadline of `max(5 × timeframe, 90s)`, re-armed on every received frame.
- On expiry the stream is cancelled and the collector **exits nonzero** (`OhlcvStreamStaleError` escalates through the supervisor), so the container supervisor restarts the process with a fresh channel — the remedy proven to restore candles in under a minute. In-process resubscription was deliberately rejected: it can silently reattach to the same wedged channel.
- Stale exits emit `cex_ohlcv_collector_stale_streams_total` and an error log naming the pair and deadline before exiting.
- Event-driven feeds (ORDERBOOK/TICKER/TRADES) get **no** timeout — silence there can be a legitimately quiet market. The invariant is documented at the deadline constants.
- An unparseable OHLCV timeframe now fails at construction instead of running a subscription without liveness.

## Verification

- `bun test test/ohlcv-collector.test.ts test/ohlcv-collector-config.test.ts test/ohlcv-collector-shutdown.test.ts` — 42 pass, including new tests for: run rejection on a silent OHLCV stream, deadline re-arming under steady frames, a silent TRADES feed staying subscribed, and construction-time timeframe validation.
- Full suite via pre-commit: 672 pass, 0 fail.
- `bunx tsc --noEmit` and `biome check` clean on the changed files.

## Deploy note

Production still runs the legacy embedded-broker collector image; this fix rides the next market-data-collector publish and its production cutover. Until then the stale-candles runbook (restart the collector when candles stall >30min with a log-silent container) still applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added liveness monitoring for OHLCV data streams based on their subscription timeframe.
  * Streams now report stale data through health and monitoring metrics.
  * Added configurable stale-data deadlines for testing and operational flexibility.
* **Bug Fixes**
  * Invalid OHLCV timeframes are rejected during setup.
  * Stale OHLCV streams now fail clearly instead of retrying indefinitely.
  * Event-driven feeds continue operating without OHLCV cadence checks.
* **Tests**
  * Added coverage for stale streams, healthy message intervals, event-driven feeds, and invalid timeframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->