### PR TITLE
fix(archive): make archive retries idempotent instead of duplicating rows

### DIFF
--- a/schema/clickhouse/market_data.sql
+++ b/schema/clickhouse/market_data.sql
@@ -8,6 +8,7 @@
 --   {
 --     "source": "broker_write",
 --     "deployment_id": "<deployment>",
+--     "batch_id": "<stable across retries of these exact rows>",
 --     "rows": [{ "table": "<fully.qualified.table>", "row": { ...columns } }]
 --   }
 --
@@ -56,7 +57,8 @@ CREATE TABLE IF NOT EXISTS market_data.orderbook_snapshots
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
 ORDER BY (exchange, asset_type, symbol, event_time_ms)
-TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY;
+TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY
+SETTINGS non_replicated_deduplication_window = 1000000;
 
 -- Every legacy market-data producer has emitted this common archive tag since
 -- the pre-canonical baseline. Add it idempotently so fresh and upgraded schemas
@@ -129,7 +131,8 @@ CREATE TABLE IF NOT EXISTS market_data.candles
 )
 ENGINE = ReplacingMergeTree(broker_version)
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(open_time_ms))
-ORDER BY (exchange, asset_type, symbol, timeframe, open_time_ms);
+ORDER BY (exchange, asset_type, symbol, timeframe, open_time_ms)
+SETTINGS non_replicated_deduplication_window = 1000000;
 
 ALTER TABLE market_data.candles ADD COLUMN IF NOT EXISTS broker_observed_timestamp String DEFAULT '' AFTER symbol;
 
@@ -160,7 +163,8 @@ CREATE TABLE IF NOT EXISTS market_data.cex_stream_events
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
 ORDER BY (exchange, asset_type, symbol, stream_type, event_time_ms)
-TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY;
+TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY
+SETTINGS non_replicated_deduplication_window = 1000000;
 
 ALTER TABLE market_data.cex_stream_events ADD COLUMN IF NOT EXISTS broker_observed_timestamp String DEFAULT '' AFTER symbol;
 
@@ -195,7 +199,8 @@ CREATE TABLE IF NOT EXISTS market_data.cex_ticker_events
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
 ORDER BY (exchange, asset_type, symbol, event_time_ms)
-TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY;
+TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY
+SETTINGS non_replicated_deduplication_window = 1000000;
 
 ALTER TABLE market_data.cex_ticker_events ADD COLUMN IF NOT EXISTS broker_observed_timestamp String DEFAULT '' AFTER symbol;
 
@@ -223,7 +228,8 @@ CREATE TABLE IF NOT EXISTS market_data.cex_trades
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(event_time_ms))
 ORDER BY (exchange, asset_type, symbol, event_time_ms, trade_id)
-TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY;
+TTL toDateTime(fromUnixTimestamp64Milli(event_time_ms)) + INTERVAL 90 DAY
+SETTINGS non_replicated_deduplication_window = 1000000;
 
 ALTER TABLE market_data.cex_trades ADD COLUMN IF NOT EXISTS broker_observed_timestamp String DEFAULT '' AFTER symbol;
 
@@ -317,7 +323,7 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(source_time_ms))
 ORDER BY (exchange, trading_pair, capture_bundle_id, source_time_ms, raw_capture_id, snapshot_id, schema_version, side, level_index)
 TTL toDateTime(fromUnixTimestamp64Milli(source_time_ms)) + INTERVAL 90 DAY
-SETTINGS allow_nullable_key = 1;
+SETTINGS allow_nullable_key = 1, non_replicated_deduplication_window = 1000000;
 
 CREATE TABLE IF NOT EXISTS market_data.cex_order_book_depth_summary
 (
@@ -365,7 +371,7 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(source_time_ms))
 ORDER BY (exchange, trading_pair, capture_bundle_id, source_time_ms, raw_capture_id, snapshot_id, schema_version)
 TTL toDateTime(fromUnixTimestamp64Milli(source_time_ms)) + INTERVAL 90 DAY
-SETTINGS allow_nullable_key = 1;
+SETTINGS allow_nullable_key = 1, non_replicated_deduplication_window = 1000000;
 
 CREATE VIEW IF NOT EXISTS market_data.cex_order_book_levels_conflicts AS
 SELECT
@@ -470,9 +476,32 @@ CREATE TABLE IF NOT EXISTS market_data.cex_ohlcv
 ENGINE = ReplacingMergeTree(broker_version)
 PARTITION BY toYYYYMM(fromUnixTimestamp64Milli(open_time_ms))
 ORDER BY (exchange, trading_pair, timeframe, open_time_ms, schema_version)
-SETTINGS allow_nullable_key = 1;
+SETTINGS allow_nullable_key = 1, non_replicated_deduplication_window = 1000000;
 
 CREATE VIEW IF NOT EXISTS market_data.cex_ohlcv_closed AS
 SELECT *
 FROM market_data.cex_ohlcv FINAL
 WHERE is_closed = 1;
+
+-- Insert deduplication for the forwarder's retry path. A batch the forwarder
+-- could not fully commit is re-posted verbatim under its original id, so the
+-- tables that already landed are inserted again; each insert carries a token
+-- derived from that id, and this window is what makes ClickHouse recognise the
+-- token and skip the repeat. Existing deployments pick it up here, since the
+-- CREATE statements above are no-ops once the tables exist.
+ALTER TABLE market_data.orderbook_snapshots
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.candles
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.cex_stream_events
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.cex_ticker_events
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.cex_trades
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.cex_order_book_levels
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.cex_order_book_depth_summary
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;
+ALTER TABLE market_data.cex_ohlcv
+    MODIFY SETTING non_replicated_deduplication_window = 1000000;

--- a/services/archive-forwarder/dedupe-token.ts
+++ b/services/archive-forwarder/dedupe-token.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Per-(batch, table) ClickHouse insert deduplication token.
+ *
+ * A sender that retries a failed batch re-posts every table in it, including
+ * tables whose insert already succeeded before a sibling table failed — the
+ * forwarder commits per table and has no cross-table transaction to roll back.
+ * A token stable across those retries is what stops the re-post from landing a
+ * second copy: ClickHouse skips an insert whose token it has already seen
+ * within the table's non_replicated_deduplication_window.
+ *
+ * The token is derived rather than sent so a sender only has to keep one batch
+ * identity stable, and so two batches can never collide on a table by accident.
+ */
+export function archiveDedupeToken(batchId: string, table: string): string {
+	return createHash("sha256")
+		.update(`maker-archive-forwarder-v1\0${batchId}\0${table}`)
+		.digest("hex");
+}

--- a/services/archive-forwarder/insert.ts
+++ b/services/archive-forwarder/insert.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { clickHouseRequestDeadline } from "./clickhouse-deadline";
+import { archiveDedupeToken } from "./dedupe-token";
 import type { ArchiveForwarderTelemetry } from "./telemetry";
 import type { ArchiveRow, ArchiveBatchResult, SupportedTable } from "./types";
 import { isSupportedTable } from "./types";
@@ -33,6 +34,7 @@ export async function insertArchiveRows(
 	inserter: RowInserter,
 	rows: ArchiveRow[],
 	telemetry?: ArchiveForwarderTelemetry,
+	batchId?: string,
 ): Promise<ArchiveBatchResult> {
 	const grouped = groupRowsByTable(rows);
 	const byTable: Record<string, number> = {};
@@ -40,12 +42,21 @@ export async function insertArchiveRows(
 	let inserted = 0;
 	let failed = 0;
 
+	// One table failing fails the whole request, and the sender retries the whole
+	// batch — including the tables that already landed. Without a batch identity
+	// those re-posts duplicate; with one, ClickHouse discards them.
 	for (const [table, tableRows] of grouped.entries()) {
 		if (tableRows.length === 0) {
 			continue;
 		}
 		try {
-			await inserter(table, tableRows);
+			await inserter(
+				table,
+				tableRows,
+				batchId
+					? { deduplicationToken: archiveDedupeToken(batchId, table) }
+					: undefined,
+			);
 			byTable[table] = tableRows.length;
 			inserted += tableRows.length;
 			telemetry?.recordRowsInserted(table, tableRows.length);

--- a/services/archive-forwarder/router.ts
+++ b/services/archive-forwarder/router.ts
@@ -123,6 +123,14 @@ export function parseArchiveBatchRequest(body: unknown): ParsedArchiveBatch {
 	if (!Array.isArray(record.rows)) {
 		return { ok: false };
 	}
+	// Absent is a valid contract (the sender claims no retry identity); present
+	// but blank is a broken sender that would silently lose deduplication.
+	if (
+		record.batch_id !== undefined &&
+		(typeof record.batch_id !== "string" || record.batch_id.trim() === "")
+	) {
+		return { ok: false };
+	}
 	const inputRowCount = record.rows.length;
 	const structurallyValidRows = record.rows.filter((entry) =>
 		isValidArchiveRow(entry, record.source as string),
@@ -139,6 +147,9 @@ export function parseArchiveBatchRequest(body: unknown): ParsedArchiveBatch {
 		batch: {
 			source: record.source,
 			deployment_id: record.deployment_id,
+			...(record.batch_id === undefined
+				? {}
+				: { batch_id: record.batch_id as string }),
 			rows,
 		},
 		inputRowCount,
@@ -196,7 +207,12 @@ export async function handleArchiveBatch(
 	request: ArchiveBatchRequest,
 	telemetry?: ArchiveForwarderTelemetry,
 ): Promise<ArchiveBatchResult> {
-	const result = await insertArchiveRows(inserter, request.rows, telemetry);
+	const result = await insertArchiveRows(
+		inserter,
+		request.rows,
+		telemetry,
+		request.batch_id,
+	);
 	// Requires rows to have actually landed. `failed === 0` is also true for an
 	// empty batch, and an empty POST advancing this gauge would keep a staleness
 	// alert green while nothing reaches ClickHouse — the precise failure this

--- a/services/archive-forwarder/strategy-spool.ts
+++ b/services/archive-forwarder/strategy-spool.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
+import { archiveDedupeToken } from "./dedupe-token";
 import { groupRowsByTable } from "./insert";
 import type { StrategyArchiveTable } from "./strategy-contract";
 import type { ArchiveBatchRequest } from "./types";
@@ -99,12 +100,6 @@ type WorkRow = {
 
 function utf8Bytes(value: string): number {
 	return new TextEncoder().encode(value).byteLength;
-}
-
-function dedupeToken(batchId: string, table: string): string {
-	return createHash("sha256")
-		.update(`maker-archive-forwarder-v1\0${batchId}\0${table}`)
-		.digest("hex");
 }
 
 function groupedRows(batch: ArchiveBatchRequest) {
@@ -243,7 +238,7 @@ export class StrategyArchiveSpool {
 						batchId,
 						group.table,
 						group.rowsJson,
-						dedupeToken(batchId, group.table),
+						archiveDedupeToken(batchId, group.table),
 						admittedAtMs,
 					);
 			}

--- a/services/archive-forwarder/types.ts
+++ b/services/archive-forwarder/types.ts
@@ -6,6 +6,13 @@ export type ArchiveRow = {
 export type ArchiveBatchRequest = {
 	source: string;
 	deployment_id: string;
+	/**
+	 * Retry identity of this batch: the same rows re-posted after a failure carry
+	 * the same id, so the forwarder can make the re-insert a no-op. Transport
+	 * metadata — it never reaches a row, and a sender that cannot keep an id
+	 * stable across its retries must omit it rather than send a fresh one.
+	 */
+	batch_id?: string;
 	rows: ArchiveRow[];
 };
 

--- a/src/helpers/broker-execution-archive/writer.ts
+++ b/src/helpers/broker-execution-archive/writer.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { closeSync, fsyncSync, openSync, writeSync } from "node:fs";
 import {
 	type ClientRequest,
@@ -81,8 +82,16 @@ const DEFAULT_BATCH_SIZE = 10;
 const DEFAULT_FLUSH_INTERVAL_MS = 1_000;
 const DEFAULT_FORWARDER_TIMEOUT_MS = 3_000;
 const SHED_WARN_INTERVAL_MS = 60_000;
+// A pinned batch is retried verbatim, so a batch the forwarder rejects for its
+// own content (an unknown table after a version skew, say) would otherwise pin
+// the archive plane behind it forever. Give up after this many attempts and
+// journal it, the same terms every other undeliverable row gets.
+const MAX_PINNED_BATCH_ATTEMPTS = 10;
 
-type ArchiveLossReason = "queue_shed" | "shutdown_forwarder_failure";
+type ArchiveLossReason =
+	| "queue_shed"
+	| "shutdown_forwarder_failure"
+	| "retry_exhausted";
 
 type ArchiveLossRecord = {
 	timestamp: string;
@@ -93,6 +102,20 @@ type ArchiveLossRecord = {
 };
 
 type QueuedArchiveRow = BrokerArchiveRow;
+
+/**
+ * A batch the forwarder did not accept, held aside instead of being pushed back
+ * into the queue. The retry must re-post byte-identical rows under the same
+ * `batchId`: that pair is what lets the forwarder recognise the re-post and skip
+ * the tables that already landed before a sibling table failed. Rows mixed back
+ * into the queue could not offer that — new arrivals and the oldest-first shed
+ * both reshape the next batch.
+ */
+type PinnedRetryBatch = {
+	batchId: string;
+	rows: QueuedArchiveRow[];
+	attempts: number;
+};
 
 const MARKET_FEEDS = new Set(["ORDERBOOK", "TICKER", "TRADES", "OHLCV"]);
 
@@ -158,6 +181,7 @@ export class BrokerExecutionArchiver {
 		flushed: 0,
 		forwarderFailures: 0,
 	};
+	private pendingRetry: PinnedRetryBatch | null = null;
 	private flushTimer: ReturnType<typeof setInterval> | null = null;
 	private flushInFlight: Promise<void> | null = null;
 	private inFlightBatch: QueuedArchiveRow[] | null = null;
@@ -335,7 +359,11 @@ export class BrokerExecutionArchiver {
 	}
 
 	async flush(): Promise<void> {
-		if (!this.enabled || this.closed || this.queue.length === 0) {
+		if (
+			!this.enabled ||
+			this.closed ||
+			(this.queue.length === 0 && this.pendingRetry === null)
+		) {
 			return;
 		}
 		if (this.flushInFlight) {
@@ -373,16 +401,24 @@ export class BrokerExecutionArchiver {
 		}
 		let closeError: unknown;
 		try {
-			while (this.queue.length > 0 || this.flushInFlight) {
+			while (
+				this.pendingRetry !== null ||
+				this.queue.length > 0 ||
+				this.flushInFlight
+			) {
 				if (this.flushInFlight) {
 					await this.flushInFlight;
 					continue;
 				}
-				const depthBefore = this.queue.length;
-				const flushed = await this.flushBatch();
-				if (!flushed && this.queue.length >= depthBefore && depthBefore > 0) {
-					const undelivered = [...this.queue];
+				// No retry loop at shutdown: one failed attempt and everything still
+				// held — pinned batch first, then the queue — goes to the journal.
+				if (!(await this.flushBatch())) {
+					const undelivered = [
+						...(this.pendingRetry?.rows ?? []),
+						...this.queue,
+					];
 					this.appendLossRecords(undelivered, "shutdown_forwarder_failure");
+					this.pendingRetry = null;
 					this.queue.length = 0;
 					break;
 				}
@@ -407,8 +443,10 @@ export class BrokerExecutionArchiver {
 		return { ...this.stats };
 	}
 
+	// Pinned rows are undelivered too, so they count as depth even though they sit
+	// outside the queue and outside its bound.
 	getQueueDepth(): number {
-		return this.queue.length;
+		return this.queue.length + (this.pendingRetry?.rows.length ?? 0);
 	}
 
 	getHealthSnapshot(): Readonly<BrokerExecutionArchiveHealthSnapshot> {
@@ -439,7 +477,9 @@ export class BrokerExecutionArchiver {
 
 		return {
 			healthy,
-			queue_depth: this.queue.length,
+			// Reported depth includes pinned rows; the saturation check above stays
+			// on the queue proper, which is the only part the bound governs.
+			queue_depth: this.getQueueDepth(),
 			oldest_pending_age_ms: oldestPendingAgeMs,
 			shed_total: this.stats.shed,
 			last_failure_at: this.lastFailureAtMs,
@@ -454,6 +494,13 @@ export class BrokerExecutionArchiver {
 
 	private oldestPendingEnqueueAtMs(): number | null {
 		let oldest: number | null = null;
+		for (const entry of this.pendingRetry?.rows ?? []) {
+			const enqueuedAtMs = this.enqueueTimes.get(entry);
+			if (enqueuedAtMs === undefined) {
+				continue;
+			}
+			oldest = oldest === null ? enqueuedAtMs : Math.min(oldest, enqueuedAtMs);
+		}
 		for (const entry of this.queue) {
 			const enqueuedAtMs = this.enqueueTimes.get(entry);
 			if (enqueuedAtMs === undefined) {
@@ -567,32 +614,6 @@ export class BrokerExecutionArchiver {
 		}
 	}
 
-	// Drop oldest rows until the queue is within maxQueueSize, counting each into
-	// the shed stat/metric. Mirrors the enqueue-time shed policy for the requeue
-	// path, which can otherwise push the queue past the bound during an outage.
-	private enforceQueueBound(): void {
-		while (this.queue.length > this.maxQueueSize) {
-			const dropped = this.queue[0];
-			if (!dropped) {
-				return;
-			}
-			this.appendLossRecords([dropped], "queue_shed");
-			this.queue.shift();
-			this.stats.shed += 1;
-			this.recordHealthEvent("shed");
-			void this.recordArchiveMetric("cex_archive_rows_shed_total", {
-				table: dropped.table,
-				source: this.source,
-				feed: archiveFeed(dropped),
-			});
-			void this.recordArchiveMetric("cex_archive_queue_saturated_rows_total", {
-				table: dropped.table,
-				source: this.source,
-				feed: archiveFeed(dropped),
-			});
-		}
-	}
-
 	private appendLossRecords(
 		rows: readonly BrokerArchiveRow[],
 		reason: ArchiveLossReason,
@@ -653,10 +674,14 @@ export class BrokerExecutionArchiver {
 	}
 
 	private async flushBatch(): Promise<boolean> {
-		const batch = this.queue.splice(0, this.batchSize);
+		// A pinned batch goes back out before anything newer, unchanged and under
+		// its original id, so the forwarder sees a retry rather than a new batch.
+		const pinned = this.pendingRetry;
+		const batch = pinned ? pinned.rows : this.queue.splice(0, this.batchSize);
 		if (batch.length === 0) {
 			return true;
 		}
+		const batchId = pinned?.batchId ?? randomUUID();
 		this.inFlightBatch = batch;
 		this.inFlightStartedAtMs = Date.now();
 
@@ -674,11 +699,11 @@ export class BrokerExecutionArchiver {
 
 		// The forwarder is the durable sink for every archive table it supports
 		// (market_data.*, broker_execution.*, broker_account.*, strategy_data.*).
-		// Requeue the whole batch on failure so nothing is silently dropped while a
+		// Pin the whole batch on failure so nothing is silently dropped while a
 		// forwarder is set.
 		if (this.forwarderUrl) {
 			try {
-				await this.postToForwarder(batch);
+				await this.postToForwarder(batch, batchId);
 			} catch (error) {
 				this.stats.forwarderFailures += 1;
 				this.recordHealthEvent("failure");
@@ -686,13 +711,18 @@ export class BrokerExecutionArchiver {
 					0,
 					Date.now() - (this.inFlightStartedAtMs ?? Date.now()),
 				);
-				// Re-apply the oldest-shed bound: the batch was spliced out before the
-				// post, so new rows may have refilled the queue while it was in flight.
-				// Prepending preserves the original order and timestamps. Requeueing can
-				// exceed maxQueueSize by up to batchSize, so trim the oldest entries.
-				this.queue.unshift(...batch);
+				const attempts = (pinned?.attempts ?? 0) + 1;
 				try {
-					this.enforceQueueBound();
+					if (attempts >= MAX_PINNED_BATCH_ATTEMPTS) {
+						this.pendingRetry = null;
+						this.appendLossRecords(batch, "retry_exhausted");
+						log.warn("Broker execution archive gave up on a batch", {
+							attempts,
+							rows: batch.length,
+						});
+					} else {
+						this.pendingRetry = { batchId, rows: batch, attempts };
+					}
 				} finally {
 					this.clearInFlightBatch(batch);
 					this.emitArchiveHealthMetrics();
@@ -705,6 +735,7 @@ export class BrokerExecutionArchiver {
 			}
 		}
 
+		this.pendingRetry = null;
 		this.stats.flushed += batch.length;
 		this.recordHealthEvent("success");
 		this.lastSinkLatencyMs = Math.max(
@@ -817,13 +848,17 @@ export class BrokerExecutionArchiver {
 	// archive plane. node's request stays on the transport proven to work in the
 	// enclave. Same failure class and mitigation as resolveOnChainSender in
 	// travel-rule-deposit-reconciler.ts.
-	private postToForwarder(batch: BrokerArchiveRow[]): Promise<void> {
+	private postToForwarder(
+		batch: BrokerArchiveRow[],
+		batchId: string,
+	): Promise<void> {
 		if (!this.forwarderUrl || batch.length === 0) {
 			return Promise.resolve();
 		}
 		const body = JSON.stringify({
 			source: this.source,
 			deployment_id: this.deploymentId,
+			batch_id: batchId,
 			rows: batch,
 		});
 		const url = new URL(this.forwarderUrl);

--- a/test/archive-forwarder.test.ts
+++ b/test/archive-forwarder.test.ts
@@ -10,7 +10,10 @@ import {
 	parseArchiveBatchRequest,
 } from "../services/archive-forwarder/router";
 import { ensureArchiveSchema } from "../services/archive-forwarder/schema";
-import { isSupportedTable } from "../services/archive-forwarder/types";
+import {
+	isSupportedTable,
+	SUPPORTED_TABLES,
+} from "../services/archive-forwarder/types";
 
 describe("archive forwarder batch parsing", () => {
 	test("parseArchiveBatchRequest accepts broker_write payloads", () => {
@@ -395,7 +398,139 @@ describe("archive forwarder routing", () => {
 	});
 });
 
+describe("archive forwarder retry deduplication", () => {
+	const rows = [
+		{ table: "market_data.cex_stream_events", row: { event_time_ms: 1 } },
+		{ table: "market_data.cex_ohlcv", row: { open_time_ms: 1 } },
+	];
+
+	function recordingInserter(failTable?: string) {
+		const calls: Array<{ table: string; token?: string }> = [];
+		const inserter = async (
+			table: string,
+			_rows: Record<string, unknown>[],
+			options?: { deduplicationToken?: string },
+		) => {
+			calls.push({ table, token: options?.deduplicationToken });
+			if (table === failTable) {
+				throw new Error("ClickHouse unavailable");
+			}
+		};
+		return { calls, inserter };
+	}
+
+	test("a batch retried under its original id repeats every table's token", async () => {
+		const batch = {
+			source: "broker_write",
+			deployment_id: "deploy-1",
+			batch_id: "batch-1",
+			rows,
+		};
+		// First attempt: one table lands, the sibling fails, so the sender re-posts
+		// the whole batch — the landed table included.
+		const attempt = recordingInserter("market_data.cex_ohlcv");
+		const first = await handleArchiveBatch(attempt.inserter, batch);
+		expect(first.inserted).toBe(1);
+		expect(first.failedTables).toEqual(["market_data.cex_ohlcv"]);
+
+		const retry = recordingInserter();
+		await handleArchiveBatch(retry.inserter, batch);
+
+		expect(retry.calls).toEqual(attempt.calls);
+		expect(
+			retry.calls.every((call) => /^[a-f0-9]{64}$/.test(call.token ?? "")),
+		).toBe(true);
+		// Distinct tables in one batch must not share a token, or the second
+		// insert of the batch would be discarded as a repeat of the first.
+		expect(new Set(retry.calls.map((call) => call.token)).size).toBe(2);
+	});
+
+	test("a different batch id produces different tokens for the same rows", async () => {
+		const first = recordingInserter();
+		await handleArchiveBatch(first.inserter, {
+			source: "broker_write",
+			deployment_id: "deploy-1",
+			batch_id: "batch-1",
+			rows,
+		});
+		const second = recordingInserter();
+		await handleArchiveBatch(second.inserter, {
+			source: "broker_write",
+			deployment_id: "deploy-1",
+			batch_id: "batch-2",
+			rows,
+		});
+
+		expect(second.calls.map(({ token }) => token)).not.toEqual(
+			first.calls.map(({ token }) => token),
+		);
+	});
+
+	test("a sender that claims no retry identity inserts without a token", async () => {
+		const { calls, inserter } = recordingInserter();
+		await handleArchiveBatch(inserter, {
+			source: "broker_write",
+			deployment_id: "deploy-1",
+			rows,
+		});
+		expect(calls.map(({ token }) => token)).toEqual([undefined, undefined]);
+	});
+
+	test("a blank batch id is rejected rather than silently losing deduplication", () => {
+		expect(
+			parseArchiveBatchRequest({
+				source: "broker_write",
+				deployment_id: "deploy-1",
+				batch_id: "   ",
+				rows,
+			}).ok,
+		).toBe(false);
+		expect(
+			parseArchiveBatchRequest({
+				source: "broker_write",
+				deployment_id: "deploy-1",
+				batch_id: 7,
+				rows,
+			}).ok,
+		).toBe(false);
+		const parsed = parseArchiveBatchRequest({
+			source: "broker_write",
+			deployment_id: "deploy-1",
+			batch_id: "batch-1",
+			rows,
+		});
+		expect(parsed.ok && parsed.batch.batch_id).toBe("batch-1");
+	});
+});
+
 describe("archive forwarder schema init", () => {
+	test("every market_data table the forwarder writes carries the dedup window", async () => {
+		// Without this setting on the table, the retry tokens are accepted and
+		// ignored, and a redelivered batch duplicates silently.
+		const statements: string[] = [];
+		const client = {
+			command: async ({ query }: { query: string }) => {
+				statements.push(query);
+			},
+		} as unknown as ClickHouseClient;
+
+		await ensureArchiveSchema(client);
+
+		const marketDataTables = SUPPORTED_TABLES.filter((table) =>
+			table.startsWith("market_data."),
+		);
+		for (const table of marketDataTables) {
+			const applied = statements.some(
+				(query) =>
+					query.includes(table) &&
+					/MODIFY SETTING non_replicated_deduplication_window = 1000000/.test(
+						query,
+					),
+			);
+			expect(`${table}:${applied}`).toBe(`${table}:true`);
+		}
+	});
+
 	test("ensureArchiveSchema applies every archive database from its SQL files", async () => {
 		const statements: string[] = [];
 		const client = {

--- a/test/broker-execution-archive.test.ts
+++ b/test/broker-execution-archive.test.ts
@@ -1665,16 +1665,20 @@ describe("broker execution archiver queue", () => {
 		}
 	});
 
-	test("keeps the queue within maxQueueSize when a failed batch is requeued after refill", async () => {
+	test("holds a failed batch outside the bounded queue and redelivers it under its original id", async () => {
 		// Gate the forwarder so a batch stays in flight while new rows refill the
-		// queue, then fail it — the classic over-cap window for the requeue path.
+		// queue, then fail it. The failed rows must survive the refill without
+		// pushing the queue past its bound, and must go back out unchanged.
 		let releasePost: () => void = () => {};
 		const postGate = new Promise<void>((resolve) => {
 			releasePost = resolve;
 		});
+		let status = 503;
 		const server = await startForwarderServer(async () => {
-			await postGate;
-			return { status: 503 };
+			if (status === 503) {
+				await postGate;
+			}
+			return { status };
 		});
 		try {
 			const archiver = BrokerExecutionArchiver.create({
@@ -1708,9 +1712,24 @@ describe("broker execution archiver queue", () => {
 			releasePost();
 			await flushPromise;
 
-			// Without bound enforcement this would be 6 (3 refill + 3 requeued).
-			expect(archiver.getQueueDepth()).toBe(3);
-			expect(archiver.getStats().shed).toBeGreaterThanOrEqual(3);
+			// The failed rows are held aside, so all six are still pending and the
+			// refill cost nothing — the old requeue shed three of them here.
+			expect(archiver.getQueueDepth()).toBe(6);
+			expect(archiver.getStats().shed).toBe(0);
+
+			// The bound still governs the queue itself: the next arrival sheds.
+			archiver.enqueue(row("7"));
+			expect(archiver.getStats().shed).toBe(1);
+
+			status = 200;
+			await archiver.flush();
+			await archiver.flush();
+			expect(archiver.getQueueDepth()).toBe(0);
+
+			// The retry re-posts the original rows under the original batch id.
+			const [firstPost, retryPost] = server.requests;
+			expect(retryPost?.body.batch_id).toBe(firstPost?.body.batch_id);
+			expect(retryPost?.body.rows).toEqual(firstPost?.body.rows);
 
 			await archiver.close();
 		} finally {
@@ -1987,6 +2006,9 @@ describe("broker execution archiver queue", () => {
 			expect(beforeSuccessHealthCalls).not.toEqual(
 				expect.arrayContaining([expect.objectContaining({ value: 1 })]),
 			);
+			// First flush redelivers the held batch, second drains what arrived
+			// during the outage.
+			await archiver.flush();
 			await archiver.flush();
 			const recovered = archiver.getHealthSnapshot();
 			expect(recovered.healthy).toBe(true);
@@ -2055,6 +2077,12 @@ describe("broker execution archiver queue", () => {
 			});
 			archiver.enqueue({
 				table: "broker_execution.order_events",
+				row: { order_id: "same-ms-retained-2" },
+			});
+			// The failed batch is held outside the queue, so saturation is reached by
+			// arrivals alone — one more enqueue is what sheds.
+			archiver.enqueue({
+				table: "broker_execution.order_events",
 				row: { order_id: "same-ms-shed" },
 			});
 			const shed = archiver.getHealthSnapshot();
@@ -2063,6 +2091,7 @@ describe("broker execution archiver queue", () => {
 			expect(shed.shed_total).toBe(1);
 
 			status = 200;
+			await archiver.flush();
 			await archiver.flush();
 			const recovered = archiver.getHealthSnapshot();
 			expect(recovered.healthy).toBe(true);

--- a/test/clickhouse-schema.integration.test.ts
+++ b/test/clickhouse-schema.integration.test.ts
@@ -1147,4 +1147,72 @@ describe("ClickHouse market_data schema integration", () => {
 			expect(await result.json()).toEqual([{ count: "1" }]);
 		}
 	});
+
+	test("a market-data batch replayed under its original id lands exactly once", async () => {
+		if (!clickhouseAvailable || !client) return;
+		// The sender re-posts a whole batch after any table in it fails, so the
+		// tables that already landed are inserted a second time. cex_stream_events
+		// is the sharp case: plain MergeTree, and no canonical view collapses a
+		// duplicate at read time.
+		const eventMs = TEST_EVENT_MS + 600_000;
+		const context: MarketCaptureContext = {
+			source: "broker_read",
+			deploymentId: TEST_DEPLOYMENT,
+			captureBundleId: "integration-replay-bundle",
+			exchange: "binance",
+			symbol: "TEST/REPLAY",
+			assetType: "spot",
+			feed: "TICKER",
+			provider: "ccxt:binance",
+			sourceMode: "broker_live_stream_v1",
+			schemaVersion: "1.0.0",
+			checksumAlgorithm: "sha256-canonical-json-v1",
+			provenanceComplete: true,
+		};
+		const rawCapture = createRawCapture(context, {
+			payload: { eventTimeMs: eventMs, last: 100.5 },
+			eventTimeMs: eventMs,
+			receivedTimeMs: eventMs + 5,
+			scope: "ccxt_normalized_object",
+		});
+		const batch = {
+			source: "broker_read",
+			deployment_id: TEST_DEPLOYMENT,
+			batch_id: `integration-replay-${TEST_DEPLOYMENT}`,
+			rows: [buildCanonicalCexStreamEventRow(context, rawCapture)],
+		};
+
+		const first = await handleArchiveBatch(
+			createClickHouseInserter(client),
+			batch,
+		);
+		const replay = await handleArchiveBatch(
+			createClickHouseInserter(client),
+			batch,
+		);
+		expect(first.failed).toBe(0);
+		expect(replay.failed).toBe(0);
+
+		const counted = await client.query({
+			query: `SELECT count() AS count FROM market_data.cex_stream_events
+				WHERE deployment_id = {deployment_id:String} AND symbol = 'TEST/REPLAY'`,
+			query_params: { deployment_id: TEST_DEPLOYMENT },
+			format: "JSONEachRow",
+		});
+		expect(await counted.json()).toEqual([{ count: "1" }]);
+
+		// A different batch carrying the same row is a distinct insert, not a
+		// replay: deduplication must not swallow genuinely re-captured data.
+		await handleArchiveBatch(createClickHouseInserter(client), {
+			...batch,
+			batch_id: `${batch.batch_id}-other`,
+		});
+		const afterDistinctBatch = await client.query({
+			query: `SELECT count() AS count FROM market_data.cex_stream_events
+				WHERE deployment_id = {deployment_id:String} AND symbol = 'TEST/REPLAY'`,
+			query_params: { deployment_id: TEST_DEPLOYMENT },
+			format: "JSONEachRow",
+		});
+		expect(await afterDistinctBatch.json()).toEqual([{ count: "2" }]);
+	});
 });


### PR DESCRIPTION
## Problem

When ClickHouse is briefly unavailable the forwarder fails the request and the broker re-posts the whole batch. The forwarder commits table by table with no cross-table transaction, so any table that landed before a sibling table failed was inserted **again** on every retry.

`market_data.cex_stream_events` kept those duplicates: plain MergeTree, and no canonical view collapses them at read time. (`cex_order_book_levels` and `cex_order_book_depth_summary` are shielded by their `SELECT DISTINCT` canonical views, `cex_ohlcv` by ReplacingMergeTree.)

The 2026-08-10 storage restart produced ~1,954 insert failures in one hour across four `market_data` tables, every one of them a retry candidate.

## Change

A batch now carries a retry identity.

- **Broker.** A failed batch is held aside instead of being pushed back into the queue, and is re-posted with the same rows under the same batch id. Rows mixed back into the queue could not offer a stable retry: new arrivals and the oldest-first shed reshape the next batch. Two side effects, both wanted: held rows sit outside the queue bound, so a refill during an outage no longer sheds the rows that just failed; and a batch the forwarder keeps rejecting (an unknown table after a version skew, say) is journaled after ten attempts instead of blocking the archive plane forever.
- **Forwarder.** A per-table `insert_deduplication_token` is derived from the batch id, so a re-inserted table is discarded by ClickHouse rather than duplicated. `batch_id` is optional on the wire: senders that cannot keep an id stable across their retries omit it and behave exactly as before. A present-but-blank id is rejected rather than silently losing deduplication.
- **Schema.** The `market_data` tables enable non-replicated insert deduplication, matching what `strategy_data` already does. Without it ClickHouse accepts the tokens and ignores them.

No change to what is archived, or to the loss journal's role as the record of anything undeliverable.

## Deployment

**This includes a schema change and needs the storage SQL apply step on deployment.** The eight `market_data` tables pick up `non_replicated_deduplication_window` via `ALTER TABLE ... MODIFY SETTING`, applied idempotently alongside the existing definitions. Until it is applied, retries still duplicate; nothing else regresses. Verified on a fresh 24.8 server that the setting lands both on freshly created tables and on tables created by the previous schema.

## Tests

- Full unit suite green (685 tests), including the ClickHouse integration file against a live 24.8 server.
- New integration test: a batch replayed under its original id lands **once** in `cex_stream_events`, while the same rows under a different id land twice, so deduplication cannot swallow genuinely re-captured data. Confirmed the test fails without the fix.
- New forwarder tests: a retry repeats every table's token, distinct tables within a batch never share one, a sender without an id inserts without a token, and a blank id is rejected.
- Broker test now proves the retry re-posts identical rows under the original id, and that a refill during the outage neither sheds the failed rows nor breaches the queue bound. Three existing tests that asserted the old requeue mechanics were updated to the new one; their durability assertions are unchanged.