### PR TITLE
Bound archive forwarder requests and surface queue health

### DIFF
--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -1,5 +1,9 @@
 import { closeSync, fsyncSync, openSync, writeSync } from "node:fs";
-import { request as httpRequest } from "node:http";
+import {
+	type ClientRequest,
+	request as httpRequest,
+	type IncomingMessage,
+} from "node:http";
 import { request as httpsRequest } from "node:https";
 import { SeverityNumber } from "@opentelemetry/api-logs";
 import { log } from "../logger";
@@ -58,6 +62,20 @@ type ArchiverStats = {
 	forwarderFailures: number;
 };
 
+export type BrokerExecutionArchiveHealthSnapshot = {
+	healthy: boolean;
+	queue_depth: number;
+	oldest_pending_age_ms: number;
+	shed_total: number;
+	last_failure_at: number | null;
+	last_shed_at: number | null;
+	last_success_at: number | null;
+	sink_latency_ms: number | null;
+	sink_errors_total: number;
+	in_flight: boolean;
+	in_flight_age_ms: number;
+};
+
 const DEFAULT_MAX_QUEUE_SIZE = 10_000;
 const DEFAULT_BATCH_SIZE = 10;
 const DEFAULT_FLUSH_INTERVAL_MS = 1_000;
@@ -73,6 +91,8 @@ type ArchiveLossRecord = {
 	reason: ArchiveLossReason;
 	payload: BrokerArchiveRow;
 };
+
+type QueuedArchiveRow = BrokerArchiveRow;
 
 const MARKET_FEEDS = new Set(["ORDERBOOK", "TICKER", "TRADES", "OHLCV"]);
 
@@ -130,7 +150,8 @@ export class BrokerExecutionArchiver {
 	private readonly batchSize: number;
 	private readonly flushIntervalMs: number;
 	private readonly forwarderTimeoutMs: number;
-	private readonly queue: BrokerArchiveRow[] = [];
+	private readonly queue: QueuedArchiveRow[] = [];
+	private readonly enqueueTimes = new WeakMap<QueuedArchiveRow, number>();
 	private readonly stats: ArchiverStats = {
 		enqueued: 0,
 		shed: 0,
@@ -139,6 +160,16 @@ export class BrokerExecutionArchiver {
 	};
 	private flushTimer: ReturnType<typeof setInterval> | null = null;
 	private flushInFlight: Promise<void> | null = null;
+	private inFlightBatch: QueuedArchiveRow[] | null = null;
+	private inFlightStartedAtMs: number | null = null;
+	private lastFailureAtMs: number | null = null;
+	private lastShedAtMs: number | null = null;
+	private lastSuccessAtMs: number | null = null;
+	private lastFailureEventSequence: number | null = null;
+	private lastShedEventSequence: number | null = null;
+	private lastSuccessEventSequence: number | null = null;
+	private lastSinkLatencyMs: number | null = null;
+	private healthEventSequence = 0;
 	private lastShedWarnAtMs = 0;
 	private closing = false;
 	private closed = false;
@@ -199,6 +230,7 @@ export class BrokerExecutionArchiver {
 
 		try {
 			this.flushTimer = setInterval(() => {
+				this.emitArchiveHealthMetrics();
 				void this.flush();
 			}, this.flushIntervalMs);
 			this.flushTimer.unref?.();
@@ -255,21 +287,22 @@ export class BrokerExecutionArchiver {
 			row: { ...row.row, source: this.source },
 		};
 		if (this.queue.length >= this.maxQueueSize) {
-			const shedRow = this.queue[0];
-			if (shedRow) {
-				this.appendLossRecords([shedRow], "queue_shed");
+			const shedEntry = this.queue[0];
+			if (shedEntry) {
+				this.appendLossRecords([shedEntry], "queue_shed");
 				this.queue.shift();
 			}
 			this.stats.shed += 1;
+			this.recordHealthEvent("shed");
 			void this.recordArchiveMetric("cex_archive_rows_shed_total", {
-				table: shedRow?.table ?? "unknown",
+				table: shedEntry?.table ?? "unknown",
 				source: this.source,
-				feed: shedRow ? archiveFeed(shedRow) : "NON_MARKET",
+				feed: shedEntry ? archiveFeed(shedEntry) : "NON_MARKET",
 			});
 			void this.recordArchiveMetric("cex_archive_queue_saturated_rows_total", {
-				table: shedRow?.table ?? "unknown",
+				table: shedEntry?.table ?? "unknown",
 				source: this.source,
-				feed: shedRow ? archiveFeed(shedRow) : "NON_MARKET",
+				feed: shedEntry ? archiveFeed(shedEntry) : "NON_MARKET",
 			});
 			// The durable journal is authoritative; this rate-limited warning makes
 			// sustained queue pressure visible without becoming another loss sink.
@@ -278,11 +311,12 @@ export class BrokerExecutionArchiver {
 				log.warn("Archive queue full: shedding oldest rows", {
 					shed_total: this.stats.shed,
 					queue_max: this.maxQueueSize,
-					table: shedRow?.table ?? "unknown",
+					table: shedEntry?.table ?? "unknown",
 				});
 				this.lastShedWarnAtMs = now;
 			}
 		}
+		this.enqueueTimes.set(archiveRow, Date.now());
 		this.queue.push(archiveRow);
 		this.stats.enqueued += 1;
 		void this.recordArchiveMetric("cex_archive_rows_enqueued_total", {
@@ -290,6 +324,7 @@ export class BrokerExecutionArchiver {
 			source: this.source,
 			feed: archiveFeed(archiveRow),
 		});
+		this.emitArchiveHealthMetrics();
 		if (this.queue.length >= this.batchSize) {
 			void this.flush();
 		}
@@ -308,9 +343,13 @@ export class BrokerExecutionArchiver {
 		}
 		// flushBatch resolves a boolean the callers read directly; the in-flight
 		// handle only needs completion, so discard it to keep this a Promise<void>.
+		const inFlightState: { promise?: Promise<void> } = {};
 		const inFlight = this.flushBatch()
 			.then(() => undefined)
 			.finally(() => {
+				if (this.flushInFlight !== inFlightState.promise) {
+					return;
+				}
 				this.flushInFlight = null;
 				if (
 					!this.closed &&
@@ -321,6 +360,7 @@ export class BrokerExecutionArchiver {
 					queueMicrotask(() => void this.flush());
 				}
 			});
+		inFlightState.promise = inFlight;
 		this.flushInFlight = inFlight;
 		return inFlight;
 	}
@@ -371,6 +411,145 @@ export class BrokerExecutionArchiver {
 		return this.queue.length;
 	}
 
+	getHealthSnapshot(): Readonly<BrokerExecutionArchiveHealthSnapshot> {
+		const now = Date.now();
+		const oldestPendingAtMs = this.oldestPendingEnqueueAtMs();
+		const oldestPendingAgeMs =
+			oldestPendingAtMs === null ? 0 : Math.max(0, now - oldestPendingAtMs);
+		const inFlightAgeMs =
+			this.inFlightStartedAtMs === null
+				? 0
+				: Math.max(0, now - this.inFlightStartedAtMs);
+		const lastUnhealthyEventSequence = Math.max(
+			this.lastFailureEventSequence ?? Number.NEGATIVE_INFINITY,
+			this.lastShedEventSequence ?? Number.NEGATIVE_INFINITY,
+		);
+		const recoveredFromEvents =
+			lastUnhealthyEventSequence === Number.NEGATIVE_INFINITY ||
+			(this.lastSuccessEventSequence !== null &&
+				this.lastSuccessEventSequence > lastUnhealthyEventSequence);
+		const healthy =
+			this.enabled &&
+			!this.closing &&
+			!this.closed &&
+			this.queue.length < this.maxQueueSize &&
+			oldestPendingAgeMs <= this.forwarderTimeoutMs &&
+			inFlightAgeMs <= this.forwarderTimeoutMs &&
+			recoveredFromEvents;
+
+		return {
+			healthy,
+			queue_depth: this.queue.length,
+			oldest_pending_age_ms: oldestPendingAgeMs,
+			shed_total: this.stats.shed,
+			last_failure_at: this.lastFailureAtMs,
+			last_shed_at: this.lastShedAtMs,
+			last_success_at: this.lastSuccessAtMs,
+			sink_latency_ms: this.lastSinkLatencyMs,
+			sink_errors_total: this.stats.forwarderFailures,
+			in_flight: this.inFlightBatch !== null,
+			in_flight_age_ms: inFlightAgeMs,
+		};
+	}
+
+	private oldestPendingEnqueueAtMs(): number | null {
+		let oldest: number | null = null;
+		for (const entry of this.queue) {
+			const enqueuedAtMs = this.enqueueTimes.get(entry);
+			if (enqueuedAtMs === undefined) {
+				continue;
+			}
+			oldest = oldest === null ? enqueuedAtMs : Math.min(oldest, enqueuedAtMs);
+		}
+		for (const entry of this.inFlightBatch ?? []) {
+			const enqueuedAtMs = this.enqueueTimes.get(entry);
+			if (enqueuedAtMs === undefined) {
+				continue;
+			}
+			oldest = oldest === null ? enqueuedAtMs : Math.min(oldest, enqueuedAtMs);
+		}
+		return oldest;
+	}
+
+	private recordHealthEvent(event: "failure" | "shed" | "success"): void {
+		const eventSequence = ++this.healthEventSequence;
+		const eventTimestampMs = Date.now();
+		switch (event) {
+			case "failure":
+				this.lastFailureAtMs = eventTimestampMs;
+				this.lastFailureEventSequence = eventSequence;
+				return;
+			case "shed":
+				this.lastShedAtMs = eventTimestampMs;
+				this.lastShedEventSequence = eventSequence;
+				return;
+			case "success":
+				this.lastSuccessAtMs = eventTimestampMs;
+				this.lastSuccessEventSequence = eventSequence;
+				return;
+		}
+	}
+
+	private emitArchiveHealthMetrics(): void {
+		const snapshot = this.getHealthSnapshot();
+		const labels = { source: this.source };
+		void this.recordArchiveObservableGauge(
+			"cex_archive_health",
+			snapshot.healthy ? 1 : 0,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_queue_depth",
+			snapshot.queue_depth,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_oldest_pending_age_ms",
+			snapshot.oldest_pending_age_ms,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_shed_total",
+			snapshot.shed_total,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_last_failure_at",
+			snapshot.last_failure_at ?? 0,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_last_shed_at",
+			snapshot.last_shed_at ?? 0,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_last_success_at",
+			snapshot.last_success_at ?? 0,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_sink_latency_ms",
+			snapshot.sink_latency_ms ?? 0,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_sink_errors_total",
+			snapshot.sink_errors_total,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_in_flight",
+			snapshot.in_flight ? 1 : 0,
+			labels,
+		);
+		void this.recordArchiveGauge(
+			"cex_archive_in_flight_age_ms",
+			snapshot.in_flight_age_ms,
+			labels,
+		);
+	}
+
 	private closeLossJournal(): void {
 		if (this.deadLetterFd === undefined) {
 			return;
@@ -400,8 +579,9 @@ export class BrokerExecutionArchiver {
 			this.appendLossRecords([dropped], "queue_shed");
 			this.queue.shift();
 			this.stats.shed += 1;
+			this.recordHealthEvent("shed");
 			void this.recordArchiveMetric("cex_archive_rows_shed_total", {
-				table: dropped?.table ?? "unknown",
+				table: dropped.table,
 				source: this.source,
 				feed: archiveFeed(dropped),
 			});
@@ -477,6 +657,8 @@ export class BrokerExecutionArchiver {
 		if (batch.length === 0) {
 			return true;
 		}
+		this.inFlightBatch = batch;
+		this.inFlightStartedAtMs = Date.now();
 
 		// Secondary observability mirror: execution rows (not market_data.*, which
 		// has no OTel schema) are echoed to OTel logs when
@@ -499,11 +681,22 @@ export class BrokerExecutionArchiver {
 				await this.postToForwarder(batch);
 			} catch (error) {
 				this.stats.forwarderFailures += 1;
+				this.recordHealthEvent("failure");
+				this.lastSinkLatencyMs = Math.max(
+					0,
+					Date.now() - (this.inFlightStartedAtMs ?? Date.now()),
+				);
 				// Re-apply the oldest-shed bound: the batch was spliced out before the
 				// post, so new rows may have refilled the queue while it was in flight.
-				// Pushing it back can exceed maxQueueSize by up to batchSize, so trim.
-				this.queue.push(...batch);
-				this.enforceQueueBound();
+				// Prepending preserves the original order and timestamps. Requeueing can
+				// exceed maxQueueSize by up to batchSize, so trim the oldest entries.
+				this.queue.unshift(...batch);
+				try {
+					this.enforceQueueBound();
+				} finally {
+					this.clearInFlightBatch(batch);
+					this.emitArchiveHealthMetrics();
+				}
 				void this.recordArchiveMetric("cex_archive_forwarder_failures_total", {
 					count: batch.length,
 				});
@@ -513,22 +706,38 @@ export class BrokerExecutionArchiver {
 		}
 
 		this.stats.flushed += batch.length;
+		this.recordHealthEvent("success");
+		this.lastSinkLatencyMs = Math.max(
+			0,
+			Date.now() - (this.inFlightStartedAtMs ?? Date.now()),
+		);
+		this.clearInFlightBatch(batch);
 		this.recordFlushHealth(batch);
+		this.emitArchiveHealthMetrics();
 		return true;
+	}
+
+	private clearInFlightBatch(batch: QueuedArchiveRow[]): void {
+		if (this.inFlightBatch !== batch) {
+			return;
+		}
+		this.inFlightBatch = null;
+		this.inFlightStartedAtMs = null;
 	}
 
 	// Self-health emitted only on a successful forwarder post:
 	// a per-table rows-flushed counter to compare against enqueued, and a
 	// last-flush-success gauge (unix seconds) whose staleness is the "archive plane
 	// stuck" signal. Fire-and-forget so metrics never gate flushing.
-	private recordFlushHealth(batch: BrokerArchiveRow[]): void {
+	private recordFlushHealth(batch: readonly QueuedArchiveRow[]): void {
 		const countByTable = new Map<
 			string,
 			{ row: BrokerArchiveRow; count: number }
 		>();
 		for (const entry of batch) {
-			const key = `${entry.table}\u0000${archiveFeed(entry)}`;
-			const grouped = countByTable.get(key) ?? { row: entry, count: 0 };
+			const row = entry;
+			const key = `${row.table}\u0000${archiveFeed(row)}`;
+			const grouped = countByTable.get(key) ?? { row, count: 0 };
 			grouped.count += 1;
 			countByTable.set(key, grouped);
 		}
@@ -564,9 +773,22 @@ export class BrokerExecutionArchiver {
 	private async recordArchiveGauge(
 		metricName: string,
 		value: number,
+		labels: Record<string, string | number> = {},
 	): Promise<void> {
 		try {
-			await this.otelMetrics?.recordGauge(metricName, value, {});
+			await this.otelMetrics?.recordGauge(metricName, value, labels);
+		} catch {
+			// Archive metrics must not affect flushing.
+		}
+	}
+
+	private async recordArchiveObservableGauge(
+		metricName: string,
+		value: number,
+		labels: Record<string, string | number>,
+	): Promise<void> {
+		try {
+			await this.otelMetrics?.setObservableGauge(metricName, value, labels);
 		} catch {
 			// Archive metrics must not affect flushing.
 		}
@@ -614,38 +836,181 @@ export class BrokerExecutionArchiver {
 			headers.authorization = `Bearer ${this.forwarderAuthToken}`;
 		}
 		return new Promise<void>((resolve, reject) => {
-			const req = doRequest(
-				url,
-				{
-					method: "POST",
-					headers,
-					// Bound the request: a hung forwarder would otherwise stall the flush
-					// loop (flushes are serialized behind flushInFlight) indefinitely.
-					timeout: this.forwarderTimeoutMs,
-				},
-				(res) => {
-					// Drain the body so the socket can be released/reused.
-					res.on("data", () => {});
-					res.on("end", () => {
-						const status = res.statusCode ?? 0;
-						if (status < 200 || status >= 300) {
-							reject(
+			let req: ClientRequest | undefined;
+			let response: IncomingMessage | undefined;
+			let settled = false;
+			let requestClosed = false;
+			let requestCloseFailureScheduled = false;
+			let responseClosed = false;
+			let responseEnded = false;
+			let outerTimer: ReturnType<typeof setTimeout> | undefined;
+
+			function cleanupRequestListeners(): void {
+				req?.removeListener("error", onRequestError);
+				req?.removeListener("timeout", onRequestTimeout);
+				req?.removeListener("close", onRequestClose);
+			}
+
+			function cleanupResponseListeners(): void {
+				response?.removeListener("data", onResponseData);
+				response?.removeListener("end", onResponseEnd);
+				response?.removeListener("aborted", onResponseAborted);
+				response?.removeListener("error", onResponseError);
+				response?.removeListener("close", onResponseClose);
+			}
+
+			function onRequestClose(): void {
+				requestClosed = true;
+				// Bun can emit ClientRequest.close after the request body finishes and
+				// before response end, but a close with no response at all is a terminal
+				// pre-header transport failure. Defer one microtask so a response callback
+				// already queued for the same turn wins without masking a real close.
+				if (!settled && !response && !requestCloseFailureScheduled) {
+					requestCloseFailureScheduled = true;
+					queueMicrotask(() => {
+						if (!settled && !response) {
+							settle(
 								new Error(
-									`Archive forwarder returned ${status} ${res.statusMessage ?? ""}`,
+									"Archive forwarder request closed before response headers",
 								),
+								false,
+								true,
 							);
-							return;
 						}
-						resolve();
 					});
-				},
-			);
-			req.on("error", reject);
-			req.on("timeout", () => {
-				req.destroy(new Error("Archive forwarder request timed out"));
-			});
-			req.write(body);
-			req.end();
+				}
+				if (settled) {
+					cleanupRequestListeners();
+				}
+			}
+
+			function onRequestError(error: Error): void {
+				if (!settled) {
+					settle(error, true);
+				} else {
+					cleanupRequestListeners();
+				}
+			}
+
+			function onRequestTimeout(): void {
+				settle(new Error("Archive forwarder socket timed out"), true);
+			}
+
+			function onResponseData(): void {}
+
+			function onResponseEnd(): void {
+				responseEnded = true;
+				if (!response?.complete) {
+					settle(new Error("Archive forwarder response was incomplete"), true);
+					return;
+				}
+				const status = response.statusCode ?? 0;
+				if (status < 200 || status >= 300) {
+					settle(
+						new Error(
+							`Archive forwarder returned ${status} ${response.statusMessage ?? ""}`,
+						),
+						false,
+					);
+					return;
+				}
+				settle(undefined, false);
+			}
+
+			function onResponseAborted(): void {
+				settle(new Error("Archive forwarder response was aborted"), true);
+			}
+
+			function onResponseError(error: Error): void {
+				if (!settled) {
+					settle(error, true);
+				}
+			}
+
+			function onResponseClose(): void {
+				responseClosed = true;
+				if (!settled && !responseEnded) {
+					settle(
+						new Error("Archive forwarder response closed before completion"),
+						true,
+					);
+					return;
+				}
+				cleanupResponseListeners();
+			}
+
+			function settle(
+				error: Error | undefined,
+				destroyRequest: boolean,
+				retainClosedRequestError = false,
+			): void {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				if (outerTimer) {
+					clearTimeout(outerTimer);
+					outerTimer = undefined;
+				}
+				response?.removeListener("data", onResponseData);
+				response?.removeListener("end", onResponseEnd);
+				response?.removeListener("aborted", onResponseAborted);
+				if (responseClosed) {
+					cleanupResponseListeners();
+				}
+				// Keep the request error listener until close when destruction is
+				// requested. ClientRequest can emit its destroy error asynchronously.
+				if (destroyRequest && req && !requestClosed) {
+					req.destroy(error);
+				} else if (retainClosedRequestError && req && requestClosed) {
+					// The close event already happened; retain only the guarded error
+					// listener so a late transport error cannot become unhandled.
+					req.removeListener("timeout", onRequestTimeout);
+					req.removeListener("close", onRequestClose);
+				} else if (!req || requestClosed) {
+					cleanupRequestListeners();
+				}
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			}
+
+			// ClientRequest.timeout only observes socket inactivity. This outer timer
+			// covers lookup, connection, request write, response headers/body, and end.
+			outerTimer = setTimeout(() => {
+				settle(new Error("Archive forwarder request deadline exceeded"), true);
+			}, this.forwarderTimeoutMs);
+
+			try {
+				req = doRequest(
+					url,
+					{
+						method: "POST",
+						headers,
+						timeout: this.forwarderTimeoutMs,
+					},
+					(nextResponse) => {
+						response = nextResponse;
+						response.on("data", onResponseData);
+						response.on("end", onResponseEnd);
+						response.on("aborted", onResponseAborted);
+						response.on("error", onResponseError);
+						response.on("close", onResponseClose);
+						if (settled) {
+							response.resume();
+						}
+					},
+				);
+				req.on("error", onRequestError);
+				req.on("timeout", onRequestTimeout);
+				req.on("close", onRequestClose);
+				req.write(body);
+				req.end();
+			} catch (error) {
+				settle(error instanceof Error ? error : new Error(String(error)), true);
+			}
 		});
 	}
 }

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -8,6 +8,7 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LogRecord } from "@opentelemetry/api-logs";
@@ -83,6 +84,191 @@ function restoreEnv(key: string, original: string | undefined): void {
 		delete process.env[key];
 	} else {
 		process.env[key] = original;
+	}
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+	condition: () => boolean,
+	timeoutMs = 500,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!condition()) {
+		if (Date.now() >= deadline) {
+			throw new Error("condition did not become true before the deadline");
+		}
+		await delay(5);
+	}
+}
+
+type RawArchiveServerMode = "stream" | "abort" | "close" | "success";
+
+type RawArchiveServer = {
+	url: string;
+	requests: Array<{ body: Record<string, unknown> }>;
+	setMode: (mode: RawArchiveServerMode) => void;
+	waitForAccepted: (count?: number) => Promise<void>;
+	waitForResponseClose: (count?: number) => Promise<void>;
+	close: () => Promise<void>;
+};
+
+function startRawArchiveServer(
+	initialMode: RawArchiveServerMode,
+): Promise<RawArchiveServer> {
+	let mode = initialMode;
+	let acceptedCount = 0;
+	let responseClosedCount = 0;
+	const requests: Array<{ body: Record<string, unknown> }> = [];
+	const acceptedWaiters: Array<{
+		count: number;
+		resolve: () => void;
+	}> = [];
+	const responseCloseWaiters: Array<{
+		count: number;
+		resolve: () => void;
+	}> = [];
+	const server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
+		let abortTimer: ReturnType<typeof setTimeout> | undefined;
+		let remoteClosed = false;
+		const markResponseClosed = () => {
+			if (remoteClosed) {
+				return;
+			}
+			remoteClosed = true;
+			if (keepAliveTimer) {
+				clearInterval(keepAliveTimer);
+				keepAliveTimer = undefined;
+			}
+			if (abortTimer) {
+				clearTimeout(abortTimer);
+				abortTimer = undefined;
+			}
+			responseClosedCount += 1;
+			for (const waiter of responseCloseWaiters.splice(0)) {
+				if (responseClosedCount >= waiter.count) {
+					waiter.resolve();
+				} else {
+					responseCloseWaiters.push(waiter);
+				}
+			}
+		};
+		res.once("close", markResponseClosed);
+		req.once("close", markResponseClosed);
+		res.on("error", () => {});
+		req.on("error", () => {});
+		req.on("data", (chunk) => chunks.push(chunk as Buffer));
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			requests.push({
+				body: raw ? (JSON.parse(raw) as Record<string, unknown>) : {},
+			});
+			acceptedCount += 1;
+			for (const waiter of acceptedWaiters.splice(0)) {
+				if (acceptedCount >= waiter.count) {
+					waiter.resolve();
+				} else {
+					acceptedWaiters.push(waiter);
+				}
+			}
+
+			if (mode === "stream") {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.write("partial");
+				keepAliveTimer = setInterval(() => {
+					if (!res.destroyed) {
+						res.write("keep-alive");
+					}
+				}, 5);
+				return;
+			}
+			if (mode === "close") {
+				req.socket?.destroy();
+				return;
+			}
+			if (mode === "abort") {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.write("partial");
+				abortTimer = setTimeout(() => res.destroy(), 5);
+				return;
+			}
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end("{}");
+		});
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			const port = typeof address === "object" && address ? address.port : 0;
+			resolve({
+				url: `http://127.0.0.1:${port}/archive`,
+				requests,
+				setMode: (nextMode) => {
+					mode = nextMode;
+				},
+				waitForAccepted: (count = 1) =>
+					acceptedCount >= count
+						? Promise.resolve()
+						: new Promise((waiterResolve) => {
+								acceptedWaiters.push({ count, resolve: waiterResolve });
+							}),
+				waitForResponseClose: (count = 1) =>
+					responseClosedCount >= count
+						? Promise.resolve()
+						: new Promise((waiterResolve) => {
+								responseCloseWaiters.push({ count, resolve: waiterResolve });
+							}),
+				close: () =>
+					new Promise<void>((closeResolve) => {
+						server.closeAllConnections?.();
+						server.close(() => closeResolve());
+					}),
+			});
+		});
+	});
+}
+
+type CapturedArchiveMetric = {
+	kind: "counter" | "gauge" | "observable_gauge";
+	name: string;
+	value: number;
+	labels: Record<string, string | number>;
+};
+
+class CapturingArchiveMetrics {
+	readonly calls: CapturedArchiveMetric[] = [];
+
+	async recordCounter(
+		name: string,
+		value: number,
+		labels: Record<string, string | number>,
+	): Promise<void> {
+		this.calls.push({ kind: "counter", name, value, labels });
+	}
+
+	async recordGauge(
+		name: string,
+		value: number,
+		labels: Record<string, string | number>,
+	): Promise<void> {
+		this.calls.push({ kind: "gauge", name, value, labels });
+	}
+
+	async setObservableGauge(
+		name: string,
+		value: number,
+		labels: Record<string, string | number>,
+	): Promise<void> {
+		this.calls.push({ kind: "observable_gauge", name, value, labels });
+	}
+
+	asOtelMetrics(): OtelMetrics {
+		return this as unknown as OtelMetrics;
 	}
 }
 
@@ -1528,6 +1714,493 @@ describe("broker execution archiver queue", () => {
 
 			await archiver.close();
 		} finally {
+			await server.close();
+		}
+	});
+
+	test("bounds a response that stays open despite socket activity and retries without loss", async () => {
+		const server = await startRawArchiveServer("stream");
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 10,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 40,
+		});
+		const row = {
+			table: "broker_execution.order_events" as const,
+			row: { order_id: "streaming-response" },
+		};
+
+		try {
+			archiver.enqueue(row);
+			let settlementCount = 0;
+			const firstFlush = archiver.flush();
+			const observedFirstFlush = firstFlush.then(
+				() => {
+					settlementCount += 1;
+				},
+				() => {
+					settlementCount += 1;
+				},
+			);
+			await server.waitForAccepted();
+			const settledBeforeDeadline = await Promise.race([
+				observedFirstFlush.then(() => true),
+				delay(160).then(() => false),
+			]);
+			expect(settledBeforeDeadline).toBe(true);
+			expect(settlementCount).toBe(1);
+			expect(
+				await Promise.race([
+					server.waitForResponseClose().then(() => true),
+					delay(160).then(() => false),
+				]),
+			).toBe(true);
+			expect(archiver.getQueueDepth()).toBe(1);
+			expect(archiver.getStats().shed).toBe(0);
+			expect(
+				archiver.getHealthSnapshot().oldest_pending_age_ms,
+			).toBeGreaterThanOrEqual(35);
+
+			server.setMode("success");
+			const retryFlush = archiver.flush();
+			expect(retryFlush).not.toBe(firstFlush);
+			await retryFlush;
+			expect(archiver.getQueueDepth()).toBe(0);
+			expect(server.requests).toHaveLength(2);
+			expect(server.requests[0]?.body.rows).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						table: row.table,
+						row: expect.objectContaining(row.row),
+					}),
+				]),
+			);
+			expect(server.requests[1]?.body.rows).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						table: row.table,
+						row: expect.objectContaining(row.row),
+					}),
+				]),
+			);
+
+			await delay(80);
+			expect(settlementCount).toBe(1);
+		} finally {
+			await server.close();
+			await archiver.close();
+		}
+	});
+
+	test("settles a response that aborts after headers and retries without loss", async () => {
+		const server = await startRawArchiveServer("abort");
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 10,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 100,
+		});
+		const originalSetTimeout = globalThis.setTimeout;
+		const outerDeadlineTimers: Array<ReturnType<typeof setTimeout>> = [];
+		const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+			(callback, delayMs, ...args) => {
+				const handle = originalSetTimeout(callback, delayMs, ...args);
+				if (delayMs === 100) {
+					outerDeadlineTimers.push(handle);
+				}
+				return handle;
+			},
+		);
+		const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+		const row = {
+			table: "market_data.candles" as const,
+			row: { open_time_ms: 1_000 },
+		};
+
+		try {
+			archiver.enqueue(row);
+			let settlementCount = 0;
+			const firstFlush = archiver.flush();
+			const observedFirstFlush = firstFlush.then(
+				() => {
+					settlementCount += 1;
+				},
+				() => {
+					settlementCount += 1;
+				},
+			);
+			await server.waitForAccepted();
+			expect(
+				await Promise.race([
+					observedFirstFlush.then(() => true),
+					delay(160).then(() => false),
+				]),
+			).toBe(true);
+			expect(settlementCount).toBe(1);
+			expect(outerDeadlineTimers).toHaveLength(1);
+			expect(clearTimeoutSpy.mock.calls).toContainEqual([
+				outerDeadlineTimers[0],
+			]);
+			expect(
+				await Promise.race([
+					server.waitForResponseClose().then(() => true),
+					delay(160).then(() => false),
+				]),
+			).toBe(true);
+			expect(archiver.getQueueDepth()).toBe(1);
+			expect(archiver.getStats().shed).toBe(0);
+
+			server.setMode("success");
+			const retryFlush = archiver.flush();
+			expect(retryFlush).not.toBe(firstFlush);
+			await retryFlush;
+			expect(archiver.getQueueDepth()).toBe(0);
+			expect(server.requests).toHaveLength(2);
+			expect(server.requests[1]?.body.rows).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						table: row.table,
+						row: expect.objectContaining(row.row),
+					}),
+				]),
+			);
+		} finally {
+			clearTimeoutSpy.mockRestore();
+			setTimeoutSpy.mockRestore();
+			await server.close();
+			await archiver.close();
+		}
+	});
+
+	test("settles a pre-header connection close and retries without loss", async () => {
+		const server = await startRawArchiveServer("close");
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 10,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 100,
+		});
+		const row = {
+			table: "broker_execution.order_events" as const,
+			row: { order_id: "pre-header-close" },
+		};
+
+		try {
+			archiver.enqueue(row);
+			let settlementCount = 0;
+			const firstFlush = archiver.flush();
+			const observedFirstFlush = firstFlush.then(
+				() => {
+					settlementCount += 1;
+				},
+				() => {
+					settlementCount += 1;
+				},
+			);
+			await server.waitForAccepted();
+			expect(
+				await Promise.race([
+					observedFirstFlush.then(() => true),
+					delay(160).then(() => false),
+				]),
+			).toBe(true);
+			expect(settlementCount).toBe(1);
+			expect(
+				await Promise.race([
+					server.waitForResponseClose().then(() => true),
+					delay(160).then(() => false),
+				]),
+			).toBe(true);
+			expect(archiver.getQueueDepth()).toBe(1);
+			expect(archiver.getStats().shed).toBe(0);
+
+			server.setMode("success");
+			const retryFlush = archiver.flush();
+			expect(retryFlush).not.toBe(firstFlush);
+			await retryFlush;
+			expect(archiver.getQueueDepth()).toBe(0);
+			expect(server.requests).toHaveLength(2);
+			expect(server.requests[1]?.body.rows).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						table: row.table,
+						row: expect.objectContaining(row.row),
+					}),
+				]),
+			);
+			await delay(80);
+			expect(settlementCount).toBe(1);
+		} finally {
+			await server.close();
+			await archiver.close();
+		}
+	});
+
+	test("reports failed current health before shedding and recovers after a fresh persisted batch", async () => {
+		let status = 503;
+		const server = await startForwarderServer(() => ({ status }));
+		const metrics = new CapturingArchiveMetrics();
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 10,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 100,
+			maxQueueSize: 2,
+			otelMetrics: metrics.asOtelMetrics(),
+		});
+
+		try {
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { order_id: "failed-first" },
+			});
+			await archiver.flush();
+			const failed = archiver.getHealthSnapshot();
+			expect(failed.healthy).toBe(false);
+			expect(failed.queue_depth).toBe(1);
+			expect(failed.shed_total).toBe(0);
+			expect(typeof failed.last_failure_at).toBe("number");
+			expect(failed.last_success_at).toBeNull();
+			const healthCalls = () =>
+				metrics.calls.filter(
+					({ kind, name }) =>
+						kind === "observable_gauge" && name === "cex_archive_health",
+				);
+			const failureMetricOffset = metrics.calls.length;
+			expect(healthCalls().some(({ value }) => value === 0)).toBe(true);
+			status = 200;
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { order_id: "successful-recovery" },
+			});
+			const beforeSuccessHealthCalls = metrics.calls
+				.slice(failureMetricOffset)
+				.filter(
+					({ kind, name }) =>
+						kind === "observable_gauge" && name === "cex_archive_health",
+				);
+			expect(beforeSuccessHealthCalls).not.toEqual(
+				expect.arrayContaining([expect.objectContaining({ value: 1 })]),
+			);
+			await archiver.flush();
+			const recovered = archiver.getHealthSnapshot();
+			expect(recovered.healthy).toBe(true);
+			expect(recovered.queue_depth).toBe(0);
+			expect(recovered.shed_total).toBe(0);
+			expect(typeof recovered.last_success_at).toBe("number");
+			expect(recovered.sink_errors_total).toBe(1);
+			expect(recovered.sink_latency_ms).toBeGreaterThanOrEqual(0);
+			expect(healthCalls().at(-1)?.value).toBe(1);
+			for (const call of healthCalls()) {
+				expect(call.labels).toEqual({ source: "broker_write" });
+			}
+
+			const metricNames = new Set(metrics.calls.map(({ name }) => name));
+			for (const name of [
+				"cex_archive_health",
+				"cex_archive_queue_depth",
+				"cex_archive_oldest_pending_age_ms",
+				"cex_archive_shed_total",
+				"cex_archive_last_failure_at",
+				"cex_archive_last_shed_at",
+				"cex_archive_last_success_at",
+				"cex_archive_sink_latency_ms",
+				"cex_archive_sink_errors_total",
+				"cex_archive_in_flight",
+				"cex_archive_in_flight_age_ms",
+			]) {
+				expect(metricNames.has(name)).toBe(true);
+			}
+		} finally {
+			await archiver.close();
+			await server.close();
+		}
+	});
+
+	test("keeps wall timestamps truthful while event order drives recovery", async () => {
+		const wallClockMs = 1_700_000_000_000;
+		const originalDateNow = Date.now;
+		Date.now = () => wallClockMs;
+		let status = 503;
+		const server = await startForwarderServer(() => ({ status }));
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 10,
+			maxQueueSize: 2,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 100,
+		});
+
+		try {
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { order_id: "same-ms-failure" },
+			});
+			await archiver.flush();
+			const failed = archiver.getHealthSnapshot();
+			expect(failed.healthy).toBe(false);
+			expect(failed.last_failure_at).toBe(wallClockMs);
+			expect(failed.last_success_at).toBeNull();
+			expect(failed.shed_total).toBe(0);
+
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { order_id: "same-ms-retained" },
+			});
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { order_id: "same-ms-shed" },
+			});
+			const shed = archiver.getHealthSnapshot();
+			expect(shed.healthy).toBe(false);
+			expect(shed.last_shed_at).toBe(wallClockMs);
+			expect(shed.shed_total).toBe(1);
+
+			status = 200;
+			await archiver.flush();
+			const recovered = archiver.getHealthSnapshot();
+			expect(recovered.healthy).toBe(true);
+			expect(recovered.last_failure_at).toBe(wallClockMs);
+			expect(recovered.last_shed_at).toBe(wallClockMs);
+			expect(recovered.last_success_at).toBe(wallClockMs);
+			expect(recovered.shed_total).toBe(1);
+			expect(recovered.sink_errors_total).toBe(1);
+		} finally {
+			Date.now = originalDateNow;
+			await archiver.close();
+			await server.close();
+		}
+	});
+
+	test("marks saturation unhealthy before the next enqueue would shed and keeps in-flight age visible", async () => {
+		let releaseResponse: () => void = () => {};
+		const responseGate = new Promise<void>((resolve) => {
+			releaseResponse = resolve;
+		});
+		const server = await startForwarderServer(async () => {
+			await responseGate;
+			return { status: 200 };
+		});
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 3,
+			maxQueueSize: 2,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 200,
+		});
+
+		try {
+			for (const orderId of ["saturated-1", "saturated-2"]) {
+				archiver.enqueue({
+					table: "broker_execution.order_events",
+					row: { order_id: orderId },
+				});
+			}
+			const saturated = archiver.getHealthSnapshot();
+			expect(saturated.healthy).toBe(false);
+			expect(saturated.queue_depth).toBe(2);
+			expect(saturated.shed_total).toBe(0);
+
+			archiver.enqueue({
+				table: "broker_execution.order_events",
+				row: { order_id: "saturated-3" },
+			});
+			const shed = archiver.getHealthSnapshot();
+			expect(shed.healthy).toBe(false);
+			expect(shed.shed_total).toBe(1);
+			expect(typeof shed.last_shed_at).toBe("number");
+
+			const flushPromise = archiver.flush();
+			await waitForCondition(() => server.requests.length === 1);
+			await delay(20);
+			const inFlight = archiver.getHealthSnapshot();
+			expect(inFlight.queue_depth).toBe(0);
+			expect(inFlight.in_flight).toBe(true);
+			expect(inFlight.in_flight_age_ms).toBeGreaterThan(0);
+			expect(inFlight.oldest_pending_age_ms).toBeGreaterThan(0);
+			expect(inFlight.oldest_pending_age_ms).toBeGreaterThanOrEqual(
+				inFlight.in_flight_age_ms,
+			);
+			expect(inFlight.healthy).toBe(false);
+
+			releaseResponse();
+			await flushPromise;
+			const recovered = archiver.getHealthSnapshot();
+			expect(recovered.healthy).toBe(true);
+			expect(recovered.oldest_pending_age_ms).toBe(0);
+			expect(recovered.shed_total).toBe(1);
+			expect(recovered.last_shed_at).toBe(shed.last_shed_at);
+		} finally {
+			await archiver.close();
+			await server.close();
+		}
+	});
+
+	test("keeps a slow successful sink healthy and bounded while the queue refills", async () => {
+		let requestCount = 0;
+		let releaseFirstResponse: () => void = () => {};
+		const firstResponseGate = new Promise<void>((resolve) => {
+			releaseFirstResponse = resolve;
+		});
+		const server = await startForwarderServer(async () => {
+			requestCount += 1;
+			if (requestCount === 1) {
+				await firstResponseGate;
+			}
+			return { status: 200 };
+		});
+		const archiver = BrokerExecutionArchiver.create({
+			forwarderUrl: server.url,
+			deadLetterPath: createDeadLetterPath(),
+			batchSize: 10,
+			maxQueueSize: 3,
+			flushIntervalMs: 60_000,
+			forwarderTimeoutMs: 200,
+		});
+
+		try {
+			for (const orderId of ["slow-1", "slow-2"]) {
+				archiver.enqueue({
+					table: "broker_execution.order_events",
+					row: { order_id: orderId },
+				});
+			}
+			const firstFlush = archiver.flush();
+			await waitForCondition(() => server.requests.length === 1);
+			await delay(20);
+			for (const orderId of ["refill-1", "refill-2"]) {
+				archiver.enqueue({
+					table: "broker_execution.order_events",
+					row: { order_id: orderId },
+				});
+			}
+			expect(archiver.getQueueDepth()).toBe(2);
+			expect(archiver.getStats().shed).toBe(0);
+
+			await delay(20);
+			releaseFirstResponse();
+			await firstFlush;
+			expect(archiver.getQueueDepth()).toBe(2);
+			expect(archiver.getStats().shed).toBe(0);
+			expect(archiver.getHealthSnapshot().healthy).toBe(true);
+			expect(archiver.getHealthSnapshot().sink_latency_ms).toBeGreaterThan(0);
+
+			const secondFlush = archiver.flush();
+			expect(secondFlush).not.toBe(firstFlush);
+			await secondFlush;
+			expect(archiver.getQueueDepth()).toBe(0);
+			expect(archiver.getStats().shed).toBe(0);
+			expect(archiver.getHealthSnapshot().healthy).toBe(true);
+			expect(server.requests).toHaveLength(2);
+		} finally {
+			await archiver.close();
 			await server.close();
 		}
 	});


### PR DESCRIPTION
## Summary
- bound archive-forwarder POSTs across connection, write, response, and completion states
- preserve queued rows through failed attempts while releasing the serialized flush for retry
- expose recoverable archive queue/sink health and low-cardinality runtime metrics before shedding
- cover hanging, aborted, pre-header-close, saturation, recovery, and slow-sink cases

## Validation
- `bun test test/broker-execution-archive.test.ts` — 51 pass
- `bun test test/ohlcv-collector.test.ts test/ohlcv-collector-shutdown.test.ts` — 5 pass
- `bun test` — 675 pass across 63 files
- TypeScript, Biome, and diff checks

## Release status
This change is not released or deployed. Live archive queue draining, candle freshness, and 48-hour verification remain separate post-deploy gates.
