### PR TITLE
refactor(archive): collapse the duplicate archive timestamp normalizer

### DIFF
--- a/src/helpers/order-telemetry.ts
+++ b/src/helpers/order-telemetry.ts
@@ -1,3 +1,6 @@
+// Imported from the row builder module rather than the package barrel: the
+// barrel pulls in capture.ts, which imports this module at runtime.
+import { normalizeTimestamp } from "./broker-execution-archive/rows";
 import { log } from "./logger";
 import type { OtelMetrics } from "./otel";
 import { REDACTED_ERROR_MESSAGE } from "./shared/errors";
@@ -300,18 +303,6 @@ function computeAveragePrice(
 		return undefined;
 	}
 	return executedQuoteQuantity / executedBaseQuantity;
-}
-
-function normalizeTimestamp(value: unknown): string | undefined {
-	if (typeof value === "string" && value.trim()) {
-		return value.trim();
-	}
-	const timestamp = firstNumber(value);
-	if (timestamp === undefined) {
-		return undefined;
-	}
-	const date = new Date(timestamp);
-	return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }
 
 function getFees(record: JsonRecord | undefined, info: JsonRecord | undefined) {


### PR DESCRIPTION
`src/helpers/order-telemetry.ts` carried a private copy of the archive timestamp normalizer that was byte-for-byte equivalent to the exported `normalizeTimestamp` in `src/helpers/broker-execution-archive/rows.ts` (down to a duplicate `firstNumber` helper it shares behavior with).

That coercion is load-bearing: the archive's DateTime64 columns are fed ISO-8601 UTC strings, and an epoch-ms integer passed through untouched is read by ClickHouse as *seconds*, landing the row tens of thousands of years ahead. Every private copy is somewhere the next producer copies the wrong thing from.

## Change

- Delete the private `normalizeTimestamp` in `order-telemetry.ts`.
- Import the exported one from `broker-execution-archive/rows`.

Imported from the row-builder module rather than the package barrel: the barrel pulls in `capture.ts`, which imports `order-telemetry` at runtime, so going through the barrel would introduce a require cycle.

No behavior change: the deleted copy and the survivor are identical in logic, including the numeric-coercion helper each used.

## Out of scope

`services/archive-forwarder/stream-health-contract.ts` also has a local `normalizeTimestamp`, but it is **not** a twin — it is a strict consumer-side validator that accepts only exact `YYYY-MM-DDTHH:MM:SS.sssZ` strings and rejects everything else, including the epoch-ms numbers the producer-side normalizer is built to convert. Collapsing it into the producer helper would weaken a validation gate. Left alone deliberately.

## Verification

- `tsc --noEmit`: clean.
- `biome check` on the touched file: clean.
- Full `bun test` suite (pre-commit hook): 679 pass, 0 fail across 63 files. No fixture weakened.