### PR TITLE
Release 0.2.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@usherlabs/cex-broker",
-	"version": "0.2.40",
+	"version": "0.2.41",
 	"description": "Unified gRPC API to CEXs by Usher Labs.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Version bump for the 0.2.41 release train.

Carries since v0.2.40:
- #119 pin bun version for reproducible builds
- #121 ohlcv-collector: detect silent OHLCV stream death via cadence deadline and exit for restart
- #122 bound archive forwarder requests and surface queue health

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 0.2.40 to 0.2.41.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->